### PR TITLE
Add git dependency

### DIFF
--- a/mujoco_ros2_control/package.xml
+++ b/mujoco_ros2_control/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>ros2_control_cmake</build_depend>
 
+  <depend>git</depend>
   <depend>backward_ros</depend>
   <depend>control_toolbox</depend>
   <depend>controller_manager</depend>


### PR DESCRIPTION
```
CMake Errors:
mujoco-ros2-control.build.log--- Ensuring Eigen3 include directory is part of orocos-kdl CMake target
mujoco-ros2-control.build.log--- Found nav_msgs: 4.9.1 (/opt/ros/humble/share/nav_msgs/cmake)
mujoco-ros2-control.build.log--- Found mujoco_ros2_control_msgs: 0.0.1 (/opt/pal/alum/share/mujoco_ros2_control_msgs/cmake)
mujoco-ros2-control.build.log--- Found transmission_interface: 4.43.0 (/opt/pal/alum/share/transmission_interface/cmake)
mujoco-ros2-control.build.log--- Found TinyXML2 via Config file: TinyXML2_DIR-NOTFOUND
mujoco-ros2-control.build.log:CMake Error at /usr/share/cmake-3.22/Modules/ExternalProject.cmake:2666 (message):
mujoco-ros2-control.build.log-  error: could not find git for clone of lodepng-populate
mujoco-ros2-control.build.log-Call Stack (most recent call first):
mujoco-ros2-control.build.log-  /usr/share/cmake-3.22/Modules/ExternalProject.cmake:3716 (_ep_add_download_command)
mujoco-ros2-control.build.log-  CMakeLists.txt:23 (ExternalProject_Add)
mujoco-ros2-control.build.log-
mujoco-ros2-control.build.log-
mujoco-ros2-control.build.log--- Configuring incomplete, errors occurred!
mujoco-ros2-control.build.log-See also "/home/worker/work/mujoco-ros2-control/mujoco-ros2-control/.obj-x86_64-linux-gnu/_deps/lodepng-subbuild/CMakeFiles/CMakeOutput.log".
mujoco-ros2-control.build.log-
mujoco-ros2-control.build.log:CMake Error at /usr/share/cmake-3.22/Modules/FetchContent.cmake:1075 (message):
mujoco-ros2-control.build.log-  CMake step for lodepng failed: 1
mujoco-ros2-control.build.log-Call Stack (most recent call first):
mujoco-ros2-control.build.log-  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1216:EVAL:2 (__FetchContent_directPopulate)
mujoco-ros2-control.build.log-  /usr/share/cmake-3.22/Modules/FetchContent.cmake:1216 (cmake_language)
mujoco-ros2-control.build.log-  CMakeLists.txt:54 (FetchContent_Populate)

```

As we are compiling lodepng here, i think this is definitely needed 