### PR TITLE
Add proper logging for the mimic joints

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1882,7 +1882,7 @@ void MujocoSystemInterface::register_urdf_joints(const hardware_interface::Hardw
                      });
     const bool actuator_exists = actuator_it != mujoco_actuator_data_.end();
     // This isn't a failure the joint just won't be controllable
-    RCLCPP_WARN_EXPRESSION(get_logger(), !actuator_exists && !joint_data.is_mimic,
+    RCLCPP_INFO_EXPRESSION(get_logger(), !actuator_exists && !joint_data.is_mimic,
                            "Failed to find actuator for joint : %s. This joint will be treated as a passive joint.",
                            joint.name.c_str());
     RCLCPP_INFO_EXPRESSION(get_logger(), joint.command_interfaces.empty() && !joint_data.is_mimic,


### PR DESCRIPTION
**Current behaviour:**

```
Failed to find actuator for joint : gripper_outer_finger_right_joint. This joint will be treated as a passive joint.
Joint : gripper_outer_finger_right_joint is a passive joint
```

**With the proposed changes:**
```
[ros2_control_node-21] [INFO] [1771335814.029415094] [MujocoSystemInterface]: MuJoCo joint 'gripper_right_outer_finger_right_joint' is a mimic joint and has no associated actuator.
[ros2_control_node-21] [INFO] [1771329892.733762642] [MujocoSystemInterface]: Joint : 'gripper_right_outer_finger_right_joint' is a mimic joint mimicking joint 'gripper_right_finger_joint' with multiplier '-8.28'
```