### PR TITLE
Export mujoco_ros2_control_plugins

### DIFF
--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -258,6 +258,7 @@ ament_export_dependencies(
   nav_msgs
   sensor_msgs
   mujoco_ros2_control_msgs
+  mujoco_ros2_control_plugins
   pluginlib
   control_toolbox
   Eigen3


### PR DESCRIPTION
Fixes https://github.com/ros-controls/mujoco_ros2_control/issues/137 which downstream packages that depend only on mujoco_ros2_control fail at CMake configure with: Target "mujoco_ros2_control_plugins::mujoco_ros2_control_plugins" not found.

**Main Change**
- In mujoco_ros2_control/CMakeLists.txt, add mujoco_ros2_control_plugins to the existing ament_export_dependencies(...) call.

With this, find_package(mujoco_ros2_control) brings in the plugins package and the plugins target is available when the generator expression is evaluated, so downstream packages do not need to depend on mujoco_ros2_control_plugins explicitly. 

**Testing**
ros2_control_demos/example_18 built successfully.