### PR TITLE
Use pkg install dir for requirements in conversion script

### DIFF
--- a/mujoco_ros2_control/scripts/robot_description_to_mjcf.sh
+++ b/mujoco_ros2_control/scripts/robot_description_to_mjcf.sh
@@ -47,7 +47,7 @@ function check_dependencies() {
     if ! python3 -c "import trimesh; import mujoco; import obj2mjcf" &> /dev/null; then
         echo "Dependencies not found. Installing from requirements.txt...."
         start_time=$(date +%s)
-        pip3 install --no-input --no-cache-dir --disable-pip-version-check -r "$(dirname "${BASH_SOURCE[0]}")/requirements.txt"
+        pip3 install --no-input --no-cache-dir --disable-pip-version-check -r "$(ros2 pkg prefix mujoco_ros2_control --share)/requirements.txt"
         end_time=$(date +%s)
         echo "Successfully installed dependencies in $((end_time - start_time)) seconds."
     fi


### PR DESCRIPTION
Otherwise it's looking in the lib when running the actual launch file.

```
[robot_description_to_mjcf.sh-1] ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/opt/mujoco/ws/install/mujoco_ros2_control/lib/mujoco_ros2_control/requirements.txt'
[robot_description_to_mjcf.sh-1] Successfully installed dependencies in 0 seconds.
```

We should either do this or install `requirements.txt` into the lib, which feels wrong.