### PR TITLE
Enable headless mode on ROS2 Humble

### DIFF
--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16)
 
 project(mujoco_ros2_control)
 
+# Detect ROS2 Humble for API compatibility (get_hardware_info() shim)
+if("$ENV{ROS_DISTRO}" STREQUAL "humble")
+  add_definitions(-DROS_DISTRO_HUMBLE)
+endif()
+
 find_package(ros2_control_cmake REQUIRED)
 
 # find dependencies

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -788,8 +788,12 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
   const auto lidar_publish_rate =
       std::stod(get_hardware_parameter(get_hardware_info(), "lidar_publish_rate").value_or("5.0"));
 
-  // Check for headless mode
+  // Check for headless mode (URDF hardware param or environment variable)
   headless_ = hardware_interface::parse_bool(get_hardware_parameter(get_hardware_info(), "headless").value_or("false"));
+  if (!headless_ && std::getenv("MUJOCO_HEADLESS"))
+  {
+    headless_ = true;
+  }
   RCLCPP_INFO_EXPRESSION(get_logger(), headless_, "Running in HEADLESS mode.");
 
   // We essentially reconstruct the 'simulate.cc::main()' function here, and


### PR DESCRIPTION
## Summary

Fixes headless mode on ROS2 Humble, which currently silently fails and falls through to GLFW (crashing on headless machines like Jetson).

Two small changes:
- **CMakeLists.txt**: Add `ROS_DISTRO_HUMBLE` cmake define. The `#if ROS_DISTRO_HUMBLE` guard for `get_hardware_info()` already exists in the header but was never activated.
- **mujoco_system_interface.cpp**: Add `MUJOCO_HEADLESS` environment variable fallback for cases where the URDF hardware param path is unreliable on Humble.

## Problem

On Humble, `get_hardware_info()` doesn't exist in `hardware_interface::SystemInterface`. The header already has a compatibility shim at line 114:
```cpp
#if ROS_DISTRO_HUMBLE
  const hardware_interface::HardwareInfo& get_hardware_info() const { return info_; }
#endif
```

But `ROS_DISTRO_HUMBLE` was never defined in cmake, so this shim is dead code. Without it, the `headless` hardware parameter can't be read, and the plugin always takes the GLFW path — crashing on headless machines.

## Testing

Tested on Jetson AGX Orin (aarch64, Ubuntu 22.04, ROS2 Humble, MuJoCo 3.6.0):
- Before: `ERROR: could not initialize GLFW` → process dies
- After: `Running in HEADLESS mode.` → robot initializes, controllers activate

## Changes

- `mujoco_ros2_control/CMakeLists.txt`: +5 lines (detect Humble, set define)
- `mujoco_ros2_control/src/mujoco_system_interface.cpp`: +4 lines (env var fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)