### PR TITLE
Add step to sanitize tag name for docker builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Run tests
         run: |
           docker run --rm \
-            mujoco_ros2_control::${{ steps.set_tag.outputs.tag }} \
+            mujoco_ros2_control:${{ steps.set_tag.outputs.tag }} \
             bash -c "
               colcon test &&
               colcon test-result --verbose


### PR DESCRIPTION
Resolves #50.

Adds a step to sanitize the tag name before building/tagging the docker image in CI.