### PR TITLE
Rename default node to mujoco_ros2_control_node

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -853,7 +853,7 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
   }
   RCLCPP_INFO(get_logger(), "Constructing node and executor...");
   executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
-  mujoco_node_ = std::make_shared<rclcpp::Node>("mujoco_node", node_options);
+  mujoco_node_ = std::make_shared<rclcpp::Node>("mujoco_ros2_control_node", node_options);
   executor_->add_node(mujoco_node_);
   executor_thread_ = std::thread([this]() { executor_->spin(); });
   RCLCPP_INFO(get_logger(), "Executor thread started.");

--- a/mujoco_ros2_control_tests/test/robot_launch_test.py
+++ b/mujoco_ros2_control_tests/test/robot_launch_test.py
@@ -348,7 +348,7 @@ class TestFixture(unittest.TestCase):
         self.node.get_logger().info(f"Clock before reset: {clock_before_reset}")
 
         # Now call the reset_world service
-        reset_client = self.node.create_client(ResetWorld, "/mujoco_node/reset_world")
+        reset_client = self.node.create_client(ResetWorld, "/mujoco_ros2_control_node/reset_world")
 
         # Wait for service to be available
         if not reset_client.wait_for_service(timeout_sec=10.0):


### PR DESCRIPTION
Rename the default node to mujoco_ros2_control_node instead of mujoco_node

Semantically, I would prefer this change