### PR TITLE
Increase timeout on sim_ready_future

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -868,7 +868,7 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
     });
   }
 
-  if (sim_ready_future.wait_for(2s) == std::future_status::timeout)
+  if (sim_ready_future.wait_for(10s) == std::future_status::timeout)
   {
     RCLCPP_FATAL(get_logger(), "Timed out waiting to start simulation rendering!");
     return hardware_interface::CallbackReturn::ERROR;


### PR DESCRIPTION
We have seen some issues with some folks trying to use the driver on hardware that is less capable (VMs with limited capabilities, or over ssh with just plain x-forwarding). I eventually found that the 2s allotted to spin up the GLFW window wasn't always sufficient, but changing this to 10s seemed to always resolve the issue. 

I don't think this change should be an issue unless we have a **lot** of testing that is expecting that spin up to fail, in which case we would be adding 8s to every failure case. But I don't imagine that is the case.