### PR TITLE
Fix invalid initial state + filter out ball joints 

### DIFF
--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -2366,6 +2366,13 @@ void MujocoSystemInterface::set_initial_pose()
     {
       mj_data_->qpos[actuator.mj_pos_adr] = actuator.position_interface.state_;
     }
+    else
+    {
+      RCLCPP_WARN_EXPRESSION(
+          get_logger(), actuator.actuator_type != ActuatorType::PASSIVE,
+          "Actuator '%s' position state is not finite. Leaving it to the MuJoCo model's default initial position.",
+          actuator.joint_name.c_str());
+    }
     if (actuator.is_position_control_enabled)
     {
       mj_data_->ctrl[actuator.mj_actuator_id] = actuator.position_interface.state_;


### PR DESCRIPTION
After Nathan's discussion, may be it is also better filter out these joints as they have 3DoF

The initial state is invalid when the model has many passive joints and these joints are not exported into the ros2_control interfaces, then their interfaces are left out as NaNs initially, so if that's the case better set them to intial value automatically.