### PR TITLE
Display the sim real time factor on the native viewer

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/sim_display_text.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/sim_display_text.hpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026 PAL Robotics S.L.
+ *
+ * All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <utility>
+
+namespace mujoco_ros2_control
+{
+
+/**
+ * @brief Composes the title/content text pair for the native-viewer status overlay.
+ *
+ * Extracted as a pure, dependency-free function so the overlay layout and number
+ * formatting can be unit tested without a live OpenGL/GLFW rendering context (the
+ * overlay itself is only drawn in non-headless mode). MuJoCo's overlay API renders
+ * the two strings side by side: each newline-separated row in @p title is paired
+ * with the row at the same position in the returned content string, so the two must
+ * always contain the same number of rows.
+ *
+ * @param running     Whether the physics loop is currently advancing. Drives the
+ *                    "Status" row ("Running"/"Paused").
+ * @param step_count  Number of physics steps taken so far (mjData step counter).
+ * @param sim_time    Current simulation clock in seconds (mjData::time).
+ * @param desired_pct Target real-time percentage — either the UI slider value or the
+ *                    `sim_speed_factor` override, resolved by the caller.
+ * @param actual_pct  Measured real-time percentage (100 / measured_slowdown). The
+ *                    caller passes 0 while paused.
+ * @param ncon        Number of active contacts in the current step (mjData::ncon).
+ * @return A pair of {title, content} strings ready to hand to MuJoCo's user-text overlay.
+ */
+inline std::pair<std::string, std::string> compose_sim_display_text(bool running, uint64_t step_count, double sim_time,
+                                                                    double desired_pct, double actual_pct, int ncon)
+{
+  char sim_time_buf[24], desired_buf[16], actual_buf[16];
+  std::snprintf(sim_time_buf, sizeof(sim_time_buf), "%.3f s", sim_time);
+  std::snprintf(desired_buf, sizeof(desired_buf), "%.1f%%", desired_pct);
+  std::snprintf(actual_buf, sizeof(actual_buf), "%.1f%%", actual_pct);
+
+  const std::string title = "Status\nSteps\nSim Time\nDesired Speed\nActual Speed\nContacts";
+  const std::string content = std::string(running ? "Running" : "Paused") + "\n" + std::to_string(step_count) + "\n" +
+                              sim_time_buf + "\n" + desired_buf + "\n" + actual_buf + "\n" + std::to_string(ncon);
+  return { title, content };
+}
+
+}  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -1274,10 +1274,24 @@ void MujocoSimulation::update_sim_display()
     return;  // render thread hasn't consumed the last update yet, skip
   }
 
+  // Desired speed: from parameter override when set, otherwise from the UI slider.
+  const double desired_pct = sim_speed_factor_ < 0 ? static_cast<double>(sim_->percentRealTime[sim_->real_time_index]) :
+                                                     sim_speed_factor_ * 100.0;
+
+  // Actual speed: measured_slowdown = CPU_time / sim_time, so speed = 100 / slowdown.
+  // Falls back to 0 while paused (slowdown stays at its last measured value but we
+  // suppress the display when there is no forward progress).
+  const double actual_pct = sim_->run ? (100.0 / sim_->measured_slowdown) : 0.0;
+
+  char desired_buf[16], actual_buf[16];
+  std::snprintf(desired_buf, sizeof(desired_buf), "%.1f%%", desired_pct);
+  std::snprintf(actual_buf, sizeof(actual_buf), "%.1f%%", actual_pct);
+
   const std::string status = sim_->run ? "Running" : "Paused";
   sim_->user_texts_new_.clear();
-  sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, "Status\nSteps",
-                                     status + "\n" + std::to_string(step_count_.load()));
+  sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, "Status\nSteps\nDesired Speed\nActual Speed",
+                                     status + "\n" + std::to_string(step_count_.load()) + "\n" + desired_buf + "\n" +
+                                         actual_buf);
 }
 
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -1260,10 +1260,24 @@ void MujocoSimulation::update_sim_display()
     return;  // render thread hasn't consumed the last update yet, skip
   }
 
+  // Desired speed: from parameter override when set, otherwise from the UI slider.
+  const double desired_pct = sim_speed_factor_ < 0 ? static_cast<double>(sim_->percentRealTime[sim_->real_time_index]) :
+                                                     sim_speed_factor_ * 100.0;
+
+  // Actual speed: measured_slowdown = CPU_time / sim_time, so speed = 100 / slowdown.
+  // Falls back to 0 while paused (slowdown stays at its last measured value but we
+  // suppress the display when there is no forward progress).
+  const double actual_pct = sim_->run ? (100.0 / sim_->measured_slowdown) : 0.0;
+
+  char desired_buf[16], actual_buf[16];
+  std::snprintf(desired_buf, sizeof(desired_buf), "%.1f%%", desired_pct);
+  std::snprintf(actual_buf, sizeof(actual_buf), "%.1f%%", actual_pct);
+
   const std::string status = sim_->run ? "Running" : "Paused";
   sim_->user_texts_new_.clear();
-  sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, "Status\nSteps",
-                                     status + "\n" + std::to_string(step_count_.load()));
+  sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, "Status\nSteps\nDesired Speed\nActual Speed",
+                                     status + "\n" + std::to_string(step_count_.load()) + "\n" + desired_buf + "\n" +
+                                         actual_buf);
 }
 
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -18,8 +18,8 @@
  */
 
 #include "mujoco_ros2_control/mujoco_simulation.hpp"
-#include "mujoco_ros2_control/sim_display_text.hpp"
 #include "array_safety.h"
+#include "mujoco_ros2_control/sim_display_text.hpp"
 
 #include <unistd.h>
 #include <cerrno>
@@ -1272,8 +1272,8 @@ void MujocoSimulation::update_sim_display()
 
   // mj_data_ is owned by this (the physics) thread, so reading time/ncon needs no extra locking.
   // Contacts surface why the sim slows down: a spike here usually explains a drop in actual speed.
-  const auto [title, content] = compose_sim_display_text(sim_->run, step_count_.load(), mj_data_->time, desired_pct,
-                                                         actual_pct, mj_data_->ncon);
+  const auto [title, content] =
+      compose_sim_display_text(sim_->run, step_count_.load(), mj_data_->time, desired_pct, actual_pct, mj_data_->ncon);
 
   sim_->user_texts_new_.clear();
   sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, title, content);

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "mujoco_ros2_control/mujoco_simulation.hpp"
+#include "mujoco_ros2_control/sim_display_text.hpp"
 #include "array_safety.h"
 
 #include <unistd.h>
@@ -1269,15 +1270,13 @@ void MujocoSimulation::update_sim_display()
   // suppress the display when there is no forward progress).
   const double actual_pct = sim_->run ? (100.0 / sim_->measured_slowdown) : 0.0;
 
-  char desired_buf[16], actual_buf[16];
-  std::snprintf(desired_buf, sizeof(desired_buf), "%.1f%%", desired_pct);
-  std::snprintf(actual_buf, sizeof(actual_buf), "%.1f%%", actual_pct);
+  // mj_data_ is owned by this (the physics) thread, so reading time/ncon needs no extra locking.
+  // Contacts surface why the sim slows down: a spike here usually explains a drop in actual speed.
+  const auto [title, content] = compose_sim_display_text(sim_->run, step_count_.load(), mj_data_->time, desired_pct,
+                                                         actual_pct, mj_data_->ncon);
 
-  const std::string status = sim_->run ? "Running" : "Paused";
   sim_->user_texts_new_.clear();
-  sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, "Status\nSteps\nDesired Speed\nActual Speed",
-                                     status + "\n" + std::to_string(step_count_.load()) + "\n" + desired_buf + "\n" +
-                                         actual_buf);
+  sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, title, content);
 }
 
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/tests/test_headless_init.cpp
+++ b/mujoco_ros2_control/tests/test_headless_init.cpp
@@ -212,9 +212,6 @@ TEST_F(HeadlessInitTest, HeadlessActivateWithoutCameras)
   EXPECT_EQ(activate_result, hardware_interface::CallbackReturn::SUCCESS);
 }
 
-// Verify that the sim_speed_factor parameter is accepted and the simulation runs.
-// The native-viewer overlay displays desired and actual speed only in non-headless mode;
-// this test exercises the initialization path that feeds the desired-speed display value.
 TEST_F(HeadlessInitTest, SpeedFactorParamInitialization)
 {
   hardware_info_.hardware_parameters["sim_speed_factor"] = "0.5";
@@ -254,6 +251,29 @@ TEST_F(HeadlessInitTest, SpeedFactorParamInitialization)
 
   // sim_time should have advanced from zero
   EXPECT_GT(test_data->time, 0.0) << "Simulation time did not advance with sim_speed_factor=0.5";
+}
+
+TEST(SimDisplayTextTest, ComposesAllRowsWhenRunning)
+{
+  const auto [title, content] = mujoco_ros2_control::compose_sim_display_text(
+      /*running=*/true, /*step_count=*/1234, /*sim_time=*/2.5,
+      /*desired_pct=*/50.0, /*actual_pct=*/48.3, /*ncon=*/7);
+
+  EXPECT_EQ(title, "Status\nSteps\nSim Time\nDesired Speed\nActual Speed\nContacts");
+  EXPECT_EQ(content, "Running\n1234\n2.500 s\n50.0%\n48.3%\n7");
+
+  // Title and content must line up row-for-row, otherwise the overlay is misaligned.
+  const auto count_rows = [](const std::string& s) { return std::count(s.begin(), s.end(), '\n'); };
+  EXPECT_EQ(count_rows(title), count_rows(content));
+}
+
+TEST(SimDisplayTextTest, ReportsPausedStatus)
+{
+  const auto [title, content] = mujoco_ros2_control::compose_sim_display_text(
+      /*running=*/false, /*step_count=*/0, /*sim_time=*/0.0,
+      /*desired_pct=*/100.0, /*actual_pct=*/0.0, /*ncon=*/0);
+
+  EXPECT_EQ(content, "Paused\n0\n0.000 s\n100.0%\n0.0%\n0");
 }
 
 int main(int argc, char** argv)

--- a/mujoco_ros2_control/tests/test_headless_init.cpp
+++ b/mujoco_ros2_control/tests/test_headless_init.cpp
@@ -154,6 +154,50 @@ TEST_F(HeadlessInitTest, HeadlessInitialization)
   EXPECT_GE(state_interfaces.size(), 0);
 }
 
+// Verify that the sim_speed_factor parameter is accepted and the simulation runs.
+// The native-viewer overlay displays desired and actual speed only in non-headless mode;
+// this test exercises the initialization path that feeds the desired-speed display value.
+TEST_F(HeadlessInitTest, SpeedFactorParamInitialization)
+{
+  hardware_info_.hardware_parameters["sim_speed_factor"] = "0.5";
+
+#if ROS_DISTRO_HUMBLE
+  auto result = interface_->on_init(hardware_info_);
+#else
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = hardware_info_;
+  auto result = interface_->on_init(params);
+#endif
+  ASSERT_EQ(result, hardware_interface::CallbackReturn::SUCCESS);
+
+  // Wait for the model to load so the physics thread starts.
+  auto start = std::chrono::steady_clock::now();
+  mjModel* test_model = nullptr;
+  mjData* test_data = nullptr;
+  while (std::chrono::steady_clock::now() - start < std::chrono::seconds(2))
+  {
+    interface_->get_model(test_model);
+    interface_->get_data(test_data);
+    if (test_model != nullptr && test_data != nullptr)
+    {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_NE(test_model, nullptr) << "Model failed to initialize within timeout";
+  ASSERT_NE(test_data, nullptr) << "Data failed to initialize within timeout";
+
+  // Let the physics thread run a few steps to confirm sim_speed_factor does not
+  // cause a crash and the sim advances time.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // Re-snapshot data after physics has had time to run (get_data copies the current state).
+  interface_->get_data(test_data);
+
+  // sim_time should have advanced from zero
+  EXPECT_GT(test_data->time, 0.0) << "Simulation time did not advance with sim_speed_factor=0.5";
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/mujoco_ros2_control/tests/test_headless_init.cpp
+++ b/mujoco_ros2_control/tests/test_headless_init.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -26,6 +27,7 @@
 #include <mujoco/mujoco.h>
 #include <hardware_interface/hardware_info.hpp>
 #include <mujoco_ros2_control/mujoco_system_interface.hpp>
+#include <mujoco_ros2_control/sim_display_text.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #define ROS_DISTRO_HUMBLE (HARDWARE_INTERFACE_VERSION_MAJOR < 3)
@@ -208,6 +210,50 @@ TEST_F(HeadlessInitTest, HeadlessActivateWithoutCameras)
   rclcpp_lifecycle::State active_state(0, "active");
   auto activate_result = interface_->on_activate(active_state);
   EXPECT_EQ(activate_result, hardware_interface::CallbackReturn::SUCCESS);
+}
+
+// Verify that the sim_speed_factor parameter is accepted and the simulation runs.
+// The native-viewer overlay displays desired and actual speed only in non-headless mode;
+// this test exercises the initialization path that feeds the desired-speed display value.
+TEST_F(HeadlessInitTest, SpeedFactorParamInitialization)
+{
+  hardware_info_.hardware_parameters["sim_speed_factor"] = "0.5";
+
+#if ROS_DISTRO_HUMBLE
+  auto result = interface_->on_init(hardware_info_);
+#else
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = hardware_info_;
+  auto result = interface_->on_init(params);
+#endif
+  ASSERT_EQ(result, hardware_interface::CallbackReturn::SUCCESS);
+
+  // Wait for the model to load so the physics thread starts.
+  auto start = std::chrono::steady_clock::now();
+  mjModel* test_model = nullptr;
+  mjData* test_data = nullptr;
+  while (std::chrono::steady_clock::now() - start < std::chrono::seconds(2))
+  {
+    interface_->get_model(test_model);
+    interface_->get_data(test_data);
+    if (test_model != nullptr && test_data != nullptr)
+    {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_NE(test_model, nullptr) << "Model failed to initialize within timeout";
+  ASSERT_NE(test_data, nullptr) << "Data failed to initialize within timeout";
+
+  // Let the physics thread run a few steps to confirm sim_speed_factor does not
+  // cause a crash and the sim advances time.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // Re-snapshot data after physics has had time to run (get_data copies the current state).
+  interface_->get_data(test_data);
+
+  // sim_time should have advanced from zero
+  EXPECT_GT(test_data->time, 0.0) << "Simulation time did not advance with sim_speed_factor=0.5";
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Sometimes I realized that my sim is running slower due to complex meshes and it was just a sensation and now adding this info really helps to understand when something goes wrong

<img width="1851" height="1165" alt="image" src="https://github.com/user-attachments/assets/4327f863-ea89-4cd6-a1f5-f137961b7e32" />
<img width="1851" height="1128" alt="image" src="https://github.com/user-attachments/assets/331dc302-00d2-4cbe-b6ef-1522ec9b2e90" />
<img width="1845" height="1168" alt="image" src="https://github.com/user-attachments/assets/d149c545-aa27-4140-8305-f46b71e4e8ed" />
