### PR TITLE
Don't check actuator command state for state only joints

### DIFF
--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -1628,7 +1628,6 @@ void MujocoSystemInterface::register_urdf_joints(const hardware_interface::Hardw
                      });
     const bool actuator_exists = actuator_it != mujoco_actuator_data_.end();
     // This isn't a failure the joint just won't be controllable
-
     RCLCPP_WARN_EXPRESSION(get_logger(), !actuator_exists,
                            "Failed to find actuator for joint : %s. This joint will be treated as a passive joint.",
                            joint.name.c_str());


### PR DESCRIPTION
If a model has passive joints (only `state_interface` defined) the code identifies it as an error and rises an exception.
This PR fixes this bug by adding a PASSIVE actuator type and handling properly the logic.

With this PR the error bellow is fixed:
```
[ros2_control_node-6] [WARN] [1768389940.808097478] [MujocoSystemInterface]: Failed to find actuator for joint : some_passive_joint. This joint will be treated as a passive joint.
[ros2_control_node-6] [INFO] [1768389940.808099191] [MujocoSystemInterface]: Joint : some_passive_joint is a passive joint
[ros2_control_node-6] [ERROR] [1768389940.808726009] [controller_manager]: Exception of type : St13runtime_error occurred while initializing hardware 'MujocoSystem': Joint 'some_passive_joint' which uses actuator 'some_passive_joint' has an unsupported command interface for the specified MuJoCo actuator
[ros2_control_node-6] [WARN] [1768389940.808749985] [controller_manager]: System hardware component 'MujocoSystem' from plugin 'mujoco_ros2_control/MujocoSystemInterface' failed to initialize.
[ros2_control_node-6] Stack trace (most recent call last) in thread 34628:
[ros2_control_node-6] #0    Object "/usr/lib/x86_64-linux-gnu/libGLdispatch.so.0.0.0", at 0x78874418ee09, in 
[ros2_control_node-6] Segmentation fault (Address not mapped to object [0x1678])
[ERROR] [ros2_control_node-6]: process has died [pid 34559, exit code -11, cmd '/home/user/kangaroo_ws/install/mujoco_ros2_control/lib/mujoco_ros2_control/ros2_control_node --ros-args --params-file /tmp/launch_params__5c89aq4'].
```
