### PR TITLE
search delimiter from back to support joint names with '/'

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1367,7 +1367,7 @@ MujocoSystemInterface::perform_command_mode_switch(const std::vector<std::string
                                                    const std::vector<std::string>& stop_interfaces)
 {
   auto update_joint_interface = [this](const std::string& interface_name, bool enabled) {
-    size_t delimiter_pos = interface_name.find('/');
+    const size_t delimiter_pos = interface_name.rfind('/');
     if (delimiter_pos == std::string::npos)
     {
       RCLCPP_ERROR(get_logger(), "Invalid interface name format: %s", interface_name.c_str());


### PR DESCRIPTION
```
To separate the joint name from the interface, the function
`perform_command_mode_switch` searches for `/` starting from the beginning.
When using a joint name with a `/`, this wrongly splits the joint name. Fix
this by searching from the end.
```