### PR TITLE
Reuse the logger with get_logger method

### DIFF
--- a/include/mujoco_ros2_simulation/mujoco_system_interface.hpp
+++ b/include/mujoco_ros2_simulation/mujoco_system_interface.hpp
@@ -185,6 +185,8 @@ private:
    */
   void publish_clock();
 
+  rclcpp::Logger get_logger() const;
+
   // System information
   std::string model_path_;
 
@@ -199,6 +201,9 @@ private:
   mjvCamera cam_;
   mjvOption opt_;
   mjvPerturb pert_;
+
+  // Logger
+  rclcpp::Logger logger_ = rclcpp::get_logger("MujocoSystemInterface");
 
   // Speed scaling parameter. if set to >0 then we ignore the value set in the simulate app and instead
   // attempt to loop at whatever this is set to. If this is <0, then we use the value from the app.


### PR DESCRIPTION
Just consolidates all get_logger calls with a single one that returns the member variable