### PR TITLE
Add changes for mujoco vendor bump

### DIFF
--- a/mujoco_ros2_control/package.xml
+++ b/mujoco_ros2_control/package.xml
@@ -24,6 +24,7 @@
   <depend>controller_manager</depend>
   <depend>hardware_interface</depend>
   <depend>fmt</depend>
+  <depend>ros2pkg</depend>
   <depend>nav_msgs</depend>
   <depend>libglfw3-dev</depend>
   <depend>mujoco_vendor</depend>

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -952,7 +952,7 @@ void MujocoSimulation::apply_control_data(mjData* control_data)
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
   mju_copy(mj_data_->ctrl, control_data->ctrl, mj_model_->nu);
   mju_copy(mj_data_->qfrc_applied, control_data->qfrc_applied, mj_model_->nv);
-  mju_copy(xfrc_plugin_desired_.data(), control_data->xfrc_applied, 6 * mj_model_->nbody);
+  mju_copy(xfrc_plugin_desired_.data(), control_data->xfrc_applied, 6 * static_cast<int>(mj_model_->nbody));
 }
 
 void MujocoSimulation::handle_xfrc_applied()
@@ -1025,7 +1025,7 @@ void MujocoSimulation::physics_loop()
         // record it in xfrc_last_written_. We can then combine the desired forces from the plugins
         // as well as the viewers prior to stepping, without either of them stacking in
         // undesirable ways.
-        const auto nbody6 = 6 * mj_model_->nbody;
+        const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
         if (std::memcmp(mj_data_->xfrc_applied, xfrc_last_written_.data(), nbody6 * sizeof(mjtNum)) != 0)
         {
           // Render thread ran: xfrc_applied was zeroed then drag was applied.

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -950,17 +950,17 @@ void MujocoSimulation::copy_physics_data(mjData*& destination)
 void MujocoSimulation::apply_control_data(mjData* control_data)
 {
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
-  mju_copy(mj_data_->ctrl, control_data->ctrl, mj_model_->nu);
-  mju_copy(mj_data_->qfrc_applied, control_data->qfrc_applied, mj_model_->nv);
+  mju_copy(mj_data_->ctrl, control_data->ctrl, static_cast<int>(mj_model_->nu));
+  mju_copy(mj_data_->qfrc_applied, control_data->qfrc_applied, static_cast<int>(mj_model_->nv));
   mju_copy(xfrc_plugin_desired_.data(), control_data->xfrc_applied, 6 * static_cast<int>(mj_model_->nbody));
 }
 
 void MujocoSimulation::handle_xfrc_applied()
 {
-  const auto nbody6 = 6 * mj_model_->nbody;
+  const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
   mju_copy(mj_data_->xfrc_applied, xfrc_viewer_capture_.data(), nbody6);
   mju_addTo(mj_data_->xfrc_applied, xfrc_plugin_desired_.data(), nbody6);
-  mju_copy(xfrc_last_written_.data(), mj_data_->xfrc_applied, 6 * mj_model_->nbody);
+  mju_copy(xfrc_last_written_.data(), mj_data_->xfrc_applied, nbody6);
 }
 
 // simulate in background thread (while rendering in main thread)

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1000,7 +1000,7 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
   // Clear plugin data, then let each plugin update as needed, in order. This enables plugins to read and
   // rewrite control inputs immediately before they are sent to the simulation. Namely, we have to zero
   // out xfrc_applied so plugins can update as needed.
-  mju_zero(mj_data_control_->xfrc_applied, 6 * simulation_->model()->nbody);
+  mju_zero(mj_data_control_->xfrc_applied, 6 * static_cast<int>(simulation_->model()->nbody));
   for (auto& plugin : plugin_instances_)
   {
     plugin->update(simulation_->model(), mj_data_control_);

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1931,11 +1931,11 @@ bool MujocoSystemInterface::set_override_start_positions(const std::string& over
   {
     RCLCPP_ERROR(get_logger(),
                  "Mismatch in data types in override starting positions. Numbers are:\n\t"
-                 "qpos size in file: %zu, qpos size in model: %d\n\t"
-                 "qvel size in file: %zu, qvel size in model: %d\n\t"
-                 "ctrl size in file: %zu, ctrl size in model: %d",
-                 qpos.size(), simulation_->model()->nq, qvel.size(), simulation_->model()->nv, ctrl.size(),
-                 simulation_->model()->nu);
+                 "qpos size in file: %zu, qpos size in model: %ld\n\t"
+                 "qvel size in file: %zu, qvel size in model: %ld\n\t"
+                 "ctrl size in file: %zu, ctrl size in model: %ld",
+                 qpos.size(), static_cast<long>(simulation_->model()->nq), qvel.size(),
+                 static_cast<long>(simulation_->model()->nv), ctrl.size(), static_cast<long>(simulation_->model()->nu));
     return false;
   }
 


### PR DESCRIPTION
The recent changes introduced in MuJoCo 3.4.0+, they have changed the types of some of the variables, and this is making our code fail to compile to to the COnversion warnings set to error, we will need these changes to work on both the existing version  of mujoco_vendor - 3.4.0 and also to bump it to 3.8.1