### PR TITLE
Fix the PYTHONPATH appending to have tests working locally

### DIFF
--- a/mujoco_ros2_control_tests/CMakeLists.txt
+++ b/mujoco_ros2_control_tests/CMakeLists.txt
@@ -20,37 +20,41 @@ if(BUILD_TESTING)
   # It is unclear why, but ctest in github action runners doesn't seem to correctly inherit
   # the PYTHONPATH from `install/setup.bash`. So we provide the exact path to ensure these are
   # locatable in CI.
-  set(test_pythonpath "$ENV{PYTHONPATH}")
-  file(TO_CMAKE_PATH "${test_pythonpath}" test_pythonpath)
+  set(append_env_args "")
+  if($ENV{GITHUB_ACTIONS})
+    set(test_pythonpath "$ENV{PYTHONPATH}")
+    file(TO_CMAKE_PATH "${test_pythonpath}" test_pythonpath)
+    list(APPEND append_env_args APPEND_ENV "PYTHONPATH=${test_pythonpath}")
+  endif()
 
   add_launch_test(test/robot_launch_test.py
     TIMEOUT 50
-    APPEND_ENV "PYTHONPATH=${test_pythonpath}"
+    ${append_env_args}
   )
 
   add_launch_test(test/robot_launch_pid_test.py
     TIMEOUT 50
-    APPEND_ENV "PYTHONPATH=${test_pythonpath}"
+    ${append_env_args}
   )
 
   add_launch_test(test/robot_launch_mjcf_generation_test.py
     TIMEOUT 50
-    APPEND_ENV "PYTHONPATH=${test_pythonpath}"
+    ${append_env_args}
   )
 
   add_launch_test(test/robot_launch_mjcf_generation_from_robot_description_test.py
     TIMEOUT 50
-    APPEND_ENV "PYTHONPATH=${test_pythonpath}"
+    ${append_env_args}
   )
 
   add_launch_test(test/robot_launch_transmission_test.py
     TIMEOUT 50
-    APPEND_ENV "PYTHONPATH=${test_pythonpath}"
+    ${append_env_args}
   )
 
   add_launch_test(test/robot_launch_transmission_pid_test.py
     TIMEOUT 50
-    APPEND_ENV "PYTHONPATH=${test_pythonpath}"
+    ${append_env_args}
   )
 endif()
 


### PR DESCRIPTION
The PYTHONPATH added in #96 fixed the CI, but the tests fail locally with the following errors. This PR hopes to fix both cases

<details>

```
colcon test --event-handlers console_direct+ --packages-select mujoco_ros2_control_tests
Starting >>> mujoco_ros2_control_tests
UpdateCTestConfiguration  from :/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/CTestConfiguration.ini
Parse Config file:/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/CTestConfiguration.ini
   Site: skk-laptop
   Build name: (empty)
 Add coverage exclude regular expressions.
Create new tag: 20260206-1238 - Experimental
UpdateCTestConfiguration  from :/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/CTestConfiguration.ini
Parse Config file:/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/CTestConfiguration.ini
Test project /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_robot_launch_test.py

1: Test command: /usr/bin/python3 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_test.py.xunit.xml" "--package-name" "mujoco_ros2_control_tests" "--output-file" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/launch_test/test_robot_launch_test.py.txt" "--env" "PYTHONDONTWRITEBYTECODE=1" "--append-env" "PYTHONPATH=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages" "/opt/ros/rolling/opt/gz_sim_vendor/lib/python" "/opt/ros/rolling/opt/gz_transport_vendor/lib/python" "/opt/ros/rolling/opt/sdformat_vendor/lib/python" "/opt/ros/rolling/opt/gz_msgs_vendor/lib/python" "/opt/ros/rolling/opt/gz_math_vendor/lib/python" "/opt/ros/rolling/lib/python3.12/site-packages" "--command" "/usr/bin/python3" "-m" "launch_testing.launch_test" "/home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_test.py" "--junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_test.py.xunit.xml" "--package-name=mujoco_ros2_control_tests"
1: Working Directory: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
1: Test timeout computed to be: 50
1: -- run_test.py: extra environment variables:         
1:  - PYTHONDONTWRITEBYTECODE=1
1: -- run_test.py: extra environment variables to append:
1:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages
1:  - PYTHONPATH+=/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages
1:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages
1:  - PYTHONPATH+=/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages
1:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_sim_vendor/lib/python
1:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_transport_vendor/lib/python
1:  - PYTHONPATH+=/opt/ros/rolling/opt/sdformat_vendor/lib/python
1:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_msgs_vendor/lib/python
1:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_math_vendor/lib/python
1:  - PYTHONPATH+=/opt/ros/rolling/lib/python3.12/site-packages
1: -- run_test.py: invoking following command in '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests':
1:  - /usr/bin/python3 -m launch_testing.launch_test /home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_test.py --junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_test.py.xunit.xml --package-name=mujoco_ros2_control_tests
1: -- run_test.py: invocation failed: [Errno 7] Argument list too long: '/usr/bin/python3'
1: -- run_test.py: generate result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_test.py.xunit.xml' with failed test
1: -- run_test.py: verify result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_test.py.xunit.xml'
1/6 Test #1: test_robot_launch_test.py ..........................................***Failed    0.06 sec
test 2
    Start 2: test_robot_launch_pid_test.py

2: Test command: /usr/bin/python3 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_pid_test.py.xunit.xml" "--package-name" "mujoco_ros2_control_tests" "--output-file" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/launch_test/test_robot_launch_pid_test.py.txt" "--env" "PYTHONDONTWRITEBYTECODE=1" "--append-env" "PYTHONPATH=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages" "/opt/ros/rolling/opt/gz_sim_vendor/lib/python" "/opt/ros/rolling/opt/gz_transport_vendor/lib/python" "/opt/ros/rolling/opt/sdformat_vendor/lib/python" "/opt/ros/rolling/opt/gz_msgs_vendor/lib/python" "/opt/ros/rolling/opt/gz_math_vendor/lib/python" "/opt/ros/rolling/lib/python3.12/site-packages" "--command" "/usr/bin/python3" "-m" "launch_testing.launch_test" "/home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_pid_test.py" "--junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_pid_test.py.xunit.xml" "--package-name=mujoco_ros2_control_tests"
2: Working Directory: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
2: Test timeout computed to be: 50
2: -- run_test.py: extra environment variables:
2:  - PYTHONDONTWRITEBYTECODE=1
2: -- run_test.py: extra environment variables to append:
2:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages
2:  - PYTHONPATH+=/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages
2:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages
2:  - PYTHONPATH+=/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages
2:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_sim_vendor/lib/python
2:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_transport_vendor/lib/python
2:  - PYTHONPATH+=/opt/ros/rolling/opt/sdformat_vendor/lib/python
2:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_msgs_vendor/lib/python
2:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_math_vendor/lib/python
2:  - PYTHONPATH+=/opt/ros/rolling/lib/python3.12/site-packages
2: -- run_test.py: invoking following command in '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests':
2:  - /usr/bin/python3 -m launch_testing.launch_test /home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_pid_test.py --junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_pid_test.py.xunit.xml --package-name=mujoco_ros2_control_tests
2: -- run_test.py: invocation failed: [Errno 7] Argument list too long: '/usr/bin/python3'
2: -- run_test.py: generate result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_pid_test.py.xunit.xml' with failed test
2: -- run_test.py: verify result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_pid_test.py.xunit.xml'
2/6 Test #2: test_robot_launch_pid_test.py ......................................***Failed    0.05 sec
test 3
    Start 3: test_robot_launch_mjcf_generation_test.py

3: Test command: /usr/bin/python3 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_test.py.xunit.xml" "--package-name" "mujoco_ros2_control_tests" "--output-file" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/launch_test/test_robot_launch_mjcf_generation_test.py.txt" "--env" "PYTHONDONTWRITEBYTECODE=1" "--append-env" "PYTHONPATH=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages" "/opt/ros/rolling/opt/gz_sim_vendor/lib/python" "/opt/ros/rolling/opt/gz_transport_vendor/lib/python" "/opt/ros/rolling/opt/sdformat_vendor/lib/python" "/opt/ros/rolling/opt/gz_msgs_vendor/lib/python" "/opt/ros/rolling/opt/gz_math_vendor/lib/python" "/opt/ros/rolling/lib/python3.12/site-packages" "--command" "/usr/bin/python3" "-m" "launch_testing.launch_test" "/home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_mjcf_generation_test.py" "--junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_test.py.xunit.xml" "--package-name=mujoco_ros2_control_tests"
3: Working Directory: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
3: Test timeout computed to be: 50
3: -- run_test.py: extra environment variables:         
3:  - PYTHONDONTWRITEBYTECODE=1
3: -- run_test.py: extra environment variables to append:
3:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages
3:  - PYTHONPATH+=/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages
3:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages
3:  - PYTHONPATH+=/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages
3:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_sim_vendor/lib/python
3:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_transport_vendor/lib/python
3:  - PYTHONPATH+=/opt/ros/rolling/opt/sdformat_vendor/lib/python
3:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_msgs_vendor/lib/python
3:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_math_vendor/lib/python
3:  - PYTHONPATH+=/opt/ros/rolling/lib/python3.12/site-packages
3: -- run_test.py: invoking following command in '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests':
3:  - /usr/bin/python3 -m launch_testing.launch_test /home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_mjcf_generation_test.py --junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_test.py.xunit.xml --package-name=mujoco_ros2_control_tests
3: -- run_test.py: invocation failed: [Errno 7] Argument list too long: '/usr/bin/python3'
3: -- run_test.py: generate result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_test.py.xunit.xml' with failed test
3: -- run_test.py: verify result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_test.py.xunit.xml'
3/6 Test #3: test_robot_launch_mjcf_generation_test.py ..........................***Failed    0.05 sec
test 4
    Start 4: test_robot_launch_mjcf_generation_from_robot_description_test.py

4: Test command: /usr/bin/python3 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_from_robot_description_test.py.xunit.xml" "--package-name" "mujoco_ros2_control_tests" "--output-file" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/launch_test/test_robot_launch_mjcf_generation_from_robot_description_test.py.txt" "--env" "PYTHONDONTWRITEBYTECODE=1" "--append-env" "PYTHONPATH=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages" "/opt/ros/rolling/opt/gz_sim_vendor/lib/python" "/opt/ros/rolling/opt/gz_transport_vendor/lib/python" "/opt/ros/rolling/opt/sdformat_vendor/lib/python" "/opt/ros/rolling/opt/gz_msgs_vendor/lib/python" "/opt/ros/rolling/opt/gz_math_vendor/lib/python" "/opt/ros/rolling/lib/python3.12/site-packages" "--command" "/usr/bin/python3" "-m" "launch_testing.launch_test" "/home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_mjcf_generation_from_robot_description_test.py" "--junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_from_robot_description_test.py.xunit.xml" "--package-name=mujoco_ros2_control_tests"
4: Working Directory: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
4: Test timeout computed to be: 50
4: -- run_test.py: extra environment variables:
4:  - PYTHONDONTWRITEBYTECODE=1
4: -- run_test.py: extra environment variables to append:
4:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages
4:  - PYTHONPATH+=/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages
4:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages
4:  - PYTHONPATH+=/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages
4:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_sim_vendor/lib/python
4:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_transport_vendor/lib/python
4:  - PYTHONPATH+=/opt/ros/rolling/opt/sdformat_vendor/lib/python
4:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_msgs_vendor/lib/python
4:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_math_vendor/lib/python
4:  - PYTHONPATH+=/opt/ros/rolling/lib/python3.12/site-packages
4: -- run_test.py: invoking following command in '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests':
4:  - /usr/bin/python3 -m launch_testing.launch_test /home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_mjcf_generation_from_robot_description_test.py --junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_from_robot_description_test.py.xunit.xml --package-name=mujoco_ros2_control_tests
4: -- run_test.py: invocation failed: [Errno 7] Argument list too long: '/usr/bin/python3'
4: -- run_test.py: generate result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_from_robot_description_test.py.xunit.xml' with failed test
4: -- run_test.py: verify result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_mjcf_generation_from_robot_description_test.py.xunit.xml'
4/6 Test #4: test_robot_launch_mjcf_generation_from_robot_description_test.py ...***Failed    0.05 sec
test 5
    Start 5: test_robot_launch_transmission_test.py

5: Test command: /usr/bin/python3 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_test.py.xunit.xml" "--package-name" "mujoco_ros2_control_tests" "--output-file" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/launch_test/test_robot_launch_transmission_test.py.txt" "--env" "PYTHONDONTWRITEBYTECODE=1" "--append-env" "PYTHONPATH=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages" "/opt/ros/rolling/opt/gz_sim_vendor/lib/python" "/opt/ros/rolling/opt/gz_transport_vendor/lib/python" "/opt/ros/rolling/opt/sdformat_vendor/lib/python" "/opt/ros/rolling/opt/gz_msgs_vendor/lib/python" "/opt/ros/rolling/opt/gz_math_vendor/lib/python" "/opt/ros/rolling/lib/python3.12/site-packages" "--command" "/usr/bin/python3" "-m" "launch_testing.launch_test" "/home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_transmission_test.py" "--junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_test.py.xunit.xml" "--package-name=mujoco_ros2_control_tests"
5: Working Directory: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
5: Test timeout computed to be: 50
5: -- run_test.py: extra environment variables:         
5:  - PYTHONDONTWRITEBYTECODE=1
5: -- run_test.py: extra environment variables to append:
5:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages
5:  - PYTHONPATH+=/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages
5:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages
5:  - PYTHONPATH+=/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages
5:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_sim_vendor/lib/python
5:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_transport_vendor/lib/python
5:  - PYTHONPATH+=/opt/ros/rolling/opt/sdformat_vendor/lib/python
5:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_msgs_vendor/lib/python
5:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_math_vendor/lib/python
5:  - PYTHONPATH+=/opt/ros/rolling/lib/python3.12/site-packages
5: -- run_test.py: invoking following command in '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests':
5:  - /usr/bin/python3 -m launch_testing.launch_test /home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_transmission_test.py --junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_test.py.xunit.xml --package-name=mujoco_ros2_control_tests
5: -- run_test.py: invocation failed: [Errno 7] Argument list too long: '/usr/bin/python3'
5: -- run_test.py: generate result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_test.py.xunit.xml' with failed test
5: -- run_test.py: verify result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_test.py.xunit.xml'
5/6 Test #5: test_robot_launch_transmission_test.py .............................***Failed    0.05 sec
test 6
    Start 6: test_robot_launch_transmission_pid_test.py

6: Test command: /usr/bin/python3 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_pid_test.py.xunit.xml" "--package-name" "mujoco_ros2_control_tests" "--output-file" "/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/launch_test/test_robot_launch_transmission_pid_test.py.txt" "--env" "PYTHONDONTWRITEBYTECODE=1" "--append-env" "PYTHONPATH=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages" "/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages" "/opt/ros/rolling/opt/gz_sim_vendor/lib/python" "/opt/ros/rolling/opt/gz_transport_vendor/lib/python" "/opt/ros/rolling/opt/sdformat_vendor/lib/python" "/opt/ros/rolling/opt/gz_msgs_vendor/lib/python" "/opt/ros/rolling/opt/gz_math_vendor/lib/python" "/opt/ros/rolling/lib/python3.12/site-packages" "--command" "/usr/bin/python3" "-m" "launch_testing.launch_test" "/home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_transmission_pid_test.py" "--junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_pid_test.py.xunit.xml" "--package-name=mujoco_ros2_control_tests"
6: Working Directory: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests
6: Test timeout computed to be: 50
6: -- run_test.py: extra environment variables:
6:  - PYTHONDONTWRITEBYTECODE=1
6: -- run_test.py: extra environment variables to append:
6:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages
6:  - PYTHONPATH+=/home/user/ros2_control_ws/install/mujoco_ros2_control_msgs/lib/python3.12/site-packages
6:  - PYTHONPATH+=/home/user/ros2_control_ws/install/controller_manager_msgs/lib/python3.12/site-packages
6:  - PYTHONPATH+=/home/user/ros2_control_ws/install/control_msgs/lib/python3.12/site-packages
6:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_sim_vendor/lib/python
6:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_transport_vendor/lib/python
6:  - PYTHONPATH+=/opt/ros/rolling/opt/sdformat_vendor/lib/python
6:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_msgs_vendor/lib/python
6:  - PYTHONPATH+=/opt/ros/rolling/opt/gz_math_vendor/lib/python
6:  - PYTHONPATH+=/opt/ros/rolling/lib/python3.12/site-packages
6: -- run_test.py: invoking following command in '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests':
6:  - /usr/bin/python3 -m launch_testing.launch_test /home/user/ros2_control_ws/src/mujoco_ros2_control/mujoco_ros2_control_tests/test/robot_launch_transmission_pid_test.py --junit-xml=/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_pid_test.py.xunit.xml --package-name=mujoco_ros2_control_tests
6: -- run_test.py: invocation failed: [Errno 7] Argument list too long: '/usr/bin/python3'
6: -- run_test.py: generate result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_pid_test.py.xunit.xml' with failed test
6: -- run_test.py: verify result file '/home/user/ros2_control_ws/build/mujoco_ros2_control_tests/test_results/mujoco_ros2_control_tests/test_robot_launch_transmission_pid_test.py.xunit.xml'
6/6 Test #6: test_robot_launch_transmission_pid_test.py .........................***Failed    0.05 sec

0% tests passed, 6 tests failed out of 6

Label Time Summary:
launch_test    =   0.32 sec*proc (6 tests)

Total Test time (real) =   0.32 sec

The following tests FAILED:
	  1 - test_robot_launch_test.py (Failed)
	  2 - test_robot_launch_pid_test.py (Failed)
	  3 - test_robot_launch_mjcf_generation_test.py (Failed)
	  4 - test_robot_launch_mjcf_generation_from_robot_description_test.py (Failed)
	  5 - test_robot_launch_transmission_test.py (Failed)
	  6 - test_robot_launch_transmission_pid_test.py (Failed)
Errors while running CTest
Output from these tests are in: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
--- stderr: mujoco_ros2_control_tests
Errors while running CTest
Output from these tests are in: /home/user/ros2_control_ws/build/mujoco_ros2_control_tests/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
---
Finished <<< mujoco_ros2_control_tests [0.41s]	[ with test failures ]

Summary: 1 package finished [0.67s]
  1 package had stderr output: mujoco_ros2_control_tests
  1 package had test failures: mujoco_ros2_control_tests

```
</details>