### PR TITLE
Make register_sensors virtual for derived class to override

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -153,45 +153,6 @@ public:
 protected:
   rclcpp::Logger get_logger() const;
 
-private:
-  /**
-   * @brief Loads actuator information from MuJoCo model into the SystemInterface.
-   *
-   * This function reads the actuator definitions from the MuJoCo model and initializes their corresponding
-   * state and command information of the actuator handles.
-   */
-  bool register_mujoco_actuators();
-
-  /**
-   * @brief Loads actuator information into the HW interface.
-   *
-   * Will pull joint/actuator information from the provided HardwareInfo, and map it to the appropriate
-   * actuator in the sim's mujoco data. The data wrappers will be used as control/state interfaces for
-   * the HW interface.
-   */
-  void register_urdf_joints(const hardware_interface::HardwareInfo& info);
-
-  /**
-   * @brief Loads transmission information into the HW interface.
-   *
-   * Will pull transmission information from the provided HardwareInfo, and map it to the appropriate
-   * joints/actuators in the sim's mujoco data. This is primarily used to have cases where the URDF
-   * specifies the transmission ratios between joints and physical actuators.
-   */
-  bool register_transmissions(const hardware_interface::HardwareInfo& info);
-
-  bool initialize_initial_positions(const hardware_interface::HardwareInfo& info);
-
-  /**
-   * @brief Applies a keyframe to the simulation.
-   *
-   * This method sets the simulation state to the specified keyframe defined in the MuJoCo model.
-   * @param key_frame_name Name of the keyframe to apply.
-   *
-   * @return true if the keyframe was applied successfully, false otherwise.
-   */
-  bool apply_keyframe(const std::string& keyframe_name);
-
   /**
    * @brief Constructs all sensor data containers for the interface
    *
@@ -242,7 +203,46 @@ private:
    *    <state_interface name="linear_acceleration.z"/>
    *  </sensor>
    */
-  void register_sensors(const hardware_interface::HardwareInfo& info);
+  virtual void register_sensors(const hardware_interface::HardwareInfo& info);
+
+private:
+  /**
+   * @brief Loads actuator information from MuJoCo model into the SystemInterface.
+   *
+   * This function reads the actuator definitions from the MuJoCo model and initializes their corresponding
+   * state and command information of the actuator handles.
+   */
+  bool register_mujoco_actuators();
+
+  /**
+   * @brief Loads actuator information into the HW interface.
+   *
+   * Will pull joint/actuator information from the provided HardwareInfo, and map it to the appropriate
+   * actuator in the sim's mujoco data. The data wrappers will be used as control/state interfaces for
+   * the HW interface.
+   */
+  void register_urdf_joints(const hardware_interface::HardwareInfo& info);
+
+  /**
+   * @brief Loads transmission information into the HW interface.
+   *
+   * Will pull transmission information from the provided HardwareInfo, and map it to the appropriate
+   * joints/actuators in the sim's mujoco data. This is primarily used to have cases where the URDF
+   * specifies the transmission ratios between joints and physical actuators.
+   */
+  bool register_transmissions(const hardware_interface::HardwareInfo& info);
+
+  bool initialize_initial_positions(const hardware_interface::HardwareInfo& info);
+
+  /**
+   * @brief Applies a keyframe to the simulation.
+   *
+   * This method sets the simulation state to the specified keyframe defined in the MuJoCo model.
+   * @param key_frame_name Name of the keyframe to apply.
+   *
+   * @return true if the keyframe was applied successfully, false otherwise.
+   */
+  bool apply_keyframe(const std::string& keyframe_name);
 
   /**
    * @brief Sets the initial simulation conditions (pos, vel, ctrl) values from provided filepath.

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -2371,7 +2371,9 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
     }
     else
     {
-      RCLCPP_ERROR_STREAM(get_logger(), "Invalid mujoco_type passed to the mujoco hardware interface: " << mujoco_type);
+      // Base only handles standard sensors; derived classes may override register_sensors for more types.
+      RCLCPP_DEBUG_STREAM(get_logger(),
+                          "Skipping sensor type '" << mujoco_type << "' (not fts/imu); derived classes may handle it");
     }
   }
 }


### PR DESCRIPTION
**Changes**
- Make register_sensors() virtual and move it to protected so derived classes can override it.
- Treat unknown sensor types as debug instead of error so derived classes can add custom types (e.g. contact) without noisy logs.

**Testing**

[Example_18](https://github.com/Juliaj/ros2_control_demos/blob/fe8fac429a6a54ebc36ffb2619aed2aaad8f0876/example_18/hardware/duck_mini_mujoco_system_interface.cpp#L47-L51)