### PR TITLE
Set MuJoCo install include dirs

### DIFF
--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -41,6 +41,9 @@ set(MUJOCO_SIMULATE_DIR "${MUJOCO_ROOT}/simulate")
 if(NOT EXISTS "${MUJOCO_SIMULATE_DIR}/simulate.h")
   set(MUJOCO_SIMULATE_DIR "${MUJOCO_ROOT}/include/simulate")
 endif()
+# So downstream packages that include our headers can find glfw_adapter.h etc.
+set(MUJOCO_INSTALL_INCLUDE_DIR "${MUJOCO_INCLUDE_DIR}")
+set(MUJOCO_INSTALL_SIMULATE_DIR "${MUJOCO_SIMULATE_DIR}")
 
 # Fetch lodepng dependency, if not available
 find_package(lodepng QUIET)


### PR DESCRIPTION
Fixes https://github.com/ros-controls/mujoco_ros2_control/issues/134

**Main changes**
- Restore the two set() calls after resolving MUJOCO_SIMULATE_DIR, so the installed interface again exports the MuJoCo include and simulate paths to downstream consumers.

This appears to be introduced by #130 (commit 0795d08): the refactor to unify apt/pixi MuJoCo paths removed the assignments to MUJOCO_INSTALL_INCLUDE_DIR and MUJOCO_INSTALL_SIMULATE_DIR. 

**Testing**
ros2_control_demos/example_18 built successfully.
