### PR TITLE
Use right arrow key to advance the simulation instead of S key

### DIFF
--- a/mujoco_ros2_control/README.md
+++ b/mujoco_ros2_control/README.md
@@ -456,9 +456,9 @@ When paused, the simulation clock stops advancing and no physics steps are execu
 
 ### Single-Stepping via the Keyboard
 
-While the simulation window is focused and the simulation is **paused**, press **`S`** to advance the simulation
-by exactly one physics step. Holding `S` down will advance the simulation continuously one step at a time,
-allowing slow, frame-by-frame inspection of the robot's motion.
+While the simulation window is focused and the simulation is **paused**, press the **right arrow key** (`→`) to
+advance the simulation by exactly one physics step. Holding the key down will advance the simulation continuously
+one step at a time, allowing slow, frame-by-frame inspection of the robot's motion.
 
 The status overlay in the top-right corner of the simulation window shows the current state
 (`Running` / `Paused`) and the total number of physics steps executed.

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -229,9 +229,20 @@ public:
 };
 
 /**
- * GlfwAdapter subclass that intercepts the 'S' key to request a single
- * simulation step while the simulation is paused.  All other keys are
- * forwarded to the parent class unchanged.
+ * GlfwAdapter subclass that overrides right-arrow-key handling so that a single
+ * simulation step is driven exclusively by the ROS control loop rather than by
+ * MuJoCo's built-in viewer.
+ *
+ * When the simulation is paused, MuJoCo's default GlfwAdapter advances the
+ * physics by one step (mj_step) on each right-arrow press or key-repeat event.
+ * This class suppresses that native behaviour and instead sets step_requested_,
+ * which the ROS control loop polls to advance the simulation.  This ensures
+ * that ros2_controller read/update/write cycles are executed for every step and
+ * that controller state remains consistent with the physics.
+ *
+ * All other keys are forwarded to the parent class unchanged so that the rest
+ * of the MuJoCo viewer UI (play/pause, reset, rendering options, etc.) works
+ * as normal.
  */
 class ROS2ControlGlfwAdapter : public mj::GlfwAdapter
 {
@@ -243,15 +254,19 @@ public:
 protected:
   void OnKey(int key, int scancode, int act) override
   {
-    // Forward all keys so normal UI behaviour is preserved.
-    mj::GlfwAdapter::OnKey(key, scancode, act);
-
-    // Queue one physics step on each press or key-repeat event for 'S',
-    // so holding the key advances the simulation continuously.
-    if (key == GLFW_KEY_S && (act == GLFW_PRESS || act == GLFW_REPEAT))
+    // Intercept the right arrow key so only the ROS loop advances the physics,
+    // preventing double-stepping (MuJoCo's native handler would also call mj_step).
+    if (key == GLFW_KEY_RIGHT)
     {
-      step_requested_.store(true);
+      if (act == GLFW_PRESS || act == GLFW_REPEAT)
+      {
+        step_requested_.store(true);
+      }
+      return;
     }
+
+    // Forward all other keys so normal UI behaviour is preserved.
+    mj::GlfwAdapter::OnKey(key, scancode, act);
   }
 
 private:


### PR DESCRIPTION
If the shadows are enabled, the current S key alternatively disabled and enables the shadow along with stepping, this is not a desired behaviour, updating the key to use the native right arrow key to advance the simulation