### PR TITLE
Move the URL to work with Humble cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,9 @@ else()
   set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
   FetchContent_Declare(
     mujoco_download
-    URL https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
     SOURCE_DIR ${MUJOCO_EXTRACT_DIR}
     DOWNLOAD_EXTRACT_TIMESTAMP True
+    URL https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
   )
   FetchContent_MakeAvailable(mujoco_download)
 


### PR DESCRIPTION
The current main doesn't ccompile on Humble when used with the rolling branches of ros2_control compiled on Humble. Seems like the cmake version `3.22.1-1ubuntu1.22.04.2` that is present on Humble doesn't like the placement of the URL. By changing to the end, it works for everyone

```
CMake Error at /usr/share/cmake-3.22/Modules/ExternalProject.cmake:2806 (message):
  At least one entry of URL is a path (invalid in a list)
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/ExternalProject.cmake:3716 (_ep_add_download_command)
  CMakeLists.txt:15 (ExternalProject_Add)


-- Configuring incomplete, errors occurred!
See also "/home/user/mujoco_ws/build/mujoco_ros2_control/_deps/mujoco_download-subbuild/CMakeFiles/CMakeOutput.log".

CMake Error at /usr/share/cmake-3.22/Modules/FetchContent.cmake:1075 (message):
  CMake step for mujoco_download failed: 1
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1216:EVAL:2 (__FetchContent_directPopulate)
  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1216 (cmake_language)
  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1259 (FetchContent_Populate)
  CMakeLists.txt:66 (FetchContent_MakeAvailable)


---
Failed   <<< mujoco_ros2_control [0.47s, exited with code 1]
```
