### PR TITLE
Fix for keeping dae textures that are images

### DIFF
--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -397,19 +397,24 @@ def convert_to_objs(mesh_info_dict, directory, xml_data, convert_stl_to_obj, dec
                 scene = trimesh.load(temp_filepath, force=trimesh.scene)
 
                 # The default glossiness was way too high, so here we iterate over each visual
-                # element, assign default glossiness and specular but keep the rgba values
-                for geom in scene.geometry.values():
-                    visual = geom.visual
-                    rgba = extract_rgba(visual)
+                # element, assign default glossiness and specular but keep the rgba values.
+                # We also ignore this process if there are any image files so that we don't
+                # accidentally overwrite those. Technically we could have cases where daes have
+                # both images, and materials but I think the logic gets exceedingly complex to
+                # handle that.
+                if not image_files:
+                    for geom in scene.geometry.values():
+                        visual = geom.visual
+                        rgba = extract_rgba(visual)
 
-                    new_mat = trimesh.visual.material.SimpleMaterial(
-                        diffuse=rgba[:3],
-                        alpha=rgba[3],
-                        glossiness=1000,
-                        specular=[0.2, 0.2, 0.2],
-                    )
+                        new_mat = trimesh.visual.material.SimpleMaterial(
+                            diffuse=rgba[:3],
+                            alpha=rgba[3],
+                            glossiness=1000,
+                            specular=[0.2, 0.2, 0.2],
+                        )
 
-                    visual.material = new_mat
+                        visual.material = new_mat
 
                 # give the material a unique name so that it can be properly referenced
                 mtl_modifier = f"m{mtl_num}"


### PR DESCRIPTION
[This PR](https://github.com/ros-controls/mujoco_ros2_control/pull/73) added some fixes to make sure that the glossiness wasn't overpowering after we switched to trimesh. Unfortunately, I didn't realize that it ended up breaking the process to bring in images textures from daes. This change should fix that by just conditioning the material changes based on whether or not the DAE has an image associated with it or not. 

Technically, we could have a case where a dae file has a regular texture and images as a texture, and this would I think continue to pull in the images correctly, and would have the remainder of the textures glossy, but I couldn't find a good way to get trimesh to distinguish for that case, so I am going with this simpler fix for now, and if we have a need to fix it in the future, we can.