### PR TITLE
Temp disable rolling build check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        ros_distro: [humble, jazzy, kilted, rolling]
+        # TODO: Re-enable rolling when keys are available:
+        # https://github.com/ros-controls/mujoco_ros2_control/issues/178
+        # ros_distro: [humble, jazzy, kilted, rolling]
+        ros_distro: [humble, jazzy, kilted]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
     apt-get update && \
     rosdep update && \
-    rosdep install -iry --from-paths src/
+    rosdep install -iy --from-paths src/
 
 # Copy remaining source
 COPY . ${ROS_WS}/src/mujoco_ros2_control/


### PR DESCRIPTION
Because of https://github.com/ros-controls/mujoco_ros2_control/issues/178

Resolving:

https://github.com/ros-controls/mujoco_ros2_control/actions/runs/25112185073/job/73595284152#step:5:407

Until deps are in place. I'd like to have the functional distros running while working on #175!