### PR TITLE
Fix the unit tests crash due to camera rendering cleanup

### DIFF
--- a/include/mujoco_ros2_control/mujoco_cameras.hpp
+++ b/include/mujoco_ros2_control/mujoco_cameras.hpp
@@ -118,22 +118,25 @@ private:
 
   mjData* mj_data_;
   mjModel* mj_model_;
-  mjData* mj_camera_data_;
+  mjData* mj_camera_data_{ nullptr };
 
   // Image publishing rate
   double camera_publish_rate_;
 
-  // Rendering options for the cameras, currently hard coded to defaults
-  mjvOption mjv_opt_;
-  mjvScene mjv_scn_;
-  mjrContext mjr_con_;
+  // Rendering options for the cameras, currently hard coded to defaults.
+  // These must be safe to destroy even if rendering was never initialized.
+  mjvOption mjv_opt_{};
+  mjvScene mjv_scn_{};
+  mjrContext mjr_con_{};
 
   // Containers for camera data and ROS constructs
   std::vector<CameraData> cameras_;
 
   // Camera processing thread
   std::thread rendering_thread_;
-  std::atomic_bool publish_images_;
+  std::atomic_bool publish_images_{ false };
+  std::atomic_bool rendering_initialized_{ false };
+  std::atomic_bool glfw_initialized_{ false };
 };
 
 }  // namespace mujoco_ros2_control

--- a/src/mujoco_cameras.cpp
+++ b/src/mujoco_cameras.cpp
@@ -130,6 +130,12 @@ void MujocoCameras::register_cameras(const hardware_interface::HardwareInfo& har
 
 void MujocoCameras::init()
 {
+  // Idempotent init: if a previous init started publishing, don't start again.
+  if (publish_images_.load())
+  {
+    return;
+  }
+
   // Start the rendering thread process
   if (!glfwInit())
   {
@@ -137,6 +143,7 @@ void MujocoCameras::init()
     publish_images_ = false;
     return;
   }
+  glfw_initialized_ = true;
   publish_images_ = true;
   rendering_thread_ = std::thread(&MujocoCameras::update_loop, this);
 }
@@ -149,8 +156,11 @@ void MujocoCameras::close()
     rendering_thread_.join();
   }
 
-  mjv_freeScene(&mjv_scn_);
-  mjr_freeContext(&mjr_con_);
+  if (glfw_initialized_.load())
+  {
+    glfwTerminate();
+    glfw_initialized_ = false;
+  }
 }
 
 void MujocoCameras::update_loop()
@@ -158,6 +168,12 @@ void MujocoCameras::update_loop()
   // We create an offscreen context specific to this process for managing camera rendering.
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
   GLFWwindow* window = glfwCreateWindow(1, 1, "", NULL, NULL);
+  if (window == nullptr)
+  {
+    RCLCPP_WARN(node_->get_logger(), "Failed to create GLFW window. Disabling camera publishing.");
+    publish_images_ = false;
+    return;
+  }
   glfwMakeContextCurrent(window);
 
   // Initialization of the context and data structures has to happen in the rendering thread
@@ -176,6 +192,7 @@ void MujocoCameras::update_loop()
   // create scene and context
   mjv_makeScene(mj_model_, &mjv_scn_, 2000);
   mjr_makeContext(mj_model_, &mjr_con_, mjFONTSCALE_150);
+  rendering_initialized_ = true;
 
   // Ensure the context will support the largest cameras
   int max_width = 1, max_height = 1;
@@ -194,6 +211,24 @@ void MujocoCameras::update_loop()
     update();
     rate.sleep();
   }
+
+  // IMPORTANT: Free MuJoCo rendering resources while a valid OpenGL context is current.
+  // mjr_freeContext() will call into OpenGL (e.g. glDeleteRenderbuffers), which can segfault if
+  // invoked from a thread without a current context.
+  if (rendering_initialized_.load())
+  {
+    mjv_freeScene(&mjv_scn_);
+    mjr_freeContext(&mjr_con_);
+    rendering_initialized_ = false;
+  }
+
+  if (mj_camera_data_ != nullptr)
+  {
+    mj_deleteData(mj_camera_data_);
+    mj_camera_data_ = nullptr;
+  }
+
+  glfwDestroyWindow(window);
 }
 
 void MujocoCameras::update()


### PR DESCRIPTION
Addresses https://github.com/ros-controls/mujoco_ros2_control/issues/70

**Summary for the fix**
- Honor disable_rendering=true by skipping creation and startup of camera/lidar wrappers (no rendering threads when disabled).
- Make camera cleanup GL-safe: free MuJoCo rendering context/scene inside the camera rendering thread while its OpenGL context is current; keep close() as “stop + join + glfwTerminate”.

Without this fix, the contact sensor unit tests fail constantly. 