### PR TITLE
Enable colcon rolling build in ROS 2 workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,4 +394,3 @@ ros2 topic pub /position_controller/commands std_msgs/msg/Float64MultiArray "dat
 ## Development
 
 More information is provided in the [developers guide](./docs/DEVELOPMENT.md) document.
-

--- a/src/mujoco_cameras.cpp
+++ b/src/mujoco_cameras.cpp
@@ -198,23 +198,12 @@ void MujocoCameras::update_loop()
 
 void MujocoCameras::update()
 {
-  // Safety check: ensure model and data are still valid
-  if (!mj_model_ || !mj_data_ || !mj_camera_data_)
-  {
-    return;
-  }
-
   // Rendering is done offscreen
   mjr_setBuffer(mjFB_OFFSCREEN, &mjr_con_);
 
   // Step 1: Lock the sim and copy data for use in all camera rendering.
   {
     std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
-    // Double-check after acquiring lock (model/data might be deleted during shutdown)
-    if (!mj_model_ || !mj_data_ || !mj_camera_data_)
-    {
-      return;
-    }
     mjv_copyData(mj_camera_data_, mj_model_, mj_data_);
   }
 


### PR DESCRIPTION
Enables building this package in standard ROS 2 workspaces on Linux/Ubuntu, making it compatible with rolling builds from ros-controls projects. For more details, see https://github.com/ros-controls/mujoco_ros2_control/issues/30.


## Changes

- Updated CMakeList.txt to handle dependency for GLFW3, mold and sccache. 
- Updated package.xml to include sccache
- Added a section to README.md for "Development Workflow within ROS 2 Workspace" section with dependencies, build instructions, and warnings about version compatibility


## Testing

Tested on Ubuntu 24.04 with:
- System ROS 2 Jazzy packages
- Rolling builds from `ros2_control_demo` and `ros2_controllers`
- All dependencies properly detected and used

Also tested pixi build workflow, build succeeded.


