### PR TITLE
Handle MuJoCo model topic load failures without exiting the process

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -485,8 +485,8 @@ mjModel* loadModelFromTopic(rclcpp::Node::SharedPtr node, const std::string& top
 
     if (now - start > timeout)
     {
-      RCLCPP_WARN(node->get_logger(), "Timeout waiting for /mujoco_robot_description topic. Aborting...");
-      exit(1);
+      RCLCPP_WARN(node->get_logger(), "Timeout waiting for '%s' topic.", topic_name.c_str());
+      return nullptr;
     }
 
     rclcpp::sleep_for(std::chrono::milliseconds(200));
@@ -507,6 +507,7 @@ mjModel* loadModelFromTopic(rclcpp::Node::SharedPtr node, const std::string& top
       RCLCPP_INFO(node->get_logger(), "Error %s", myerr);
       RCLCPP_FATAL(node->get_logger(), "Failed to compile MuJoCo model: %s", error);
       mj_deleteSpec(spec);
+      return nullptr;
     }
     mj_deleteSpec(spec);
     RCLCPP_INFO(node->get_logger(), "Model body count: %ld", static_cast<long>(mnew->nbody));


### PR DESCRIPTION
This PR updates `loadModelFromTopic()` so model loading failures are reported through the normal `on_init()` error path instead of terminating the whole process.

Previously, if no MuJoCo model was received from the configured topic before timeout, `loadModelFromTopic()` called `exit(1)`. That can unexpectedly shut down the entire process hosting the hardware interface, bypassing normal ROS 2 control lifecycle error handling.

This change makes `loadModelFromTopic()` return `nullptr` on timeout. `on_init()` already checks for a null model and returns `CallbackReturn::ERROR`.

The PR also returns `nullptr` when parsing or compiling model XML from the topic fails, avoiding a possible null dereference when logging model details.

## Changes

Replace `exit(1)` in `loadModelFromTopic()` with return `nullptr`
Log the configured topic name when waiting for the model times out
Return `nullptr` after failed MuJoCo XML parsing/compilation
Reuse the existing `on_init()` null-model error path

## Why

Hardware interface plugins should not terminate the host process directly. Returning failure lets the controller manager and ROS 2 lifecycle infrastructure handle initialization errors consistently.