### PR TITLE
Improve LiDAR validation in URDF-to-MJCF conversion

### DIFF
--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -991,11 +991,13 @@ def add_lidar_from_sites(dom, lidar_dict):
     """
 
     x_form = [0.5, 0.5, 0.5, 0.5]  # pi/2 around x, pi/2 about y
+    matched_sites = set()
 
     # Construct all lidar sensor bodies for relevant sites in xml and add them as children to the same parent
     for node in dom.getElementsByTagName("site"):
         site_name = node.getAttribute("name")
         if site_name in lidar_dict:
+            matched_sites.add(site_name)
             replicate = lidar_dict[site_name]
 
             # Handle conversion of the frames by applying the site transform, rangefinder transform, then
@@ -1024,6 +1026,10 @@ def add_lidar_from_sites(dom, lidar_dict):
                 print(f"  {attr.name}: {attr.value}")
 
             node.parentNode.appendChild(new_body)
+
+    unmatched = set(lidar_dict.keys()) - matched_sites
+    if unmatched:
+        raise ValueError(f"Lidar site(s) not found in the MJCF: {', '.join(sorted(unmatched))}")
 
     return dom
 

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -534,6 +534,8 @@ def get_processed_mujoco_inputs(processed_inputs_element):
             min_angle = float(lidar_element.getAttribute("min_angle"))
             max_angle = float(lidar_element.getAttribute("max_angle"))
             angle_increment = float(lidar_element.getAttribute("angle_increment"))
+            if angle_increment <= 0:
+                raise ValueError("'angle_increment' must be greater than zero for a 'lidar' tag!")
 
             num_sensors = int((max_angle - min_angle) / angle_increment) + 1
 

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -555,6 +555,18 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         decompose_dict, cameras_dict, modify_element_dict, lidar_dict = get_processed_mujoco_inputs(processed_element)
         assert "lidar_site" in lidar_dict
 
+    def test_get_processed_mujoco_inputs_lidar_zero_angle_increment(self):
+        xml_string = """<?xml version="1.0"?>
+<processed_inputs>
+  <lidar ref_site="lidar_site" sensor_name="rf" min_angle="0" max_angle="1.57" angle_increment="0"/>
+</processed_inputs>"""
+        dom = minidom.parseString(xml_string)
+        processed_element = dom.getElementsByTagName("processed_inputs")[0]
+
+        with self.assertRaises(ValueError) as context:
+            get_processed_mujoco_inputs(processed_element)
+        assert "angle_increment" in str(context.exception)
+
     def test_get_processed_mujoco_inputs_modify_element(self):
         xml_string = """<?xml version="1.0"?>
 <processed_inputs>
@@ -980,9 +992,9 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         lidar_elem.setAttribute("min_angle", "0")
         lidar_dict["other_site"] = lidar_elem
 
-        result_dom = add_lidar_from_sites(dom, lidar_dict)
-        result_xml = result_dom.toxml()
-        assert "lidar_body" not in result_xml
+        with self.assertRaises(ValueError) as context:
+            add_lidar_from_sites(dom, lidar_dict)
+        assert "other_site" in str(context.exception)
 
     def test_add_lidar_from_sites_removes_min_angle(self):
         xml_string = """<?xml version="1.0"?>


### PR DESCRIPTION
This PR improves validation for LiDAR handling in the URDF-to-MJCF conversion pipeline.

Currently, camera handling records matched sites and raises an error when a referenced site cannot be found. However, LiDAR handling does not have the same validation behavior. If a LiDAR `ref_site` is misspelled or missing, `add_lidar_from_sites()` silently skips it, and the generated MJCF contains no LiDAR without any failure signal.

In addition, `angle_increment` is used in LiDAR angle processing, but invalid values such as `0` were not explicitly checked before use. This could lead to a division-by-zero error later in the conversion process. This PR adds validation to ensure `angle_increment` is greater than zero, so invalid LiDAR configurations fail early with a clearer error message.


## Changes

1. Raise an error for unmatched LiDAR sites

   If a referenced LiDAR site cannot be found, the converter now raises a clear error instead of silently continuing:

   ```python
   ValueError("Lidar site(s) not found ...")


2. Validate `angle_increment`

   Since `angle_increment` is used in LiDAR angle processing, setting it to `0` could previously lead to a division-by-zero error. This PR now catches that invalid configuration earlier by raising a clear `ValueError`:

   ```python
   ValueError("'angle_increment' must be greater than zero for a 'lidar' tag!")