### PR TITLE
Add python3-venv depdendency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>libglfw3-dev</depend>
   <depend>pluginlib</depend>
   <depend>python3-pykdl</depend>
+  <depend>python3-venv</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
I observed during these days with rosdep this venv is not installed and the script to setup the venv is failing consistently. So, it's better to add this dependency