### PR TITLE
Use collision tags for the collision geometries for the URDF->MJCF conversion

### DIFF
--- a/mujoco_ros2_control/docs/tools.rst
+++ b/mujoco_ros2_control/docs/tools.rst
@@ -129,19 +129,25 @@ Rough outline of the automated conversion process
      For instance, if running multiple types of UR robots in one sim, there will be multiple ``shoulder.dae`` files.
 
 - Reads absolute filepaths of all meshes (from both ``<visual>`` and ``<collision>`` tags) and
-  converts either ``.dae`` or ``.stl`` to ``.obj`` using trimesh.
-
-  - Puts all meshes into an ``assets/`` folder under ``mjcf_data/`` relative to current working dir.
-  - Modifies filepaths again in URDF to point to the ``assets/`` folder.
-  - Decomposes large meshes into multiple components to ensure convex hulls.
+  materializes them into an ``assets/`` folder under ``mjcf_data/`` relative to the current
+  working dir, rewriting the URDF mesh paths to point there.
 
 - Handles visual and collision geometry independently:
 
-  - The ``<visual>`` geometry is used purely for rendering (the ``visual`` class).
-  - The ``<collision>`` geometry drives physics (the ``collision`` class). When a link defines no
-    ``<collision>``, a collision is synthesized from its ``<visual>`` so the visual mesh is reused
-    as the collision shape (the previous behaviour). This synthesis happens at the URDF level, so it
-    stays correct per link even when MuJoCo fuses fixed-jointed bodies together.
+  - **Visual** geometry is used purely for rendering (the ``visual`` class). Visual meshes are
+    plain references - ``.stl``/``.obj`` are kept as-is and only ``.dae`` is converted to ``.obj``
+    (MuJoCo cannot load DAE). They live under ``assets/visual/`` and are **never decomposed**; their
+    color is applied as the geom's ``rgba``.
+  - **Collision** geometry drives physics (the ``collision`` class). Collision *primitives*
+    (box/sphere/cylinder/capsule) are used directly. Collision *meshes* are also used directly
+    (as a single whole-mesh collision geom) **unless** their link is named in a ``decompose_mesh``
+    input, in which case they are convex-decomposed with obj2mjcf (coacd) under
+    ``assets/decomposed/`` at the requested threshold. So decomposition is opt-in per link.
+  - When a link defines no ``<collision>``, one is synthesized from its ``<visual>`` so the visual
+    mesh is reused as the collision shape. This synthesis happens at the URDF level, so it stays
+    correct per link even when MuJoCo fuses fixed-jointed bodies together. A mesh shared by a visual
+    and a collision is converted once and reused for both (and, if that link requests decomposition,
+    the whole mesh renders while its decomposed pieces collide).
 
 - Publishes the new formatted robot description XML file that can be used for conversion.
 - Converts the new robot description URDF file.

--- a/mujoco_ros2_control/docs/tools.rst
+++ b/mujoco_ros2_control/docs/tools.rst
@@ -148,18 +148,42 @@ Rough outline of the automated conversion process
     correct per link even when MuJoCo fuses fixed-jointed bodies together. A mesh shared by a visual
     and a collision is converted once and reused for both (and, if that link requests decomposition,
     the whole mesh renders while its decomposed pieces collide).
-  - Both kinds of geom get explicit attributes written directly onto them, so visual/collision
-    separation does not depend on a user-supplied ``<default class="...">`` block:
+  - The converter uses MuJoCo ``<default>`` class blocks to centralise the physics attributes
+    so individual geoms stay compact. Three classes are auto-generated in the output MJCF
+    (unless the user already supplies them via ``mujoco_inputs``, in which case the user's
+    definition is kept as-is):
 
-    - **Visual** geoms: ``class="visual"`` with ``contype="0" conaffinity="0" group="2"
-      density="0"`` (render-only, never collide) and keep their ``rgba``.
-    - **Collision** geoms: ``class="collision"`` with ``group="3" contype="1" conaffinity="1"``.
-      Whole-mesh/primitive collisions are tinted ``material="bright_orange"`` so they are easy to
-      spot in the viewer (toggle group 3); the material is added to the ``<asset>`` automatically
-      when not already defined (an existing definition, e.g. from ``mujoco_inputs``, is left
-      untouched). **Decomposed** collision pieces are the exception: they get the same group 3 /
-      contype / conaffinity attributes but keep obj2mjcf's own per-decomposition materials/colors
-      instead of being recolored, so the individual convex hulls stay distinguishable.
+    .. code-block:: xml
+
+       <default>
+         <default class="visual">
+           <geom contype="0" conaffinity="0" group="2" density="0"/>
+         </default>
+         <default class="collision">
+           <geom group="3" type="mesh" contype="1" conaffinity="1" material="bright_orange"/>
+         </default>
+         <default class="decomposed_collision">
+           <geom group="3" type="mesh" contype="1" conaffinity="1"/>
+         </default>
+       </default>
+
+    - **Visual** geoms (``class="visual"``) are render-only and never collide.  They keep their
+      ``rgba`` for colour; the raw URDF-import attrs (``contype``, ``conaffinity``, ``group``,
+      ``density``) are stripped from the geom element and inherited from the class default.
+    - **Collision** geoms (``class="collision"``) are whole-mesh or primitive shapes that
+      collide (``contype="1" conaffinity="1"``).  The class sets ``type="mesh"`` as a fallback;
+      primitive collisions carry their own explicit ``type`` (e.g. ``box``) which overrides it.
+      They are tinted ``bright_orange`` (via the class default's ``material``) so they are easy
+      to inspect in the viewer (toggle group 3); the material is added to ``<asset>``
+      automatically.  If the user provides a ``bright_orange`` material in ``mujoco_inputs`` it
+      is left untouched.
+    - **Decomposed collision** geoms (``class="decomposed_collision"``) are the convex pieces
+      produced by obj2mjcf.  They reference a mesh by name only, so the class sets
+      ``type="mesh"`` (without it MuJoCo defaults to ``type="sphere"`` and fits a sphere around
+      each piece).  ``group="3"`` keeps them in the collision group and ``contype="1"
+      conaffinity="1"`` makes them collide with everything; no ``material`` override is applied
+      so obj2mjcf's own per-piece colours remain visible and each convex hull stays
+      distinguishable in the viewer.
   - Mirrored links (e.g. left/right feet) make MuJoCo emit a scaled sibling of a decomposed
     mesh (same source, ``scale="1 -1 1"``). The sibling is decomposed as well - scaled copies
     of the convex pieces are generated - so both sides of a mirrored link get the

--- a/mujoco_ros2_control/docs/tools.rst
+++ b/mujoco_ros2_control/docs/tools.rst
@@ -148,6 +148,18 @@ Rough outline of the automated conversion process
     correct per link even when MuJoCo fuses fixed-jointed bodies together. A mesh shared by a visual
     and a collision is converted once and reused for both (and, if that link requests decomposition,
     the whole mesh renders while its decomposed pieces collide).
+  - Both kinds of geom get explicit attributes written directly onto them, so visual/collision
+    separation does not depend on a user-supplied ``<default class="...">`` block:
+
+    - **Visual** geoms: ``class="visual"`` with ``contype="0" conaffinity="0" group="2"
+      density="0"`` (render-only, never collide) and keep their ``rgba``.
+    - **Collision** geoms: ``class="collision"`` with ``group="3" contype="1" conaffinity="1"``.
+      Whole-mesh/primitive collisions are tinted ``material="bright_orange"`` so they are easy to
+      spot in the viewer (toggle group 3); the material is added to the ``<asset>`` automatically
+      when not already defined (an existing definition, e.g. from ``mujoco_inputs``, is left
+      untouched). **Decomposed** collision pieces are the exception: they get the same group 3 /
+      contype / conaffinity attributes but keep obj2mjcf's own per-decomposition materials/colors
+      instead of being recolored, so the individual convex hulls stay distinguishable.
 
 - Publishes the new formatted robot description XML file that can be used for conversion.
 - Converts the new robot description URDF file.

--- a/mujoco_ros2_control/docs/tools.rst
+++ b/mujoco_ros2_control/docs/tools.rst
@@ -160,6 +160,10 @@ Rough outline of the automated conversion process
       untouched). **Decomposed** collision pieces are the exception: they get the same group 3 /
       contype / conaffinity attributes but keep obj2mjcf's own per-decomposition materials/colors
       instead of being recolored, so the individual convex hulls stay distinguishable.
+  - Mirrored links (e.g. left/right feet) make MuJoCo emit a scaled sibling of a decomposed
+    mesh (same source, ``scale="1 -1 1"``). The sibling is decomposed as well - scaled copies
+    of the convex pieces are generated - so both sides of a mirrored link get the
+    decomposition rather than only one.
 
 - Publishes the new formatted robot description XML file that can be used for conversion.
 - Converts the new robot description URDF file.

--- a/mujoco_ros2_control/docs/tools.rst
+++ b/mujoco_ros2_control/docs/tools.rst
@@ -128,11 +128,20 @@ Rough outline of the automated conversion process
      Duplicate mesh files will have an ``_N`` appended to them to avoid conflicts in the output ``assets`` folder.
      For instance, if running multiple types of UR robots in one sim, there will be multiple ``shoulder.dae`` files.
 
-- Reads absolute filepaths of all meshes and converts either ``.dae`` or ``.stl`` to ``.obj`` using trimesh.
+- Reads absolute filepaths of all meshes (from both ``<visual>`` and ``<collision>`` tags) and
+  converts either ``.dae`` or ``.stl`` to ``.obj`` using trimesh.
 
   - Puts all meshes into an ``assets/`` folder under ``mjcf_data/`` relative to current working dir.
   - Modifies filepaths again in URDF to point to the ``assets/`` folder.
   - Decomposes large meshes into multiple components to ensure convex hulls.
+
+- Handles visual and collision geometry independently:
+
+  - The ``<visual>`` geometry is used purely for rendering (the ``visual`` class).
+  - The ``<collision>`` geometry drives physics (the ``collision`` class). When a link defines no
+    ``<collision>``, a collision is synthesized from its ``<visual>`` so the visual mesh is reused
+    as the collision shape (the previous behaviour). This synthesis happens at the URDF level, so it
+    stays correct per link even when MuJoCo fuses fixed-jointed bodies together.
 
 - Publishes the new formatted robot description XML file that can be used for conversion.
 - Converts the new robot description URDF file.

--- a/mujoco_ros2_control/mujoco_ros2_control/__init__.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/__init__.py
@@ -43,6 +43,8 @@ from .urdf_to_mujoco_utils import (
     write_mujoco_scene,
     DECOMPOSED_PATH_NAME,
     COMPOSED_PATH_NAME,
+    VISUAL_PATH_NAME,
+    DEFAULT_DECOMPOSE_THRESHOLD,
 )
 
 __all__ = [
@@ -76,4 +78,6 @@ __all__ = [
     "write_mujoco_scene",
     DECOMPOSED_PATH_NAME,
     COMPOSED_PATH_NAME,
+    VISUAL_PATH_NAME,
+    DEFAULT_DECOMPOSE_THRESHOLD,
 ]

--- a/mujoco_ros2_control/mujoco_ros2_control/__init__.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/__init__.py
@@ -24,6 +24,7 @@ from .urdf_to_mujoco_utils import (
     update_obj_assets,
     update_non_obj_assets,
     add_mujoco_inputs,
+    ensure_default_geom_classes,
     get_processed_mujoco_inputs,
     parse_inputs_xml,
     parse_scene_xml,
@@ -46,6 +47,12 @@ from .urdf_to_mujoco_utils import (
     VISUAL_PATH_NAME,
     DEFAULT_DECOMPOSE_THRESHOLD,
     COLLISION_MATERIAL_NAME,
+    VISUAL_CLASS_NAME,
+    COLLISION_CLASS_NAME,
+    DECOMPOSED_COLLISION_CLASS_NAME,
+    VISUAL_CLASS_GEOM_ATTRS,
+    COLLISION_CLASS_GEOM_ATTRS,
+    DECOMPOSED_COLLISION_CLASS_GEOM_ATTRS,
 )
 
 __all__ = [
@@ -60,6 +67,7 @@ __all__ = [
     "update_obj_assets",
     "update_non_obj_assets",
     "add_mujoco_inputs",
+    "ensure_default_geom_classes",
     "get_processed_mujoco_inputs",
     "parse_inputs_xml",
     "parse_scene_xml",
@@ -82,4 +90,10 @@ __all__ = [
     VISUAL_PATH_NAME,
     DEFAULT_DECOMPOSE_THRESHOLD,
     COLLISION_MATERIAL_NAME,
+    VISUAL_CLASS_NAME,
+    COLLISION_CLASS_NAME,
+    DECOMPOSED_COLLISION_CLASS_NAME,
+    "VISUAL_CLASS_GEOM_ATTRS",
+    "COLLISION_CLASS_GEOM_ATTRS",
+    "DECOMPOSED_COLLISION_CLASS_GEOM_ATTRS",
 ]

--- a/mujoco_ros2_control/mujoco_ros2_control/__init__.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/__init__.py
@@ -45,6 +45,7 @@ from .urdf_to_mujoco_utils import (
     COMPOSED_PATH_NAME,
     VISUAL_PATH_NAME,
     DEFAULT_DECOMPOSE_THRESHOLD,
+    COLLISION_MATERIAL_NAME,
 )
 
 __all__ = [
@@ -80,4 +81,5 @@ __all__ = [
     COMPOSED_PATH_NAME,
     VISUAL_PATH_NAME,
     DEFAULT_DECOMPOSE_THRESHOLD,
+    COLLISION_MATERIAL_NAME,
 ]

--- a/mujoco_ros2_control/mujoco_ros2_control/__init__.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/__init__.py
@@ -15,6 +15,7 @@
 from .urdf_to_mujoco_utils import (
     add_mujoco_info,
     remove_tag,
+    add_missing_collisions,
     extract_mesh_info,
     replace_package_names,
     get_images_from_dae,
@@ -47,6 +48,7 @@ from .urdf_to_mujoco_utils import (
 __all__ = [
     "add_mujoco_info",
     "remove_tag",
+    "add_missing_collisions",
     "extract_mesh_info",
     "replace_package_names",
     "get_images_from_dae",

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -538,18 +538,27 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
 
 def update_non_obj_assets(dom, output_filepath):
     """
-    We want to take the group 1 objects that get created, and turn them into the equivalent
-    but both in group 2 and in group 3. That means taking something like this
+    Classifies the geoms that MuJoCo imported from the URDF into the "visual" and
+    "collision" default classes. Because the source URDF now always carries both a
+    <visual> and a <collision> per renderable link (the latter synthesized from the
+    visual when missing, see add_missing_collisions), MuJoCo emits a separate geom for
+    each, and we simply tag them rather than duplicating a single geom.
+
+    MuJoCo imports a URDF <visual> as a geom that still carries its raw import
+    attributes, e.g.
         <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="finger_v6"/>
-    and turning it into this
-        <geom mesh="finger_v6" class="visual" pos="0 0 0" quat="0.707107 0.707107 0 0"/>
-        <geom mesh="finger_v6" class="collision" pos="0 0 0" quat="0.707107 0.707107 0 0"/>
+    and a <collision> as a plain collidable geom with no contype. So:
 
-    To do this, we need to add in class visual, and class collision to them, keep the rgba on the visual one, and
-    get rid of the other components (type, contype, conaffinity, group, density)
+    - A geom WITH a contype attribute is a visual: it becomes
+        <geom mesh="finger_v6" class="visual" rgba="0.2 0.2 0.2 1" .../>
+      keeping its rgba but dropping the raw import attributes (contype, conaffinity,
+      group, density).
+    - A geom WITHOUT a contype attribute is a collision: it becomes
+        <geom mesh="finger_v6" class="collision" .../>
+      and its rgba (if any) is dropped since collisions are not rendered.
 
-    We can tell that we need to modify it because it will have a contype attribute attached to it (not the best way
-    but I guess it works for now)
+    Geoms that already carry a class attribute (e.g. those expanded by
+    update_obj_assets) are left untouched.
     """
 
     # Find the <worldbody> element
@@ -559,39 +568,27 @@ def update_non_obj_assets(dom, output_filepath):
     # get all of the geom elements in the worldbody element
     worldbody_geoms = worldbody_element.getElementsByTagName("geom")
 
-    # elements to remove
+    # raw import attributes that should not survive on a classified visual geom
     remove_attributes = ["contype", "conaffinity", "group", "density"]
 
     for geom in worldbody_geoms:
-        if not geom.hasAttribute("contype"):
-            pass
-        else:
-            collision_geom = geom.cloneNode(False)
+        # already classified upstream (e.g. obj-decomposed meshes); leave as is
+        if geom.hasAttribute("class"):
+            continue
 
-            # if there is no type associated, make the type sphere explicitly
-            if not collision_geom.hasAttribute("type"):
-                collision_geom.setAttribute("type", "sphere")
-
-            # set to collision class
-            collision_geom.setAttribute("class", "collision")
+        if geom.hasAttribute("contype"):
+            # visual geom: keep rgba, strip the raw import attributes
+            geom.setAttribute("class", "visual")
             for attribute in remove_attributes:
-                if collision_geom.hasAttribute(attribute):
-                    collision_geom.removeAttribute(attribute)
-
-            # most of the components are the same between collision and visual, so just copy it
-            visual_geom = collision_geom.cloneNode(False)
-            visual_geom.setAttribute("class", "visual")
-
-            # remove rgba from collision geom bc it isn't necessary
+                if geom.hasAttribute(attribute):
+                    geom.removeAttribute(attribute)
+        else:
+            # collision geom: ensure a type, drop rgba (not rendered)
+            if not geom.hasAttribute("type"):
+                geom.setAttribute("type", "sphere")
+            geom.setAttribute("class", "collision")
             if geom.hasAttribute("rgba"):
-                collision_geom.removeAttribute("rgba")
-
-            # get the parent of the geom node, and remove the old element
-            parent = geom.parentNode
-            parent.removeChild(geom)
-            # add the new collision and visual specific elements
-            parent.appendChild(collision_geom)
-            parent.appendChild(visual_geom)
+                geom.removeAttribute("rgba")
 
     return dom
 

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -35,6 +35,13 @@ from xml.dom import minidom
 # Hardcoded relative paths for MuJoCo asset outputs
 DECOMPOSED_PATH_NAME = "decomposed"
 COMPOSED_PATH_NAME = "full"
+# Plain visual meshes (rendering only) live here; they are referenced as-is and never
+# decomposed. Collision meshes go through DECOMPOSED_PATH_NAME (obj2mjcf --decompose).
+VISUAL_PATH_NAME = "visual"
+
+# coacd threshold used when a collision mesh is not named in a decompose_mesh input.
+# Matches obj2mjcf's coacd default.
+DEFAULT_DECOMPOSE_THRESHOLD = "0.05"
 
 
 def add_mujoco_info(raw_xml, output_filepath, publish_topic, fuse=True):

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -475,6 +475,11 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
     mesh is shared by a visual the whole ``<mesh>`` asset is kept so that visual still
     resolves. Visual-only meshes live in VISUAL_PATH_NAME, are not decomposed, and are
     left as plain single references.
+
+    Each decomposed collision piece receives the collision-separation attributes (group 3,
+    contype/conaffinity 1) but, unlike plain collision geoms, is NOT tinted with
+    COLLISION_MATERIAL_NAME - the pieces keep obj2mjcf's own materials/colors so the
+    individual convex hulls remain visually distinguishable.
     """
     # Find the <asset> element
     asset = dom.getElementsByTagName("asset")
@@ -592,8 +597,14 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                 if quat:
                     sub_geom_local.setAttribute("quat", quat)
                 sub_geom_local.setAttribute("class", "collision")
-                if sub_geom_local.hasAttribute("rgba"):
-                    sub_geom_local.removeAttribute("rgba")
+                # Give decomposed pieces the same collision-separation attributes as plain
+                # collisions (group 3, contype/conaffinity 1), but NOT the bright_orange
+                # material: decomposed meshes keep obj2mjcf's own materials/rgba so the
+                # individual convex pieces stay distinguishable.
+                for attribute, value in COLLISION_GEOM_ATTRS.items():
+                    if attribute == "material":
+                        continue
+                    sub_geom_local.setAttribute(attribute, value)
                 parent.appendChild(sub_geom_local)
 
     return dom
@@ -634,20 +645,17 @@ def update_non_obj_assets(dom, output_filepath, mesh_info_dict=None):
     # get all of the geom elements in the worldbody element
     worldbody_geoms = worldbody_element.getElementsByTagName("geom")
 
-    # raw import attributes that should not survive on a classified visual geom
-    remove_attributes = ["contype", "conaffinity", "group", "density"]
-
+    used_collision_material = False
     for geom in worldbody_geoms:
         # already classified upstream (e.g. obj-decomposed meshes); leave as is
         if geom.hasAttribute("class"):
             continue
 
         if geom.hasAttribute("contype"):
-            # visual geom: keep rgba, strip the raw import attributes
+            # visual geom: keep rgba, set explicit render attributes (contype=0 -> no collide)
             geom.setAttribute("class", "visual")
-            for attribute in remove_attributes:
-                if geom.hasAttribute(attribute):
-                    geom.removeAttribute(attribute)
+            for attribute, value in VISUAL_GEOM_ATTRS.items():
+                geom.setAttribute(attribute, value)
             # apply the URDF color so plain visual meshes (no obj2mjcf material) render
             if mesh_info_dict:
                 mesh_name = geom.getAttribute("mesh")
@@ -655,13 +663,48 @@ def update_non_obj_assets(dom, output_filepath, mesh_info_dict=None):
                     rgba = mesh_info_dict[mesh_name]["color"]
                     geom.setAttribute("rgba", " ".join(str(v) for v in rgba))
         else:
-            # collision geom: ensure a type, drop rgba (not rendered)
+            # collision geom: ensure a type, drop rgba (not rendered), set explicit collision
+            # attributes and tint it so the collision shape is visible in the viewer
             if not geom.hasAttribute("type"):
                 geom.setAttribute("type", "sphere")
             geom.setAttribute("class", "collision")
             if geom.hasAttribute("rgba"):
                 geom.removeAttribute("rgba")
+            for attribute, value in COLLISION_GEOM_ATTRS.items():
+                geom.setAttribute(attribute, value)
+            used_collision_material = True
 
+    # Collision geoms reference COLLISION_MATERIAL_NAME, so it must exist or MuJoCo fails to
+    # load. Add it only when absent to avoid a repeated-name clash with a user-defined one.
+    if used_collision_material:
+        _ensure_collision_material(dom)
+
+    return dom
+
+
+def _ensure_collision_material(dom):
+    """
+    Ensures an ``<asset>`` ``<material>`` named COLLISION_MATERIAL_NAME exists in ``dom``.
+
+    Collision geoms are tinted with this material so the collision geometry can be inspected
+    in the MuJoCo viewer. If the material is already defined (e.g. supplied via mujoco_inputs)
+    it is left untouched; otherwise a default orange material is created. Creates the
+    ``<asset>`` element if the document has none.
+    """
+    assets = dom.getElementsByTagName("asset")
+    if assets:
+        asset = assets[0]
+        for material in asset.getElementsByTagName("material"):
+            if material.getAttribute("name") == COLLISION_MATERIAL_NAME:
+                return dom
+    else:
+        asset = dom.createElement("asset")
+        dom.documentElement.appendChild(asset)
+
+    material = dom.createElement("material")
+    material.setAttribute("name", COLLISION_MATERIAL_NAME)
+    material.setAttribute("rgba", "1 0.5 0 1")
+    asset.appendChild(material)
     return dom
 
 

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -480,6 +480,12 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
     contype/conaffinity 1) but, unlike plain collision geoms, is NOT tinted with
     COLLISION_MATERIAL_NAME - the pieces keep obj2mjcf's own materials/colors so the
     individual convex hulls remain visually distinguishable.
+
+    A mirrored link (e.g. left/right feet) makes MuJoCo emit a scaled sibling of the
+    decomposed mesh (same source file, a scale like "1 -1 1", auto-named e.g. "leg_7_link1").
+    That sibling is handled too: scaled copies of the convex pieces are created (carrying the
+    sibling's scale) and its collision geom is expanded into them, so both sides of a mirrored
+    link get the decomposition rather than only one.
     """
     # Find the <asset> element
     asset = dom.getElementsByTagName("asset")
@@ -526,10 +532,16 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
         # This should definitely be there, otherwise something is horribly wrong
         scale = mesh_info_dict[mesh_name]["scale"]
         used_as_visual = mesh_info_dict[mesh_name].get("used_as_visual", False)
+        # the whole-mesh file shared by the visual and any scaled mirror siblings
+        base_file = mesh.getAttribute("file")
 
         mesh_path = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{mesh_name}.xml"
         if not os.path.exists(mesh_path):
             continue
+
+        # rewritten file path of each decomposed convex piece, keyed by its effective name -
+        # used to build scaled copies for mirror siblings (see below)
+        decomposed_piece_files = {}
 
         sub_dom = minidom.parse(mesh_path)
         sub_asset_element = sub_dom.getElementsByTagName("asset")[0]
@@ -547,11 +559,13 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
             if eff in existing_mesh_names:
                 continue
             sub_mesh_file = sub_mesh.getAttribute("file")
-            sub_mesh.setAttribute("file", f"{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{sub_mesh_file}")
+            rewritten_file = f"{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{sub_mesh_file}"
+            sub_mesh.setAttribute("file", rewritten_file)
             if scale:
                 sub_mesh.setAttribute("scale", scale)
             asset_element.appendChild(sub_mesh)
             existing_mesh_names.add(eff)
+            decomposed_piece_files[eff] = rewritten_file
 
         # bring in any materials/textures (collision usually has none, kept for safety),
         # also de-duplicating by name
@@ -574,14 +588,10 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
         body_element = sub_dom.getElementsByTagName("body")[0]
         sub_geoms = body_element.getElementsByTagName("geom")
 
-        # Replace each collision geom (no contype) referencing this mesh with the decomposed
-        # convex pieces. Visual geoms (contype) are left referencing the whole mesh.
-        for geom_element in list(worldbody_geoms):
-            if geom_element.getAttribute("mesh") != mesh_name:
-                continue
-            if geom_element.hasAttribute("contype"):
-                continue
-
+        def expand_collision_geom(geom_element, mesh_suffix=""):
+            # Replace a whole-mesh collision geom with the decomposed convex pieces. ``mesh_suffix``
+            # is appended to each piece's mesh name so a scaled mirror sibling can reference its own
+            # scaled piece meshes (see the sibling handling below).
             pos = geom_element.getAttribute("pos")
             quat = geom_element.getAttribute("quat")
             parent = geom_element.parentNode
@@ -592,6 +602,8 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                 if sub_geom.getAttribute("class") == "visual" or sub_geom.getAttribute("mesh") == mesh_name:
                     continue
                 sub_geom_local = sub_geom.cloneNode(False)
+                if mesh_suffix:
+                    sub_geom_local.setAttribute("mesh", sub_geom.getAttribute("mesh") + mesh_suffix)
                 if pos:
                     sub_geom_local.setAttribute("pos", pos)
                 if quat:
@@ -606,6 +618,54 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                         continue
                     sub_geom_local.setAttribute(attribute, value)
                 parent.appendChild(sub_geom_local)
+
+        # Expand the (unscaled) collision geoms referencing this mesh directly. Visual geoms
+        # (contype) are left referencing the whole mesh.
+        for geom_element in list(worldbody_geoms):
+            if geom_element.getAttribute("mesh") != mesh_name:
+                continue
+            if geom_element.hasAttribute("contype"):
+                continue
+            expand_collision_geom(geom_element)
+
+        # A mirrored link (e.g. left/right feet) makes MuJoCo emit a scaled sibling mesh -
+        # same source file, scale like "1 -1 1", auto-named e.g. "leg_7_link1". That sibling is
+        # not in decomposed_dirs, so without this its collision would stay a single whole mesh
+        # while the other side is decomposed. Decompose it too, using scaled copies of the
+        # convex pieces that carry the sibling's scale.
+        siblings = [s for s in list(meshes) if s is not mesh and s.getAttribute("file") == base_file]
+        for sibling in siblings:
+            sibling_name = sibling.getAttribute("name")
+            if not sibling_name:
+                continue
+            sibling_scale = sibling.getAttribute("scale")
+            suffix = f"__{sibling_name}"
+            # one scaled mesh asset per decomposed piece, referencing the same piece .obj
+            for eff, piece_file in decomposed_piece_files.items():
+                scaled_name = eff + suffix
+                if scaled_name in existing_mesh_names:
+                    continue
+                scaled_mesh = dom.createElement("mesh")
+                scaled_mesh.setAttribute("name", scaled_name)
+                scaled_mesh.setAttribute("file", piece_file)
+                if sibling_scale:
+                    scaled_mesh.setAttribute("scale", sibling_scale)
+                asset_element.appendChild(scaled_mesh)
+                existing_mesh_names.add(scaled_name)
+            # expand the sibling's collision geoms into the scaled pieces
+            for geom_element in list(worldbody_geoms):
+                if geom_element.getAttribute("mesh") != sibling_name:
+                    continue
+                if geom_element.hasAttribute("contype"):
+                    continue
+                expand_collision_geom(geom_element, suffix)
+            # drop the whole sibling <mesh> asset unless a visual geom still references it
+            sibling_used_as_visual = any(
+                g.getAttribute("mesh") == sibling_name and g.hasAttribute("contype") for g in worldbody_geoms
+            )
+            if not sibling_used_as_visual:
+                asset_element.removeChild(sibling)
+                existing_mesh_names.discard(sibling_name)
 
     return dom
 

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -43,6 +43,20 @@ VISUAL_PATH_NAME = "visual"
 # Matches obj2mjcf's coacd default.
 DEFAULT_DECOMPOSE_THRESHOLD = "0.05"
 
+# Explicit attributes written onto classified geoms so visual/collision separation does not
+# depend on the user supplying a <default class="..."> block via mujoco_inputs.
+# Visuals are render-only (contype=0 -> never collide) and live in group 2; collisions do the
+# colliding (contype/conaffinity=1), live in group 3, and are tinted COLLISION_MATERIAL_NAME
+# so they can be inspected in the viewer.
+COLLISION_MATERIAL_NAME = "bright_orange"
+VISUAL_GEOM_ATTRS = {"contype": "0", "conaffinity": "0", "group": "2", "density": "0"}
+COLLISION_GEOM_ATTRS = {
+    "group": "3",
+    "contype": "1",
+    "conaffinity": "1",
+    "material": COLLISION_MATERIAL_NAME,
+}
+
 
 def add_mujoco_info(raw_xml, output_filepath, publish_topic, fuse=True):
     dom = minidom.parseString(raw_xml)

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -768,6 +768,70 @@ def _ensure_collision_material(dom):
     return dom
 
 
+def ensure_default_geom_classes(dom):
+    """Ensures visual, collision, and decomposed_collision default geom class blocks exist.
+
+    For each of the three classes not already present in the DOM (e.g. user-supplied via
+    ``mujoco_inputs``), an auto-generated ``<default class="..."><geom .../></default>`` block
+    is appended to the top-level ``<default>`` element.  Call this **after**
+    ``add_mujoco_inputs()`` so user-defined classes are already merged before the gap-fill runs.
+
+    When the ``collision`` class is auto-generated (it references ``material="bright_orange"``),
+    the material is also ensured in ``<asset>`` via ``_ensure_collision_material``.
+
+    :param dom: parsed MJCF DOM (xml.dom.minidom.Document)
+    :return: the modified DOM
+    """
+    root = dom.documentElement
+
+    # Collect all top-level <default> elements. Normally there is at most one (MJCF allows
+    # only one), but merge any extras defensively before adding new class blocks.
+    root_level_defaults = [
+        child for child in root.childNodes if child.nodeType == child.ELEMENT_NODE and child.tagName == "default"
+    ]
+
+    if not root_level_defaults:
+        root_default = dom.createElement("default")
+        worldbody_elements = root.getElementsByTagName("worldbody")
+        if worldbody_elements:
+            root.insertBefore(root_default, worldbody_elements[0])
+        else:
+            root.appendChild(root_default)
+    else:
+        root_default = root_level_defaults[0]
+        # Merge any extra <default> siblings into the first one.
+        for extra in root_level_defaults[1:]:
+            _merge_default_element(dom, extra)
+            root.removeChild(extra)
+
+    # Collect class names already defined as direct children of the (now single) root default.
+    existing_classes = set()
+    for child in root_default.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and child.tagName == "default":
+            if child.hasAttribute("class"):
+                existing_classes.add(child.getAttribute("class"))
+
+    classes_to_add = {
+        VISUAL_CLASS_NAME: VISUAL_CLASS_GEOM_ATTRS,
+        COLLISION_CLASS_NAME: COLLISION_CLASS_GEOM_ATTRS,
+        DECOMPOSED_COLLISION_CLASS_NAME: DECOMPOSED_COLLISION_CLASS_GEOM_ATTRS,
+    }
+
+    for class_name, attrs in classes_to_add.items():
+        if class_name in existing_classes:
+            continue
+        class_default = dom.createElement("default")
+        class_default.setAttribute("class", class_name)
+        geom_el = dom.createElement("geom")
+        for attr, val in attrs.items():
+            geom_el.setAttribute(attr, val)
+        class_default.appendChild(geom_el)
+        root_default.appendChild(class_default)
+        if class_name == COLLISION_CLASS_NAME:
+            # The collision class references bright_orange; ensure the material exists.
+            _ensure_collision_material(dom)
+
+    return dom
 def add_mujoco_inputs(dom, raw_inputs, scene_inputs):
     """
     Copies all elements under the "raw_inputs" and "scene_inputs" XML tags directly in the provided dom.

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -176,11 +176,20 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
                     return tuple(ref.color.rgba)
         return (1.0, 1.0, 1.0, 1.0)
 
-    # Track which source mesh files have already been turned into an asset entry so a
-    # collision that reuses a visual's mesh (the fallback case) shares the same asset
-    # instead of producing a duplicate. Visuals are processed first so their material
-    # color wins; collisions then only add entries for genuinely distinct meshes.
-    processed_uris = set()
+    # Map each source mesh file to the entry (stem) it produced, so a collision that
+    # reuses a visual's mesh (the fallback case) shares the single converted source
+    # instead of duplicating it. Visuals are processed first so their material color
+    # wins; a shared entry is then flagged for both visual and collision use, and the
+    # downstream pipeline emits a whole visual mesh and decomposed collision pieces from
+    # that one source.
+    uri_to_stem = {}
+
+    def mark_usage(stem_key, is_collision):
+        entry = mesh_info_dict[stem_key]
+        if is_collision:
+            entry["used_as_collision"] = True
+        else:
+            entry["used_as_visual"] = True
 
     def process_geometry(element, is_collision):
         nonlocal raw_xml
@@ -190,8 +199,10 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
 
         uri = geom.filename  # full URI
 
-        # A collision reusing a visual's mesh file shares that already-built asset.
-        if is_collision and uri in processed_uris:
+        # A collision reusing a visual's mesh file just records the extra usage on the
+        # shared entry (one converted source, reused for both classes).
+        if is_collision and uri in uri_to_stem:
+            mark_usage(uri_to_stem[uri], is_collision)
             return
 
         original_stem = pathlib.Path(uri).stem  # NEW: remember original for disambiguation
@@ -202,15 +213,21 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
             stem = f"{original_stem}__{counter}"
         stem_to_original_uri[stem] = uri
 
+        # A collision mesh is only decomposed when its link was named in a decompose_mesh
+        # input; otherwise (and for all visual meshes) it is used directly as a plain mesh.
+        decompose_this = is_collision and (original_stem in decompose_dict)
+
         # Select the mesh file: use a pre-generated OBJ if available and valid; otherwise use the original
         is_pre_generated = False
         new_uri = uri  # default fallback
 
         if asset_dir:
-            if original_stem in decompose_dict:
-                # Decomposed mesh: check if a pre-generated OBJ exists and threshold matches
+            if decompose_this:
+                # Decomposed collision mesh: reuse a pre-generated OBJ only if its coacd
+                # threshold matches the requested one.
                 mesh_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/{stem}/{stem}/{stem}.obj"
                 settings_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/metadata.json"
+                required_threshold = float(decompose_dict[original_stem])
 
                 if os.path.exists(mesh_file) and os.path.exists(settings_file):
                     try:
@@ -221,25 +238,26 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
                         print(f"Warning: could not read thresholds for {stem}: {e}")
                         used_threshold = None
                     # Use existing decomposed object only if it has the same threshold, otherwise regenerate it.
-                    if used_threshold is not None and math.isclose(
-                        used_threshold, float(decompose_dict[original_stem]), rel_tol=1e-9
-                    ):
+                    if used_threshold is not None and math.isclose(used_threshold, required_threshold, rel_tol=1e-9):
                         new_uri = mesh_file
                         is_pre_generated = True
                         raw_xml = raw_xml.replace(geom.filename, new_uri)
                     else:
                         print(
                             f"Existing decomposed obj for {stem} has different threshold {used_threshold} "
-                            f"than required {decompose_dict[original_stem]}. Regenerating..."
+                            f"than required {required_threshold}. Regenerating..."
                         )
             else:
-                # Composed mesh: check if a pre-generated OBJ exists
-                mesh_file = f"{asset_dir}/{COMPOSED_PATH_NAME}/{stem}/{stem}.obj"
-
-                if os.path.exists(mesh_file):
-                    new_uri = mesh_file
-                    is_pre_generated = True
-                    raw_xml = raw_xml.replace(geom.filename, new_uri)
+                # Plain mesh (visual, or a collision used directly): reuse a pre-generated
+                # asset (.obj or copied .stl) from the appropriate plain dir.
+                plain_dir = VISUAL_PATH_NAME if not is_collision else COMPOSED_PATH_NAME
+                for ext in (".obj", ".stl"):
+                    candidate = f"{asset_dir}/{plain_dir}/{stem}{ext}"
+                    if os.path.exists(candidate):
+                        new_uri = candidate
+                        is_pre_generated = True
+                        raw_xml = raw_xml.replace(geom.filename, new_uri)
+                        break
 
         scale = " ".join(f"{v}" for v in geom.scale) if geom.scale else "1.0 1.0 1.0"
         # Collision elements carry no <material>, so they default to white.
@@ -252,9 +270,6 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
             "color": rgba,
         }
 
-        # this source mesh file has now been accounted for
-        processed_uris.add(uri)
-
         # check to see if the values we are trying to add already exist
         existing_identifier = None
         for key, value in mesh_info_dict.items():
@@ -262,28 +277,38 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
                 existing_identifier = key
                 break
 
-        # if the values we want to add are not in the dictionary yet, add them
-        if existing_identifier is None:
-            # get the name of the new file so that we can reference it later, but grab correct
-            # pre generated asset if it exists
-            path_obj = pathlib.Path(new_uri)
-            if is_pre_generated:
-                new_filepath = str(path_obj.parent.parent / stem / (stem + path_obj.suffix))
-            else:
-                new_filepath = str(path_obj.parent / (stem + path_obj.suffix))
+        # an identical mesh already exists: reuse it and just record this usage
+        if existing_identifier is not None:
+            uri_to_stem.setdefault(uri, existing_identifier)
+            mark_usage(existing_identifier, is_collision)
+            return
 
-            # add the unique name to the dictionary
-            mesh_info_dict[stem] = {
-                "is_pre_generated": is_pre_generated,
-                "filename": new_uri,
-                "scale": scale,
-                "color": rgba,
-                "new_filepath": new_filepath,
-            }
+        # get the name of the new file so that we can reference it later, but grab correct
+        # pre generated asset if it exists
+        path_obj = pathlib.Path(new_uri)
+        if is_pre_generated and decompose_this:
+            # pre-generated decomposed layout: .../<stem>/<stem>/<stem>.obj
+            new_filepath = str(path_obj.parent.parent / stem / (stem + path_obj.suffix))
+        else:
+            # plain asset (visual or direct collision), or a freshly-sourced mesh
+            new_filepath = str(path_obj.parent / (stem + path_obj.suffix))
 
-            # if we changed the identifier, make sure we update it in the underlying file
-            if stem != pathlib.Path(new_uri).stem:
-                raw_xml = raw_xml.replace(new_uri, new_filepath)
+        # add the unique name to the dictionary
+        mesh_info_dict[stem] = {
+            "is_pre_generated": is_pre_generated,
+            "filename": new_uri,
+            "scale": scale,
+            "color": rgba,
+            "new_filepath": new_filepath,
+            # which classes reference this source; a shared source carries both
+            "used_as_visual": not is_collision,
+            "used_as_collision": is_collision,
+        }
+        uri_to_stem.setdefault(uri, stem)
+
+        # if we changed the identifier, make sure we update it in the underlying file
+        if stem != pathlib.Path(new_uri).stem:
+            raw_xml = raw_xml.replace(new_uri, new_filepath)
 
     # First pass: visual meshes (their material color wins). Second pass: collision
     # meshes, which only add genuinely distinct meshes thanks to processed_uris.
@@ -426,6 +451,17 @@ def set_up_axis_to_z_up(dae_file_path):
 
 
 def update_obj_assets(dom, output_filepath, mesh_info_dict):
+    """
+    Expands each decomposed collision mesh into its obj2mjcf convex pieces.
+
+    Only meshes that were decomposed (collision meshes, found under DECOMPOSED_PATH_NAME)
+    are processed. For each such mesh, the collision geoms referencing it (the no-contype
+    geoms) are replaced with the decomposed sub-geoms in the ``collision`` class. Visual
+    geoms (contype-bearing) are left untouched referencing the whole mesh, and when the
+    mesh is shared by a visual the whole ``<mesh>`` asset is kept so that visual still
+    resolves. Visual-only meshes live in VISUAL_PATH_NAME, are not decomposed, and are
+    left as plain single references.
+    """
     # Find the <asset> element
     asset = dom.getElementsByTagName("asset")
 
@@ -444,112 +480,121 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
     asset_element = asset[0]
     meshes = asset_element.getElementsByTagName("mesh")
 
-    # obj
     full_decomposed_path = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}"
-    full_composed_path = f"{output_filepath}assets/{COMPOSED_PATH_NAME}"
     decomposed_dirs = [
         name for name in os.listdir(full_decomposed_path) if os.path.isdir(os.path.join(full_decomposed_path, name))
     ]
-    composed_dirs = [
-        name for name in os.listdir(full_composed_path) if os.path.isdir(os.path.join(full_composed_path, name))
-    ]
+
+    # obj2mjcf emits its meshes WITHOUT a name attribute, so MuJoCo derives the name from
+    # the file stem. We dedupe on that "effective name" (explicit name, else file stem):
+    # this skips obj2mjcf's whole/visual mesh when it collides with the kept whole mesh,
+    # while still letting every uniquely-named collision piece through.
+    def effective_mesh_name(m):
+        name = m.getAttribute("name")
+        return name if name else pathlib.Path(m.getAttribute("file")).stem
+
+    existing_mesh_names = {effective_mesh_name(m) for m in asset_element.getElementsByTagName("mesh")}
+    existing_material_names = {m.getAttribute("name") for m in asset_element.getElementsByTagName("material")}
+    existing_texture_names = {t.getAttribute("name") for t in asset_element.getElementsByTagName("texture")}
 
     for mesh in meshes:
         mesh_name = mesh.getAttribute("name")
 
+        # only collision meshes are decomposed; visual-only plain references are skipped
+        if mesh_name not in decomposed_dirs:
+            continue
+
         # This should definitely be there, otherwise something is horribly wrong
         scale = mesh_info_dict[mesh_name]["scale"]
+        used_as_visual = mesh_info_dict[mesh_name].get("used_as_visual", False)
 
-        mesh_path = ""
-        if mesh_name in decomposed_dirs:
-            composed_type = DECOMPOSED_PATH_NAME
-            mesh_path = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{mesh_name}.xml"
-        elif mesh_name in composed_dirs:
-            composed_type = COMPOSED_PATH_NAME
-            mesh_path = f"{output_filepath}assets/{COMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}.xml"
+        mesh_path = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{mesh_name}.xml"
+        if not os.path.exists(mesh_path):
+            continue
 
-        if mesh_path:
-            sub_dom = minidom.parse(mesh_path)
-            # Find the <asset> element
-            sub_asset = sub_dom.getElementsByTagName("asset")
-            sub_asset_element = sub_asset[0]
+        sub_dom = minidom.parse(mesh_path)
+        sub_asset_element = sub_dom.getElementsByTagName("asset")[0]
 
-            # remove the old mesh element that is not separated
+        # If a visual also uses this mesh (shared / fallback), keep the whole <mesh> asset
+        # so the visual geom still resolves; otherwise the undecomposed mesh is unused.
+        if not used_as_visual:
             asset_element.removeChild(mesh)
+            existing_mesh_names.discard(mesh_name)
 
-            # bring in the new elements
-            sub_meshes = sub_asset_element.getElementsByTagName("mesh")
-            for sub_mesh in sub_meshes:
-                sub_mesh_file = sub_mesh.getAttribute("file")
-                if composed_type == DECOMPOSED_PATH_NAME:
-                    sub_mesh.setAttribute("file", f"{composed_type}/{mesh_name}/{mesh_name}/{sub_mesh_file}")
-                else:
-                    sub_mesh.setAttribute("file", f"{composed_type}/{mesh_name}/{sub_mesh_file}")
-                if scale:
-                    sub_mesh.setAttribute("scale", scale)
-                asset_element.appendChild(sub_mesh)
+        # bring in the decomposed sub-mesh assets, skipping any effective name we already
+        # have (notably obj2mjcf's nameless visual mesh, which maps to mesh_name)
+        for sub_mesh in sub_asset_element.getElementsByTagName("mesh"):
+            eff = effective_mesh_name(sub_mesh)
+            if eff in existing_mesh_names:
+                continue
+            sub_mesh_file = sub_mesh.getAttribute("file")
+            sub_mesh.setAttribute("file", f"{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{sub_mesh_file}")
+            if scale:
+                sub_mesh.setAttribute("scale", scale)
+            asset_element.appendChild(sub_mesh)
+            existing_mesh_names.add(eff)
 
-            # bring in the materials
-            sub_materials = sub_asset_element.getElementsByTagName("material")
-            for sub_material in sub_materials:
-                asset_element.appendChild(sub_material)
+        # bring in any materials/textures (collision usually has none, kept for safety),
+        # also de-duplicating by name
+        for sub_material in sub_asset_element.getElementsByTagName("material"):
+            name = sub_material.getAttribute("name")
+            if name in existing_material_names:
+                continue
+            asset_element.appendChild(sub_material)
+            existing_material_names.add(name)
+        for sub_texture in sub_asset_element.getElementsByTagName("texture"):
+            if sub_texture.hasAttribute("file"):
+                name = sub_texture.getAttribute("name")
+                if name in existing_texture_names:
+                    continue
+                sub_texture_file = sub_texture.getAttribute("file")
+                sub_texture.setAttribute("file", f"{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/{sub_texture_file}")
+                asset_element.appendChild(sub_texture)
+                existing_texture_names.add(name)
 
-            # bring in the textures, and modify filepath to properly reference filepaths
-            sub_textures = sub_asset_element.getElementsByTagName("texture")
-            for sub_texture in sub_textures:
-                if sub_texture.hasAttribute("file"):
-                    sub_texture_file = sub_texture.getAttribute("file")
-                    if composed_type == DECOMPOSED_PATH_NAME:
-                        sub_texture.setAttribute("file", f"{composed_type}/{mesh_name}/{mesh_name}/{sub_texture_file}")
-                    else:
-                        sub_texture.setAttribute("file", f"{composed_type}/{mesh_name}/{sub_texture_file}")
-                    asset_element.appendChild(sub_texture)
+        body_element = sub_dom.getElementsByTagName("body")[0]
+        sub_geoms = body_element.getElementsByTagName("geom")
 
-            sub_body = sub_dom.getElementsByTagName("body")
-            sub_body = sub_body[0]
+        # Replace each collision geom (no contype) referencing this mesh with the decomposed
+        # convex pieces. Visual geoms (contype) are left referencing the whole mesh.
+        for geom_element in list(worldbody_geoms):
+            if geom_element.getAttribute("mesh") != mesh_name:
+                continue
+            if geom_element.hasAttribute("contype"):
+                continue
 
-            # change the geoms
-            body = sub_dom.getElementsByTagName("body")
-            body_element = body[0]
-            sub_geoms = body_element.getElementsByTagName("geom")
-            # raw import attributes that should not survive on a classified geom
-            remove_attributes = ["contype", "conaffinity", "group", "density"]
-            for geom_element in worldbody_geoms:
-                if geom_element.getAttribute("mesh") == mesh_name:
-                    pos = geom_element.getAttribute("pos")
-                    quat = geom_element.getAttribute("quat")
-                    # A visual geom from a URDF <visual> keeps its contype marker; a
-                    # collision geom does not. Tag the expanded sub-geoms accordingly so
-                    # obj-converted collision meshes land in the collision class.
-                    is_visual = geom_element.hasAttribute("contype")
-
-                    parent = geom_element.parentNode
-                    parent.removeChild(geom_element)
-                    for sub_geom in sub_geoms:
-                        sub_geom_local = sub_geom.cloneNode(False)
-                        sub_geom_local.setAttribute("pos", pos)
-                        sub_geom_local.setAttribute("quat", quat)
-                        for attribute in remove_attributes:
-                            if sub_geom_local.hasAttribute(attribute):
-                                sub_geom_local.removeAttribute(attribute)
-                        if is_visual:
-                            sub_geom_local.setAttribute("class", "visual")
-                        else:
-                            sub_geom_local.setAttribute("class", "collision")
-                            if sub_geom_local.hasAttribute("rgba"):
-                                sub_geom_local.removeAttribute("rgba")
-                        parent.appendChild(sub_geom_local)
+            pos = geom_element.getAttribute("pos")
+            quat = geom_element.getAttribute("quat")
+            parent = geom_element.parentNode
+            parent.removeChild(geom_element)
+            for sub_geom in sub_geoms:
+                # skip obj2mjcf's own visual geom (it references the whole mesh); only the
+                # convex collision pieces should become collision geoms
+                if sub_geom.getAttribute("class") == "visual" or sub_geom.getAttribute("mesh") == mesh_name:
+                    continue
+                sub_geom_local = sub_geom.cloneNode(False)
+                if pos:
+                    sub_geom_local.setAttribute("pos", pos)
+                if quat:
+                    sub_geom_local.setAttribute("quat", quat)
+                sub_geom_local.setAttribute("class", "collision")
+                if sub_geom_local.hasAttribute("rgba"):
+                    sub_geom_local.removeAttribute("rgba")
+                parent.appendChild(sub_geom_local)
 
     return dom
 
 
-def update_non_obj_assets(dom, output_filepath):
+def update_non_obj_assets(dom, output_filepath, mesh_info_dict=None):
     """
     Classifies the geoms that MuJoCo imported from the URDF into the "visual" and
     "collision" default classes. Because the source URDF now always carries both a
     <visual> and a <collision> per renderable link (the latter synthesized from the
     visual when missing, see add_missing_collisions), MuJoCo emits a separate geom for
     each, and we simply tag them rather than duplicating a single geom.
+
+    When ``mesh_info_dict`` is provided, a visual mesh geom is also given an ``rgba`` from
+    the mesh's URDF color, so plain (non-obj2mjcf) visual meshes keep their solid color.
 
     MuJoCo imports a URDF <visual> as a geom that still carries its raw import
     attributes, e.g.
@@ -589,6 +634,12 @@ def update_non_obj_assets(dom, output_filepath):
             for attribute in remove_attributes:
                 if geom.hasAttribute(attribute):
                     geom.removeAttribute(attribute)
+            # apply the URDF color so plain visual meshes (no obj2mjcf material) render
+            if mesh_info_dict:
+                mesh_name = geom.getAttribute("mesh")
+                if mesh_name in mesh_info_dict and "color" in mesh_info_dict[mesh_name]:
+                    rgba = mesh_info_dict[mesh_name]["color"]
+                    geom.setAttribute("rgba", " ".join(str(v) for v in rgba))
         else:
             # collision geom: ensure a type, drop rgba (not rendered)
             if not geom.hasAttribute("type"):
@@ -1221,7 +1272,10 @@ def add_modifiers(dom, modify_element_dict):
 
 def copy_pre_generated_meshes(output_filepath, mesh_info_dict, decompose_dict):
     """
-    Copies pre-generated mesh folders into the final MJCF assets structure.
+    Copies pre-generated meshes (from an --asset_dir) into the final MJCF assets
+    structure. Collision meshes are copied as decomposed folders under
+    DECOMPOSED_PATH_NAME; plain visual meshes are copied as single files under
+    VISUAL_PATH_NAME.
     """
     thresholds_file = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}/metadata.json"
     thresholds_data = {}
@@ -1234,20 +1288,26 @@ def copy_pre_generated_meshes(output_filepath, mesh_info_dict, decompose_dict):
 
     for mesh_name in mesh_info_dict:
         mesh_item = mesh_info_dict[mesh_name]
-        filename = os.path.basename(mesh_item["filename"])
-        filename_no_ext = os.path.splitext(filename)[0]
+        if not mesh_item["is_pre_generated"]:
+            continue
+
         full_path = mesh_item["filename"]
-        mesh_dir = os.path.dirname(os.path.splitext(full_path)[0])
+        # decomposed only when the collision mesh was explicitly requested via decompose_mesh
+        decompose_this = mesh_item.get("used_as_collision", False) and (mesh_name in decompose_dict)
 
-        if mesh_item["is_pre_generated"]:
-            if filename_no_ext in decompose_dict:
-                threshold = decompose_dict[filename_no_ext]
-                dst_base = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}/{filename_no_ext}/{filename_no_ext}/"
-                thresholds_data[filename_no_ext] = float(threshold)
-            else:
-                dst_base = f"{output_filepath}assets/{COMPOSED_PATH_NAME}/{filename_no_ext}"
-
-            shutil.copytree(mesh_dir, dst_base, dirs_exist_ok=True)
+        if decompose_this:
+            # decomposed collision mesh: copy the .../<stem>/<stem>/ folder of pieces
+            threshold = decompose_dict[mesh_name]
+            src_dir = os.path.dirname(full_path)
+            dst_base = f"{output_filepath}assets/{DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}/"
+            shutil.copytree(src_dir, dst_base, dirs_exist_ok=True)
+            thresholds_data[mesh_name] = float(threshold)
+        else:
+            # plain mesh used directly: copy the single file into its plain dir
+            plain_dir = VISUAL_PATH_NAME if mesh_item.get("used_as_visual", False) else COMPOSED_PATH_NAME
+            os.makedirs(f"{output_filepath}assets/{plain_dir}", exist_ok=True)
+            ext = os.path.splitext(full_path)[1]
+            shutil.copy2(full_path, f"{output_filepath}assets/{plain_dir}/{mesh_name}{ext}")
 
     if thresholds_data:
         with open(thresholds_file, "w") as f:

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -43,18 +43,39 @@ VISUAL_PATH_NAME = "visual"
 # Matches obj2mjcf's coacd default.
 DEFAULT_DECOMPOSE_THRESHOLD = "0.05"
 
-# Explicit attributes written onto classified geoms so visual/collision separation does not
-# depend on the user supplying a <default class="..."> block via mujoco_inputs.
-# Visuals are render-only (contype=0 -> never collide) and live in group 2; collisions do the
-# colliding (contype/conaffinity=1), live in group 3, and are tinted COLLISION_MATERIAL_NAME
-# so they can be inspected in the viewer.
+# Geom classification uses MuJoCo default classes so individual geoms only carry class=
+# instead of repeating attrs on every element.  The three classes below are auto-generated
+# by ensure_default_geom_classes() unless the user already defined them via mujoco_inputs.
+#
+# visual         – render-only (contype=0 → never collide), lives in group 2.
+# collision      – collidable plain/primitive geoms, tinted COLLISION_MATERIAL_NAME for
+#                  easy inspection in the viewer.
+# decomposed_collision – convex pieces from obj2mjcf; same physics as collision but keep
+#                  obj2mjcf's own per-piece materials/colors so individual hulls are
+#                  distinguishable — no bright_orange tint.
 COLLISION_MATERIAL_NAME = "bright_orange"
-VISUAL_GEOM_ATTRS = {"contype": "0", "conaffinity": "0", "group": "2", "density": "0"}
-COLLISION_GEOM_ATTRS = {
+
+VISUAL_CLASS_NAME = "visual"
+COLLISION_CLASS_NAME = "collision"
+DECOMPOSED_COLLISION_CLASS_NAME = "decomposed_collision"
+
+VISUAL_CLASS_GEOM_ATTRS = {"contype": "0", "conaffinity": "0", "group": "2", "density": "0"}
+COLLISION_CLASS_GEOM_ATTRS = {
     "group": "3",
+    "type": "mesh",
     "contype": "1",
     "conaffinity": "1",
     "material": COLLISION_MATERIAL_NAME,
+}
+# type="mesh" is required: decomposed pieces reference a mesh by name only (obj2mjcf emits
+# them with no explicit type), so without it MuJoCo falls back to its default type="sphere"
+# and fits a sphere around each convex piece. contype/conaffinity are set explicitly to 1 so
+# the pieces collide with everything regardless of any user-changed global geom defaults.
+DECOMPOSED_COLLISION_CLASS_GEOM_ATTRS = {
+    "group": "3",
+    "type": "mesh",
+    "contype": "1",
+    "conaffinity": "1",
 }
 
 
@@ -608,15 +629,9 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                     sub_geom_local.setAttribute("pos", pos)
                 if quat:
                     sub_geom_local.setAttribute("quat", quat)
-                sub_geom_local.setAttribute("class", "collision")
-                # Give decomposed pieces the same collision-separation attributes as plain
-                # collisions (group 3, contype/conaffinity 1), but NOT the bright_orange
-                # material: decomposed meshes keep obj2mjcf's own materials/rgba so the
-                # individual convex pieces stay distinguishable.
-                for attribute, value in COLLISION_GEOM_ATTRS.items():
-                    if attribute == "material":
-                        continue
-                    sub_geom_local.setAttribute(attribute, value)
+                # decomposed_collision class: same physics as collision but no material attr
+                # so obj2mjcf's per-piece colors remain distinguishable in the viewer.
+                sub_geom_local.setAttribute("class", DECOMPOSED_COLLISION_CLASS_NAME)
                 parent.appendChild(sub_geom_local)
 
         # Expand the (unscaled) collision geoms referencing this mesh directly. Visual geoms
@@ -687,12 +702,12 @@ def update_non_obj_assets(dom, output_filepath, mesh_info_dict=None):
     and a <collision> as a plain collidable geom with no contype. So:
 
     - A geom WITH a contype attribute is a visual: it becomes
-        <geom mesh="finger_v6" class="visual" rgba="0.2 0.2 0.2 1" .../>
-      keeping its rgba but dropping the raw import attributes (contype, conaffinity,
-      group, density).
+        <geom mesh="finger_v6" class="visual" rgba="0.2 0.2 0.2 1"/>
+      keeping its rgba but the raw import attrs (contype, conaffinity, group, density) are
+      removed so they don't override the <default class="visual"> block.
     - A geom WITHOUT a contype attribute is a collision: it becomes
-        <geom mesh="finger_v6" class="collision" .../>
-      and its rgba (if any) is dropped since collisions are not rendered.
+        <geom mesh="finger_v6" class="collision"/>
+      with rgba (if any) dropped. Physics attrs come from <default class="collision">.
 
     Geoms that already carry a class attribute (e.g. those expanded by
     update_obj_assets) are left untouched.
@@ -705,17 +720,19 @@ def update_non_obj_assets(dom, output_filepath, mesh_info_dict=None):
     # get all of the geom elements in the worldbody element
     worldbody_geoms = worldbody_element.getElementsByTagName("geom")
 
-    used_collision_material = False
+    has_collision_geom = False
     for geom in worldbody_geoms:
         # already classified upstream (e.g. obj-decomposed meshes); leave as is
         if geom.hasAttribute("class"):
             continue
 
         if geom.hasAttribute("contype"):
-            # visual geom: keep rgba, set explicit render attributes (contype=0 -> no collide)
-            geom.setAttribute("class", "visual")
-            for attribute, value in VISUAL_GEOM_ATTRS.items():
-                geom.setAttribute(attribute, value)
+            # visual geom: strip raw import attrs so the visual class default takes over,
+            # keep rgba so plain visual meshes render with their URDF color.
+            geom.setAttribute("class", VISUAL_CLASS_NAME)
+            for attr in VISUAL_CLASS_GEOM_ATTRS:
+                if geom.hasAttribute(attr):
+                    geom.removeAttribute(attr)
             # apply the URDF color so plain visual meshes (no obj2mjcf material) render
             if mesh_info_dict:
                 mesh_name = geom.getAttribute("mesh")
@@ -723,20 +740,19 @@ def update_non_obj_assets(dom, output_filepath, mesh_info_dict=None):
                     rgba = mesh_info_dict[mesh_name]["color"]
                     geom.setAttribute("rgba", " ".join(str(v) for v in rgba))
         else:
-            # collision geom: ensure a type, drop rgba (not rendered), set explicit collision
-            # attributes and tint it so the collision shape is visible in the viewer
+            # collision geom: ensure a type, drop rgba (not rendered). Physics attrs
+            # (group/contype/conaffinity/material) come from the collision class default.
             if not geom.hasAttribute("type"):
                 geom.setAttribute("type", "sphere")
-            geom.setAttribute("class", "collision")
+            geom.setAttribute("class", COLLISION_CLASS_NAME)
             if geom.hasAttribute("rgba"):
                 geom.removeAttribute("rgba")
-            for attribute, value in COLLISION_GEOM_ATTRS.items():
-                geom.setAttribute(attribute, value)
-            used_collision_material = True
+            has_collision_geom = True
 
-    # Collision geoms reference COLLISION_MATERIAL_NAME, so it must exist or MuJoCo fails to
-    # load. Add it only when absent to avoid a repeated-name clash with a user-defined one.
-    if used_collision_material:
+    # The collision class default references COLLISION_MATERIAL_NAME, so the material must
+    # exist in <asset>. Add it now (idempotent) so it is available when the class default
+    # is later injected by ensure_default_geom_classes().
+    if has_collision_geom:
         _ensure_collision_material(dom)
 
     return dom
@@ -832,6 +848,62 @@ def ensure_default_geom_classes(dom):
             _ensure_collision_material(dom)
 
     return dom
+
+
+def _merge_default_element(dom, incoming_default):
+    """Merges the children of ``incoming_default`` into the DOM's top-level ``<default>``.
+
+    MJCF allows only one top-level ``<default>`` element; appending a second one is invalid.
+    This helper finds (or creates) the single root ``<default>`` and moves each child of
+    ``incoming_default`` into it.  For ``<default class="X">`` children, an existing
+    definition with the same class name is replaced by the incoming one so user-supplied
+    definitions always take precedence over auto-generated ones.
+
+    :param dom: parsed MJCF DOM (xml.dom.minidom.Document)
+    :param incoming_default: ``<default>`` element whose children should be merged
+    """
+    root = dom.documentElement
+
+    # Find or create the single root <default>.
+    root_default = None
+    for child in root.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and child.tagName == "default":
+            root_default = child
+            break
+
+    if root_default is None:
+        root_default = dom.createElement("default")
+        worldbody_elements = root.getElementsByTagName("worldbody")
+        if worldbody_elements:
+            root.insertBefore(root_default, worldbody_elements[0])
+        else:
+            root.appendChild(root_default)
+
+    # Index existing <default class="X"> children by class name.
+    existing_class_nodes = {}
+    for child in root_default.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and child.tagName == "default":
+            class_name = child.getAttribute("class")
+            if class_name:
+                existing_class_nodes[class_name] = child
+
+    for child in incoming_default.childNodes:
+        if child.nodeType != child.ELEMENT_NODE:
+            continue
+        imported = dom.importNode(child, True)
+        if child.tagName == "default" and child.hasAttribute("class"):
+            class_name = child.getAttribute("class")
+            if class_name in existing_class_nodes:
+                # Replace existing with incoming (user definition takes precedence).
+                root_default.replaceChild(imported, existing_class_nodes[class_name])
+                existing_class_nodes[class_name] = imported
+            else:
+                root_default.appendChild(imported)
+                existing_class_nodes[class_name] = imported
+        else:
+            root_default.appendChild(imported)
+
+
 def add_mujoco_inputs(dom, raw_inputs, scene_inputs):
     """
     Copies all elements under the "raw_inputs" and "scene_inputs" XML tags directly in the provided dom.
@@ -843,14 +915,20 @@ def add_mujoco_inputs(dom, raw_inputs, scene_inputs):
     if scene_inputs:
         for child in scene_inputs.childNodes:
             if child.nodeType == child.ELEMENT_NODE:
-                imported_node = dom.importNode(child, True)
-                root.appendChild(imported_node)
+                if child.tagName == "default":
+                    _merge_default_element(dom, child)
+                else:
+                    imported_node = dom.importNode(child, True)
+                    root.appendChild(imported_node)
 
     if raw_inputs:
         for child in raw_inputs.childNodes:
             if child.nodeType == child.ELEMENT_NODE:
-                imported_node = dom.importNode(child, True)
-                root.appendChild(imported_node)
+                if child.tagName == "default":
+                    _merge_default_element(dom, child)
+                else:
+                    imported_node = dom.importNode(child, True)
+                    root.appendChild(imported_node)
 
     return dom
 

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -125,9 +125,12 @@ def add_missing_collisions(xml_string):
 
 def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
     """
-    Builds a dictionary of all unique visual meshes in the URDF and rewrites the
-    raw_xml so every mesh filename points at a disambiguated path. There are some
-    gotchas:
+    Builds a dictionary of all unique meshes in the URDF (from both <visual> and
+    <collision> tags) and rewrites the raw_xml so every mesh filename points at a
+    disambiguated path. Visuals are processed first so their <material> color wins;
+    a collision that reuses a visual's mesh file shares that asset, while a distinct
+    collision mesh gets its own entry (defaulting to white, as collisions carry no
+    material). There are some gotchas:
 
     - Different URDF meshes can share a filename stem, so colliding stems get an
       "__N" suffix so each resolves to its own asset directory. For example, if
@@ -166,99 +169,123 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
                     return tuple(ref.color.rgba)
         return (1.0, 1.0, 1.0, 1.0)
 
-    for link in robot.links:
-        for vis in link.visuals:
-            geom = vis.geometry
-            if not (geom and hasattr(geom, "filename")):
-                continue
+    # Track which source mesh files have already been turned into an asset entry so a
+    # collision that reuses a visual's mesh (the fallback case) shares the same asset
+    # instead of producing a duplicate. Visuals are processed first so their material
+    # color wins; collisions then only add entries for genuinely distinct meshes.
+    processed_uris = set()
 
-            uri = geom.filename  # full URI
-            original_stem = pathlib.Path(uri).stem  # NEW: remember original for disambiguation
-            stem = original_stem
-            counter = 0
-            while stem in stem_to_original_uri and stem_to_original_uri[stem] != uri:
-                counter += 1
-                stem = f"{original_stem}__{counter}"
-            stem_to_original_uri[stem] = uri
+    def process_geometry(element, is_collision):
+        nonlocal raw_xml
+        geom = element.geometry
+        if not (geom and hasattr(geom, "filename")):
+            return
 
-            # Select the mesh file: use a pre-generated OBJ if available and valid; otherwise use the original
-            is_pre_generated = False
-            new_uri = uri  # default fallback
+        uri = geom.filename  # full URI
 
-            if asset_dir:
-                if original_stem in decompose_dict:
-                    # Decomposed mesh: check if a pre-generated OBJ exists and threshold matches
-                    mesh_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/{stem}/{stem}/{stem}.obj"
-                    settings_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/metadata.json"
+        # A collision reusing a visual's mesh file shares that already-built asset.
+        if is_collision and uri in processed_uris:
+            return
 
-                    if os.path.exists(mesh_file) and os.path.exists(settings_file):
-                        try:
-                            with open(settings_file) as f:
-                                data = json.load(f)
-                                used_threshold = float(data.get(f"{stem}"))
-                        except (FileNotFoundError, PermissionError, json.JSONDecodeError) as e:
-                            print(f"Warning: could not read thresholds for {stem}: {e}")
-                            used_threshold = None
-                        # Use existing decomposed object only if it has the same threshold, otherwise regenerate it.
-                        if used_threshold is not None and math.isclose(
-                            used_threshold, float(decompose_dict[original_stem]), rel_tol=1e-9
-                        ):
-                            new_uri = mesh_file
-                            is_pre_generated = True
-                            raw_xml = raw_xml.replace(geom.filename, new_uri)
-                        else:
-                            print(
-                                f"Existing decomposed obj for {stem} has different threshold {used_threshold} "
-                                f"than required {decompose_dict[original_stem]}. Regenerating..."
-                            )
-                else:
-                    # Composed mesh: check if a pre-generated OBJ exists
-                    mesh_file = f"{asset_dir}/{COMPOSED_PATH_NAME}/{stem}/{stem}.obj"
+        original_stem = pathlib.Path(uri).stem  # NEW: remember original for disambiguation
+        stem = original_stem
+        counter = 0
+        while stem in stem_to_original_uri and stem_to_original_uri[stem] != uri:
+            counter += 1
+            stem = f"{original_stem}__{counter}"
+        stem_to_original_uri[stem] = uri
 
-                    if os.path.exists(mesh_file):
+        # Select the mesh file: use a pre-generated OBJ if available and valid; otherwise use the original
+        is_pre_generated = False
+        new_uri = uri  # default fallback
+
+        if asset_dir:
+            if original_stem in decompose_dict:
+                # Decomposed mesh: check if a pre-generated OBJ exists and threshold matches
+                mesh_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/{stem}/{stem}/{stem}.obj"
+                settings_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/metadata.json"
+
+                if os.path.exists(mesh_file) and os.path.exists(settings_file):
+                    try:
+                        with open(settings_file) as f:
+                            data = json.load(f)
+                            used_threshold = float(data.get(f"{stem}"))
+                    except (FileNotFoundError, PermissionError, json.JSONDecodeError) as e:
+                        print(f"Warning: could not read thresholds for {stem}: {e}")
+                        used_threshold = None
+                    # Use existing decomposed object only if it has the same threshold, otherwise regenerate it.
+                    if used_threshold is not None and math.isclose(
+                        used_threshold, float(decompose_dict[original_stem]), rel_tol=1e-9
+                    ):
                         new_uri = mesh_file
                         is_pre_generated = True
                         raw_xml = raw_xml.replace(geom.filename, new_uri)
+                    else:
+                        print(
+                            f"Existing decomposed obj for {stem} has different threshold {used_threshold} "
+                            f"than required {decompose_dict[original_stem]}. Regenerating..."
+                        )
+            else:
+                # Composed mesh: check if a pre-generated OBJ exists
+                mesh_file = f"{asset_dir}/{COMPOSED_PATH_NAME}/{stem}/{stem}.obj"
 
-            scale = " ".join(f"{v}" for v in geom.scale) if geom.scale else "1.0 1.0 1.0"
-            rgba = resolve_color(vis)
+                if os.path.exists(mesh_file):
+                    new_uri = mesh_file
+                    is_pre_generated = True
+                    raw_xml = raw_xml.replace(geom.filename, new_uri)
 
-            mesh_dict_value = {
+        scale = " ".join(f"{v}" for v in geom.scale) if geom.scale else "1.0 1.0 1.0"
+        # Collision elements carry no <material>, so they default to white.
+        rgba = (1.0, 1.0, 1.0, 1.0) if is_collision else resolve_color(element)
+
+        mesh_dict_value = {
+            "is_pre_generated": is_pre_generated,
+            "filename": new_uri,
+            "scale": scale,
+            "color": rgba,
+        }
+
+        # this source mesh file has now been accounted for
+        processed_uris.add(uri)
+
+        # check to see if the values we are trying to add already exist
+        existing_identifier = None
+        for key, value in mesh_info_dict.items():
+            if mesh_dict_value.items() <= value.items():
+                existing_identifier = key
+                break
+
+        # if the values we want to add are not in the dictionary yet, add them
+        if existing_identifier is None:
+            # get the name of the new file so that we can reference it later, but grab correct
+            # pre generated asset if it exists
+            path_obj = pathlib.Path(new_uri)
+            if is_pre_generated:
+                new_filepath = str(path_obj.parent.parent / stem / (stem + path_obj.suffix))
+            else:
+                new_filepath = str(path_obj.parent / (stem + path_obj.suffix))
+
+            # add the unique name to the dictionary
+            mesh_info_dict[stem] = {
                 "is_pre_generated": is_pre_generated,
                 "filename": new_uri,
                 "scale": scale,
                 "color": rgba,
+                "new_filepath": new_filepath,
             }
 
-            # check to see if the values we are trying to add already exist
-            existing_identifier = None
-            for key, value in mesh_info_dict.items():
-                if mesh_dict_value.items() <= value.items():
-                    existing_identifier = key
-                    break
+            # if we changed the identifier, make sure we update it in the underlying file
+            if stem != pathlib.Path(new_uri).stem:
+                raw_xml = raw_xml.replace(new_uri, new_filepath)
 
-            # if the values we want to add are not in the dictionary yet, add them
-            if existing_identifier is None:
-                # get the name of the new file so that we can reference it later, but grab correct
-                # pre generated asset if it exists
-                path_obj = pathlib.Path(new_uri)
-                if is_pre_generated:
-                    new_filepath = str(path_obj.parent.parent / stem / (stem + path_obj.suffix))
-                else:
-                    new_filepath = str(path_obj.parent / (stem + path_obj.suffix))
-
-                # add the unique name to the dictionary
-                mesh_info_dict[stem] = {
-                    "is_pre_generated": is_pre_generated,
-                    "filename": new_uri,
-                    "scale": scale,
-                    "color": rgba,
-                    "new_filepath": new_filepath,
-                }
-
-                # if we changed the identifier, make sure we update it in the underlying file
-                if stem != pathlib.Path(new_uri).stem:
-                    raw_xml = raw_xml.replace(new_uri, new_filepath)
+    # First pass: visual meshes (their material color wins). Second pass: collision
+    # meshes, which only add genuinely distinct meshes thanks to processed_uris.
+    for link in robot.links:
+        for vis in link.visuals:
+            process_geometry(vis, is_collision=False)
+    for link in robot.links:
+        for col in link.collisions:
+            process_geometry(col, is_collision=True)
 
     return mesh_info_dict, raw_xml
 
@@ -478,10 +505,16 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
             body = sub_dom.getElementsByTagName("body")
             body_element = body[0]
             sub_geoms = body_element.getElementsByTagName("geom")
+            # raw import attributes that should not survive on a classified geom
+            remove_attributes = ["contype", "conaffinity", "group", "density"]
             for geom_element in worldbody_geoms:
                 if geom_element.getAttribute("mesh") == mesh_name:
                     pos = geom_element.getAttribute("pos")
                     quat = geom_element.getAttribute("quat")
+                    # A visual geom from a URDF <visual> keeps its contype marker; a
+                    # collision geom does not. Tag the expanded sub-geoms accordingly so
+                    # obj-converted collision meshes land in the collision class.
+                    is_visual = geom_element.hasAttribute("contype")
 
                     parent = geom_element.parentNode
                     parent.removeChild(geom_element)
@@ -489,6 +522,15 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                         sub_geom_local = sub_geom.cloneNode(False)
                         sub_geom_local.setAttribute("pos", pos)
                         sub_geom_local.setAttribute("quat", quat)
+                        for attribute in remove_attributes:
+                            if sub_geom_local.hasAttribute(attribute):
+                                sub_geom_local.removeAttribute(attribute)
+                        if is_visual:
+                            sub_geom_local.setAttribute("class", "visual")
+                        else:
+                            sub_geom_local.setAttribute("class", "collision")
+                            if sub_geom_local.hasAttribute("rgba"):
+                                sub_geom_local.removeAttribute("rgba")
                         parent.appendChild(sub_geom_local)
 
     return dom

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -84,6 +84,45 @@ def remove_tag(xml_string, tag_to_remove):
     return xmldoc.toprettyxml()
 
 
+def add_missing_collisions(xml_string):
+    """
+    Ensures every link that can be rendered can also collide, while respecting any
+    collision geometry the URDF author already provided.
+
+    For each <link> that has at least one <visual> but no <collision>, a <collision>
+    is synthesized for every visual by copying that visual's <geometry> and <origin>.
+    Links that already declare a collision are left untouched (the authored collision
+    drives physics), and links without any visual are left untouched.
+
+    Establishing this fallback at the URDF level - before MuJoCo conversion and any
+    static-body fusion - keeps the visual->collision fallback correct per link: the
+    visual meshes are used purely for rendering while the collision geometry (authored
+    when present, copied from the visual otherwise) is used for physics.
+
+    :param xml_string: the URDF as a string
+    :returns: the URDF string with synthesized collisions added where they were missing
+    """
+    dom = minidom.parseString(xml_string)
+
+    for link in dom.getElementsByTagName("link"):
+        visuals = [c for c in link.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "visual"]
+        collisions = [c for c in link.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "collision"]
+
+        # Respect authored collisions and skip links with nothing to render.
+        if collisions or not visuals:
+            continue
+
+        for visual in visuals:
+            collision = dom.createElement("collision")
+            # Copy the geometry and origin (collisions carry no material in URDF).
+            for child in visual.childNodes:
+                if child.nodeType == child.ELEMENT_NODE and child.tagName in ("geometry", "origin"):
+                    collision.appendChild(child.cloneNode(deep=True))
+            link.appendChild(collision)
+
+    return dom.toprettyxml()
+
+
 def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
     """
     Builds a dictionary of all unique visual meshes in the URDF and rewrites the

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -310,8 +310,12 @@ def fix_mujoco_description(
     dom = mrc.update_obj_assets(dom, output_filepath, mesh_info_dict)
     dom = mrc.update_non_obj_assets(dom, output_filepath, mesh_info_dict)
 
-    # Add the MuJoCo input elements
+    # Add the MuJoCo input elements (user-defined default classes land here)
     dom = mrc.add_mujoco_inputs(dom, raw_inputs, scene_inputs)
+
+    # Fill in any missing visual/collision/decomposed_collision default class blocks so
+    # geoms that only carry class= can inherit their physics attrs from the defaults.
+    dom = mrc.ensure_default_geom_classes(dom)
 
     # Add links as sites
     dom = mrc.add_links_as_sites(urdf, dom, request_add_free_joint)

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -484,9 +484,11 @@ def main(args=None):
     # Add required MuJoCo tags to the starting URDF
     xml_data = mrc.add_mujoco_info(urdf, output_filepath, parsed_args.publish_topic, parsed_args.fuse)
 
-    # get rid of collision data, assuming the visual data is much better resolution.
-    # not sure if this is the best move...
-    xml_data = mrc.remove_tag(xml_data, "collision")
+    # Keep authored collision geometry so it drives the MuJoCo collision geoms, and
+    # only synthesize a collision from the visual for links that don't define one.
+    # This way visual meshes render the robot while the (often simpler) collision
+    # geometry is used for physics, with the visual mesh as the fallback.
+    xml_data = mrc.add_missing_collisions(xml_data)
 
     xml_data = mrc.replace_package_names(xml_data)
     mesh_info_dict, xml_data = mrc.extract_mesh_info(xml_data, parsed_args.asset_dir, decompose_dict)

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -31,7 +31,6 @@ import trimesh  # Added trimesh
 
 from xml.dom import minidom
 import mujoco_ros2_control as mrc
-import pathlib
 
 
 def extract_rgba(visual):
@@ -67,221 +66,207 @@ def extract_rgba(visual):
     return np.array([0.7, 0.7, 0.7, 1.0])
 
 
-def convert_to_objs(mesh_info_dict, directory, xml_data, convert_stl_to_obj, decompose_dict):
-    # keep track of files we have already processed so we don't do it again
-    converted_filenames = []
+def _export_stl_to_obj(full_filepath, output_path, mesh_item, mesh_name):
+    """Convert an STL source mesh to an OBJ at output_path, baking in the URDF color."""
+    mesh = trimesh.load(full_filepath)
+    if "color" in mesh_item:
+        # trimesh expects an rgba; make a material so the color survives the export
+        rgba = mesh_item["color"]
+        mtl_name = "mtl_" + mesh_name
+        material = trimesh.visual.material.SimpleMaterial(
+            name=mtl_name, diffuse=rgba, glossiness=1000, specular=[0.2, 0.2, 0.2]
+        )
+        mesh.visual = trimesh.visual.TextureVisuals(material=material)
+        mesh.export(output_path, include_color=True, mtl_name=mtl_name)
+    else:
+        mesh.export(output_path)
 
+
+def _export_dae_to_obj(full_filepath, output_path, mesh_name):
+    """Convert a Collada (.dae) source mesh to an OBJ at output_path, preserving its
+    materials/textures (MuJoCo cannot load DAE directly, so conversion is required)."""
+    # keep track of the image files that we need to copy from the dae
+    image_files = mrc.get_images_from_dae(full_filepath)
+    copied_image_files = []
+
+    # set z axis to up in the dae file because that is how MuJoCo expects it
+    z_up_dae_txt = mrc.set_up_axis_to_z_up(full_filepath)
+
+    # make a temporary file rather than overwriting the old one
+    temp_file = tempfile.NamedTemporaryFile(suffix=".dae", mode="w+", delete=False)
+    temp_filepath = temp_file.name
+    temp_folder = os.path.dirname(temp_filepath)
+    try:
+        temp_file.write(z_up_dae_txt)
+        temp_file.close()
+
+        for image_file in image_files:
+            shutil.copy2(image_file, temp_folder)
+            copied_image_files.append(f"{temp_folder}/{os.path.basename(image_file)}")
+
+        scene = trimesh.load(temp_filepath, force=trimesh.scene)
+
+        # The default glossiness was way too high, so reassign default glossiness and
+        # specular but keep the rgba values. Skipped when there are image files so we
+        # don't accidentally overwrite textures.
+        if not image_files:
+            for geom in scene.geometry.values():
+                visual = geom.visual
+                rgba = extract_rgba(visual)
+                new_mat = trimesh.visual.material.SimpleMaterial(
+                    diffuse=rgba[:3],
+                    alpha=rgba[3],
+                    glossiness=1000,
+                    specular=[0.2, 0.2, 0.2],
+                )
+                visual.material = new_mat
+
+        # give the material a unique name so that it can be properly referenced
+        mtl_modifier = f"{mesh_name}"
+        mtl_name = "mtl_" + mtl_modifier
+        mtl_filepath = os.path.dirname(output_path) + f"/{mtl_name}"
+        scene.export(output_path, include_color=True, mtl_name=mtl_name)
+        mrc.rename_material_textures(dir_path=os.path.dirname(output_path), modifier=mtl_modifier)
+
+        # make the material names unique (material_0 -> material_{mesh_name}_0) so the
+        # per-mesh .obj/.mtl pair don't collide across meshes
+        if os.path.exists(mtl_filepath):
+            for filepath in [mtl_filepath, output_path]:
+                with open(filepath) as f:
+                    data = f.read()
+                data = data.replace("material_", f"material_{mtl_modifier}_")
+                with open(filepath, "w") as f:
+                    f.write(data)
+    finally:
+        if os.path.exists(temp_filepath):
+            os.remove(temp_filepath)
+
+    for copied_image_file in copied_image_files:
+        if os.path.exists(copied_image_file):
+            os.remove(copied_image_file)
+
+
+def convert_to_objs(mesh_info_dict, directory, xml_data, convert_stl_to_obj, decompose_dict):
+    """
+    Materializes each URDF mesh into the assets folder and rewrites xml_data to point at
+    it. Visual and collision meshes are routed differently:
+
+    - Visual-only meshes are plain references for rendering: kept as-is (.stl/.obj copied,
+      .dae converted to .obj) under ``VISUAL_PATH_NAME``. They are never decomposed and
+      never run through obj2mjcf; their color is applied later as the geom's rgba.
+    - Collision meshes (and the collision side of a shared mesh) are converted to a whole
+      .obj under ``DECOMPOSED_PATH_NAME/<stem>/`` so run_obj2mjcf can convex-decompose them
+      for the collision class.
+    - A mesh used by both a visual and a collision (the shared / fallback case) is
+      converted once: the single whole .obj backs the visual geom directly, and its
+      decomposed pieces back the collision geoms - no duplicate copy.
+    """
     # clean assets directory and remake required paths
     if os.path.exists(f"{directory}assets/"):
         shutil.rmtree(f"{directory}assets/")
+    os.makedirs(f"{directory}assets/{mrc.VISUAL_PATH_NAME}", exist_ok=True)
     os.makedirs(f"{directory}assets/{mrc.COMPOSED_PATH_NAME}", exist_ok=True)
     os.makedirs(f"{directory}assets/{mrc.DECOMPOSED_PATH_NAME}", exist_ok=True)
 
     for mesh_name in mesh_info_dict:
         mesh_item = mesh_info_dict[mesh_name]
         filename = os.path.basename(mesh_item["filename"])
-        filename_no_ext = os.path.splitext(filename)[0]
-        filename_ext = os.path.splitext(filename)[1]
+        filename_ext = os.path.splitext(filename)[1].lower()
         full_filepath = mesh_item["filename"]
         new_filepath = mesh_item["new_filepath"]
-        if full_filepath in converted_filenames:
-            pass
+        used_as_visual = mesh_item.get("used_as_visual", False)
+        used_as_collision = mesh_item.get("used_as_collision", False)
+        # Only decompose a collision mesh when its link was named in a decompose_mesh input.
+        decompose_this = used_as_collision and (mesh_name in decompose_dict)
 
-        print(f"processing {full_filepath} (mesh_name={mesh_name})")
+        print(f"processing {full_filepath} (mesh_name={mesh_name}, collision={used_as_collision}, "
+              f"decompose={decompose_this})")
 
-        # if we want to decompose the mesh, put it in decomposed filepath, otherwise put it in full
-        # Note: we use the mesh_name as the the unique rather than filename_no_ext to avoid collisions
-        # for commonly named elements like on UR robots.
-        if mesh_name in decompose_dict or filename_no_ext in decompose_dict:
-            assets_relative_filepath = f"{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}/"
-            os.makedirs(f"{directory}assets/{assets_relative_filepath}", exist_ok=True)
+        if decompose_this:
+            # whole .obj in the decomposed dir so obj2mjcf --decompose can run on it; the
+            # visual side of a shared mesh reuses that same whole .obj
+            os.makedirs(f"{directory}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}", exist_ok=True)
+            assets_relative_filepath = f"{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}/{mesh_name}"
+            force_obj = True
         else:
-            assets_relative_filepath = f"{mrc.COMPOSED_PATH_NAME}/"
-        assets_relative_filepath += mesh_name
+            # plain reference, used directly: visual meshes (and the shared case) go to the
+            # visual dir, collision-only meshes used directly go to the composed dir
+            plain_dir = mrc.VISUAL_PATH_NAME if used_as_visual else mrc.COMPOSED_PATH_NAME
+            assets_relative_filepath = f"{plain_dir}/{mesh_name}"
+            force_obj = False
 
         output_path = f"{directory}assets/{assets_relative_filepath}.obj"
 
-        # Import the .stl or .dae file
-        if filename_ext.lower() == ".stl":
-            if filename_no_ext in decompose_dict and not convert_stl_to_obj:
-                raise ValueError("The --convert_stl_to_obj argument must be specified to decompose .stl mesh")
-            if convert_stl_to_obj:
-                # Load mesh using trimesh
-                mesh = trimesh.load(full_filepath)
-
-                # bring in file color from urdf
-                if "color" in mesh_item:
-                    # trimesh expects 0-255 uint8 for colors
-                    rgba = mesh_item["color"]
-                    # make a material for the rgba values and export it
-                    mtl_name = "mtl_" + mesh_name
-                    material = trimesh.visual.material.SimpleMaterial(
-                        name=mtl_name, diffuse=rgba, glossiness=1000, specular=[0.2, 0.2, 0.2]
-                    )  # RGBA
-                    mesh.visual = trimesh.visual.TextureVisuals(material=material)
-
-                # Export to OBJ
-                mesh.export(output_path, include_color=True, mtl_name=mtl_name)
+        if filename_ext == ".stl":
+            if convert_stl_to_obj or force_obj:
+                # collision meshes always need an .obj (obj2mjcf input); visuals only when asked
+                _export_stl_to_obj(full_filepath, output_path, mesh_item, mesh_name)
                 xml_data = xml_data.replace(new_filepath, f"{assets_relative_filepath}.obj")
             else:
+                # plain visual reference: MuJoCo loads .stl directly, no conversion needed
                 shutil.copy2(full_filepath, f"{directory}assets/{assets_relative_filepath}.stl")
                 xml_data = xml_data.replace(new_filepath, f"{assets_relative_filepath}.stl")
-                pass
-        elif filename_ext.lower() == ".obj":
-            # If import .obj files from URDF
+        elif filename_ext == ".obj":
             if not mesh_item["is_pre_generated"]:
-                shutil.copy2(full_filepath, f"{directory}assets/{assets_relative_filepath}.obj")
-                # If the .obj depends on a mtl should copy also this
+                shutil.copy2(full_filepath, output_path)
+                # if the .obj depends on a mtl, copy that too
                 old_directory = os.path.dirname(mesh_item["filename"])
                 if os.path.exists(old_directory + "/material.mtl"):
                     final_path = os.path.dirname(assets_relative_filepath)
                     shutil.copy2(old_directory + "/material.mtl", f"{directory}assets/{final_path}/material.mtl")
-            pass
-            # objs are ok as is
-        elif filename_ext.lower() == ".dae":
-            # keep track of the image files that we need to copy from the dae
-            image_files = mrc.get_images_from_dae(full_filepath)
-            # keep track of the files that were copied to tmp directory to delete
-            copied_image_files = []
-
-            # set z axis to up in the dae file because that is how MuJoCo expects it
-            z_up_dae_txt = mrc.set_up_axis_to_z_up(full_filepath)
-
-            # make a temporary file rather than overwriting the old one
-            temp_file = tempfile.NamedTemporaryFile(suffix=".dae", mode="w+", delete=False)
-            temp_filepath = temp_file.name
-            temp_folder = os.path.dirname(temp_filepath)
-            try:
-                temp_file.write(z_up_dae_txt)
-                temp_file.close()
-
-                # copy relevant images into the temporary directory
-                for image_file in image_files:
-                    shutil.copy2(image_file, temp_folder)
-                    copied_image_files.append(f"{temp_folder}/{os.path.basename(image_file)}")
-
-                # Load scene using trimesh
-                scene = trimesh.load(temp_filepath, force=trimesh.scene)
-
-                # The default glossiness was way too high, so here we iterate over each visual
-                # element, assign default glossiness and specular but keep the rgba values.
-                # We also ignore this process if there are any image files so that we don't
-                # accidentally overwrite those. Technically we could have cases where daes have
-                # both images, and materials but I think the logic gets exceedingly complex to
-                # handle that.
-                if not image_files:
-                    for geom in scene.geometry.values():
-                        visual = geom.visual
-                        rgba = extract_rgba(visual)
-                        new_mat = trimesh.visual.material.SimpleMaterial(
-                            diffuse=rgba[:3],
-                            alpha=rgba[3],
-                            glossiness=1000,
-                            specular=[0.2, 0.2, 0.2],
-                        )
-                        visual.material = new_mat
-
-                # give the material a unique name so that it can be properly referenced
-                mtl_modifier = f"{mesh_name}"
-                mtl_name = "mtl_" + mtl_modifier
-                mtl_filepath = os.path.dirname(output_path) + f"/{mtl_name}"
-                scene.export(output_path, include_color=True, mtl_name=mtl_name)
-                # rename textures
-                mrc.rename_material_textures(dir_path=os.path.dirname(output_path), modifier=mtl_modifier)
-
-                # we need to modify the material names to not all be material_X so they don't conflict
-                # all of the objs will have a line that looks like
-                #   usemtl material_0
-                # and all of the mtl files will have a line that looks like
-                #   newmtl material_0
-                # We will modify both of them to be like so
-                #   usemtl material_{mesh_name}_0
-                #   newmtl material_{mesh_name}_0
-
-                if os.path.exists(mtl_filepath):
-                    for filepath in [mtl_filepath, output_path]:
-                        with open(filepath) as f:
-                            data = f.read()
-                        data = data.replace("material_", f"material_{mtl_modifier}_")
-                        with open(filepath, "w") as f:
-                            f.write(data)
-            finally:
-                if os.path.exists(temp_filepath):
-                    os.remove(temp_filepath)
-
-            # get rid of copied image files in the temporary file directory
-            for copied_image_file in copied_image_files:
-                if os.path.exists(copied_image_file):
-                    os.remove(copied_image_file)
-
+            xml_data = xml_data.replace(new_filepath, f"{assets_relative_filepath}.obj")
+        elif filename_ext == ".dae":
+            _export_dae_to_obj(full_filepath, output_path, mesh_name)
             xml_data = xml_data.replace(new_filepath, f"{assets_relative_filepath}.obj")
         else:
-            print(f"Can't convert {full_filepath} \n\tOnly stl and dae file extensions are supported at the moment")
+            print(f"Can't convert {full_filepath} \n\tOnly stl, obj and dae file extensions are supported")
             print(f"extension: {filename_ext}")
-            pass
-
-        # keep track of what we have been working on
-        converted_filenames.append(full_filepath)
 
     return xml_data
 
 
 def run_obj2mjcf(output_filepath, decompose_dict, mesh_info_dict):
-    # remove the folders in the asset directory so that we are clean to run obj2mjcf
-    with os.scandir(f"{output_filepath}assets/{mrc.COMPOSED_PATH_NAME}") as entries:
-        for entry in entries:
-            if entry.is_dir():
-                shutil.rmtree(entry.path)
-
-    # remove the folders in the asset directory so that we are clean to run obj2mjcf
+    """
+    Convex-decomposes the collision meshes that were explicitly requested via a
+    decompose_mesh input (obj2mjcf --decompose, at the requested coacd threshold). Visual
+    meshes and collision meshes used directly are plain references and are NOT processed
+    here.
+    """
+    # clean any pre-existing decomposed sub-folders so the run starts fresh
     top_level_path = f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}"
     for item in os.listdir(top_level_path):
         first_level_path = os.path.join(top_level_path, item)
         if os.path.isdir(first_level_path):
-            # Now check inside this first-level directory
             for sub_item in os.listdir(first_level_path):
                 second_level_path = os.path.join(first_level_path, sub_item)
                 if os.path.isdir(second_level_path):
                     shutil.rmtree(second_level_path)
 
-    # run obj2mjcf to generate folders of processed objs
-    cmd = ["obj2mjcf", "--obj-dir", f"{output_filepath}assets/{mrc.COMPOSED_PATH_NAME}", "--save-mjcf"]
-    subprocess.run(cmd)
-    composed_base_path = f"{output_filepath}assets/{mrc.COMPOSED_PATH_NAME}"
-    for file in os.listdir(composed_base_path):
-        if file.lower().endswith(".obj"):
-            mesh_name = pathlib.Path(file).stem
-            mesh_subfolder = os.path.join(composed_base_path, mesh_name)
-
-            target_path = os.path.join(mesh_subfolder, file)
-            source_path = os.path.join(composed_base_path, file)
-
-            try:
-                if not os.path.exists(target_path):
-                    shutil.copy2(source_path, target_path)
-            except Exception as e:
-                print(f"Error while running the obj2mjcf command for {mesh_name}:{e}")
-                raise
-
-    thresholds_file = os.path.join(f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}", "metadata.json")
+    thresholds_file = os.path.join(top_level_path, "metadata.json")
     thresholds_data = {}
 
-    # run obj2mjcf to generate folders of processed objs with decompose option for decomposed components
-    for mesh_name, threshold in decompose_dict.items():
-        mesh_item = mesh_info_dict[mesh_name]
-        if not mesh_item["is_pre_generated"]:
-            cmd = [
-                "obj2mjcf",
-                "--obj-dir",
-                f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}",
-                "--save-mjcf",
-                "--decompose",
-                "--coacd-args.threshold",
-                threshold,
-            ]
-            subprocess.run(cmd)
+    # decompose only the collision meshes named in a decompose_mesh input
+    for mesh_name, mesh_item in mesh_info_dict.items():
+        if not mesh_item.get("used_as_collision", False):
+            continue
+        if mesh_name not in decompose_dict:
+            continue
+        if mesh_item["is_pre_generated"]:
+            continue
 
-            thresholds_data[mesh_name] = float(threshold)
+        threshold = str(decompose_dict[mesh_name])
+        cmd = [
+            "obj2mjcf",
+            "--obj-dir",
+            f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}",
+            "--save-mjcf",
+            "--decompose",
+            "--coacd-args.threshold",
+            threshold,
+        ]
+        subprocess.run(cmd)
+
+        thresholds_data[mesh_name] = float(threshold)
 
     with open(thresholds_file, "w") as f:
         json.dump(thresholds_data, f, indent=4)
@@ -321,7 +306,7 @@ def fix_mujoco_description(
 
     # Update and add the new fixed assets
     dom = mrc.update_obj_assets(dom, output_filepath, mesh_info_dict)
-    dom = mrc.update_non_obj_assets(dom, output_filepath)
+    dom = mrc.update_non_obj_assets(dom, output_filepath, mesh_info_dict)
 
     # Add the MuJoCo input elements
     dom = mrc.add_mujoco_inputs(dom, raw_inputs, scene_inputs)

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -179,8 +179,10 @@ def convert_to_objs(mesh_info_dict, directory, xml_data, convert_stl_to_obj, dec
         # Only decompose a collision mesh when its link was named in a decompose_mesh input.
         decompose_this = used_as_collision and (mesh_name in decompose_dict)
 
-        print(f"processing {full_filepath} (mesh_name={mesh_name}, collision={used_as_collision}, "
-              f"decompose={decompose_this})")
+        print(
+            f"processing {full_filepath} (mesh_name={mesh_name}, collision={used_as_collision}, "
+            f"decompose={decompose_this})"
+        )
 
         if decompose_this:
             # whole .obj in the decomposed dir so obj2mjcf --decompose can run on it; the

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -414,16 +414,16 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         os.makedirs(mesh_dir)
         with open(os.path.join(mesh_dir, f"{name}.xml"), "w") as f:
             f.write(
-                '<mujoco><asset>'
+                "<mujoco><asset>"
                 '<mesh file="{n}.obj"/>'
                 '<mesh file="{n}_collision_0.obj"/>'
                 '<mesh file="{n}_collision_1.obj"/>'
-                '</asset>'
-                '<worldbody><body>'
+                "</asset>"
+                "<worldbody><body>"
                 '<geom mesh="{n}" class="visual"/>'
                 '<geom mesh="{n}_collision_0" class="collision"/>'
                 '<geom mesh="{n}_collision_1" class="collision"/>'
-                '</body></worldbody></mujoco>'.format(n=name)
+                "</body></worldbody></mujoco>".format(n=name)
             )
 
     def test_update_obj_assets_expands_collision_only(self):
@@ -446,8 +446,8 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
             self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*class="collision"[^>]*>')
             # both convex piece mesh assets are present (not skipped as duplicate empty names)
-            self.assertIn("col_mesh_collision_0.obj", result_xml)
-            self.assertIn("col_mesh_collision_1.obj", result_xml)
+            assert "col_mesh_collision_0.obj" in result_xml
+            assert "col_mesh_collision_1.obj" in result_xml
             # obj2mjcf's visual sub-geom (whole mesh) is not cloned as a collision geom
             self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh"[^>]*class="collision"[^>]*>')
             # decomposed collision pieces get the explicit collision separation attributes
@@ -518,7 +518,7 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
                 '<?xml version="1.0"?><mujoco><asset>'
                 '<mesh name="leg" file="decomposed/leg/leg.obj"/>'
                 '<mesh name="leg1" file="decomposed/leg/leg.obj" scale="1 -1 1"/>'
-                '</asset><worldbody>'
+                "</asset><worldbody>"
                 '<body name="left">'
                 '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="leg"/>'
                 '<geom type="mesh" mesh="leg"/>'

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -50,6 +50,7 @@ from mujoco_ros2_control import (
     parse_scene_xml,
     extract_mesh_info,
     copy_pre_generated_meshes,
+    add_missing_collisions,
 )
 
 
@@ -404,7 +405,55 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
             self.assertIsNotNone(result_dom)
 
-    def test_update_non_obj_assets_basic(self):
+    def test_update_obj_assets_tags_visual_and_collision(self):
+        # A visual-source geom (has contype) and a collision-source geom (no contype)
+        # that reference obj-converted meshes should have their expanded sub-geoms
+        # tagged class="visual" and class="collision" respectively.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            composed = os.path.join(tmpdir, "assets", COMPOSED_PATH_NAME)
+            os.makedirs(os.path.join(tmpdir, "assets", DECOMPOSED_PATH_NAME))
+            for name in ("vis_mesh", "col_mesh"):
+                mesh_dir = os.path.join(composed, name)
+                os.makedirs(mesh_dir)
+                with open(os.path.join(mesh_dir, f"{name}.xml"), "w") as f:
+                    f.write(
+                        '<mujoco><asset><mesh name="{n}_0" file="{n}.obj"/></asset>'
+                        '<worldbody><body><geom mesh="{n}_0"/></body></worldbody></mujoco>'.format(n=name)
+                    )
+            xml_string = (
+                '<?xml version="1.0"?><mujoco><asset>'
+                '<mesh name="vis_mesh" file="vis.obj"/><mesh name="col_mesh" file="col.obj"/>'
+                '</asset><worldbody><body name="test">'
+                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" '
+                'rgba="1 0 0 1" mesh="vis_mesh" pos="0 0 0" quat="1 0 0 0"/>'
+                '<geom type="mesh" mesh="col_mesh" pos="0 0 0" quat="1 0 0 0"/>'
+                "</body></worldbody></mujoco>"
+            )
+            dom = minidom.parseString(xml_string)
+            mesh_info_dict = {
+                "vis_mesh": {
+                    "is_pre_generated": False,
+                    "filename": "/p/vis.obj",
+                    "scale": "1 1 1",
+                    "color": (1, 0, 0, 1),
+                },
+                "col_mesh": {
+                    "is_pre_generated": False,
+                    "filename": "/p/col.obj",
+                    "scale": "1 1 1",
+                    "color": (1, 1, 1, 1),
+                },
+            }
+            result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
+            result_xml = result_dom.toxml()
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="vis_mesh_0"[^>]*class="visual"[^>]*>')
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_0"[^>]*class="collision"[^>]*>')
+            # raw import attrs stripped from the expanded visual geom
+            self.assertEqual(result_xml.count("contype"), 0)
+
+    def test_update_non_obj_assets_visual_geom(self):
+        # A geom with contype is a MuJoCo-imported <visual>; it is classified as
+        # visual only (no collision clone) and its raw import attributes are stripped.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
@@ -416,45 +465,70 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         dom = minidom.parseString(xml_string)
         result_dom = update_non_obj_assets(dom, "/tmp/output/")
         result_xml = result_dom.toxml()
-        assert 'class="collision"' in result_xml
         assert 'class="visual"' in result_xml
+        assert 'class="collision"' not in result_xml
         assert "contype" not in result_xml
+        assert "conaffinity" not in result_xml
+        assert 'group="1"' not in result_xml
+        assert 'density="0"' not in result_xml
+        # visual keeps its rgba for rendering
+        assert 'rgba="0.2 0.2 0.2 1"' in result_xml
 
-    def test_update_non_obj_assets_no_contype(self):
+    def test_update_non_obj_assets_collision_geom(self):
+        # A geom without contype is a MuJoCo-imported <collision>; it is classified
+        # as collision and its rgba (if any) is dropped.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
     <body name="test">
-      <geom type="box" size="1 1 1"/>
+      <geom type="box" size="1 1 1" rgba="0.2 0.2 0.2 1"/>
     </body>
   </worldbody>
 </mujoco>"""
         dom = minidom.parseString(xml_string)
         result_dom = update_non_obj_assets(dom, "/tmp/output/")
         result_xml = result_dom.toxml()
-        assert "<geom" in result_xml
+        assert 'class="collision"' in result_xml
+        assert 'class="visual"' not in result_xml
+        assert "rgba" not in result_xml
 
-    def test_update_non_obj_assets_multiple_geoms(self):
+    def test_update_non_obj_assets_visual_and_collision(self):
+        # Real case: a link with both a visual mesh and a collision mesh. The visual
+        # geom becomes class="visual" and the collision geom becomes class="collision";
+        # no duplication occurs.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
     <body name="test">
-      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="mesh1"/>
-      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="mesh2"/>
+      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="visual_mesh"/>
+      <geom type="mesh" mesh="collision_mesh"/>
     </body>
   </worldbody>
 </mujoco>"""
         dom = minidom.parseString(xml_string)
         result_dom = update_non_obj_assets(dom, "/tmp/output/")
         result_xml = result_dom.toxml()
-        self.assertEqual(result_xml.count('class="collision"'), 2)
-        self.assertEqual(result_xml.count('class="visual"'), 2)
+        self.assertEqual(result_xml.count('class="visual"'), 1)
+        self.assertEqual(result_xml.count('class="collision"'), 1)
         self.assertEqual(result_xml.count("contype"), 0)
-        self.assertEqual(result_xml.count("conaffinity"), 0)
-        self.assertEqual(result_xml.count('group="1"'), 0)
-        self.assertEqual(result_xml.count('density="0"'), 0)
-        self.assertRegex(result_xml, r'<geom[^>]*mesh="mesh1"[^>]*class="visual"[^>]*>')
-        self.assertRegex(result_xml, r'<geom[^>]*mesh="mesh2"[^>]*class="collision"[^>]*>')
+        self.assertRegex(result_xml, r'<geom[^>]*mesh="visual_mesh"[^>]*class="visual"[^>]*>')
+        self.assertRegex(result_xml, r'<geom[^>]*mesh="collision_mesh"[^>]*class="collision"[^>]*>')
+
+    def test_update_non_obj_assets_skips_classified(self):
+        # Geoms already classified (e.g. by update_obj_assets) are left untouched.
+        xml_string = """<?xml version="1.0"?>
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <geom mesh="already" class="visual"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        dom = minidom.parseString(xml_string)
+        result_dom = update_non_obj_assets(dom, "/tmp/output/")
+        result_xml = result_dom.toxml()
+        self.assertEqual(result_xml.count('class="visual"'), 1)
+        self.assertEqual(result_xml.count('class="collision"'), 0)
 
     def test_add_mujoco_inputs_both_none(self):
         xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
@@ -1694,6 +1768,86 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         finally:
             os.unlink(invalid_path)
 
+    def test_add_missing_collisions_adds_from_visual(self):
+        # A link with a visual but no collision should get a synthesized collision
+        # that copies the visual's geometry and origin.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <origin rpy="0 0 0" xyz="0.5 0 0"/>
+      <geometry>
+        <mesh filename="package://test_package/meshes/model.stl"/>
+      </geometry>
+      <material name="red"><color rgba="1 0 0 1"/></material>
+    </visual>
+  </link>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        collisions = link.getElementsByTagName("collision")
+        self.assertEqual(len(collisions), 1)
+        col = collisions[0]
+        # geometry mesh is copied
+        col_meshes = col.getElementsByTagName("mesh")
+        self.assertEqual(len(col_meshes), 1)
+        self.assertEqual(col_meshes[0].getAttribute("filename"), "package://test_package/meshes/model.stl")
+        # origin is copied
+        col_origins = col.getElementsByTagName("origin")
+        self.assertEqual(len(col_origins), 1)
+        self.assertEqual(col_origins[0].getAttribute("xyz"), "0.5 0 0")
+        # collisions must not carry a material
+        self.assertEqual(len(col.getElementsByTagName("material")), 0)
+
+    def test_add_missing_collisions_keeps_existing(self):
+        # A link that already defines a collision must be left untouched.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+    </visual>
+    <collision>
+      <geometry><sphere radius="0.5"/></geometry>
+    </collision>
+  </link>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        collisions = link.getElementsByTagName("collision")
+        self.assertEqual(len(collisions), 1)
+        # the original sphere collision is preserved (not replaced by the visual box)
+        self.assertEqual(len(collisions[0].getElementsByTagName("sphere")), 1)
+        self.assertEqual(len(collisions[0].getElementsByTagName("box")), 0)
+
+    def test_add_missing_collisions_no_visual(self):
+        # A link without any visual must not get a collision.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link"/>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        self.assertEqual(len(link.getElementsByTagName("collision")), 0)
+
+    def test_add_missing_collisions_multiple_visuals(self):
+        # Every visual on a collision-less link produces a matching collision.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual><geometry><box size="1 1 1"/></geometry></visual>
+    <visual><geometry><sphere radius="0.5"/></geometry></visual>
+  </link>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        collisions = link.getElementsByTagName("collision")
+        self.assertEqual(len(collisions), 2)
+
     def test_extract_mesh_info_basic(self):
         urdf = """<?xml version="1.0"?>
 <robot name="test_robot">
@@ -1769,6 +1923,58 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result, updated_xml = extract_mesh_info(urdf, None, {})
         self.assertEqual(len(result), 0)
         self.assertEqual(updated_xml, urdf)
+
+    def test_extract_mesh_info_distinct_collision_mesh(self):
+        # A link with a visual mesh and a different collision mesh yields two entries.
+        # The collision entry has no material, so its color defaults to white.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://test_package/meshes/visual_model.stl"/>
+      </geometry>
+      <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://test_package/meshes/collision_model.stl"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>"""
+        result, updated_xml = extract_mesh_info(urdf, None, {})
+        self.assertEqual(len(result), 2)
+        assert "visual_model" in result
+        assert "collision_model" in result
+        self.assertEqual(result["visual_model"]["color"], (1.0, 0.0, 0.0, 1.0))
+        self.assertEqual(result["collision_model"]["color"], (1.0, 1.0, 1.0, 1.0))
+        assert "package://test_package/meshes/collision_model.stl" in updated_xml
+
+    def test_extract_mesh_info_shared_collision_mesh(self):
+        # When the collision references the same mesh file as the visual (the
+        # fallback case), they share a single entry - no duplicate asset - and the
+        # visual's material color wins.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://test_package/meshes/model.stl"/>
+      </geometry>
+      <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://test_package/meshes/model.stl"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>"""
+        result, _ = extract_mesh_info(urdf, None, {})
+        self.assertEqual(len(result), 1)
+        assert "model" in result
+        self.assertEqual(result["model"]["color"], (1.0, 0.0, 0.0, 1.0))
 
     def test_extract_mesh_info_with_decompose_dict(self):
         urdf = """<?xml version="1.0"?>

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -34,10 +34,17 @@ from mujoco_ros2_control import (
     update_obj_assets,
     update_non_obj_assets,
     add_mujoco_inputs,
+    ensure_default_geom_classes,
     get_processed_mujoco_inputs,
     DECOMPOSED_PATH_NAME,
     COMPOSED_PATH_NAME,
     VISUAL_PATH_NAME,
+    VISUAL_CLASS_NAME,
+    COLLISION_CLASS_NAME,
+    DECOMPOSED_COLLISION_CLASS_NAME,
+    VISUAL_CLASS_GEOM_ATTRS,
+    COLLISION_CLASS_GEOM_ATTRS,
+    DECOMPOSED_COLLISION_CLASS_GEOM_ATTRS,
     write_mujoco_scene,
     add_urdf_free_joint,
     get_xml_from_file,
@@ -444,18 +451,21 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
                 "col_mesh": {"scale": "1 1 1", "used_as_visual": False, "used_as_collision": True},
             }
             result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*class="collision"[^>]*>')
+            # decomposed pieces use the decomposed_collision class (not collision) so they
+            # inherit group/contype/conaffinity from the default but keep obj2mjcf's own materials
+            self.assertRegex(
+                result_xml,
+                r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*class="decomposed_collision"[^>]*>',
+            )
             # both convex piece mesh assets are present (not skipped as duplicate empty names)
             assert "col_mesh_collision_0.obj" in result_xml
             assert "col_mesh_collision_1.obj" in result_xml
             # obj2mjcf's visual sub-geom (whole mesh) is not cloned as a collision geom
-            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh"[^>]*class="collision"[^>]*>')
-            # decomposed collision pieces get the explicit collision separation attributes
-            # (group 3, contype/conaffinity 1) ...
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*group="3"[^>]*>')
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*contype="1"[^>]*>')
-            # ... but are NOT tinted bright_orange - they keep obj2mjcf's own decomposition
-            # materials, and no bright_orange material is injected for them.
+            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh"[^>]*class="decomposed_collision"[^>]*>')
+            # no per-geom collision attrs - they come from the decomposed_collision class default
+            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*group="3"[^>]*>')
+            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*contype="1"[^>]*>')
+            # no bright_orange material injected - decomposed pieces keep obj2mjcf's own colors
             self.assertNotIn('material="bright_orange"', result_xml)
 
     def test_update_obj_assets_visual_only_untouched(self):
@@ -506,7 +516,10 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             # the visual geom still references the whole mesh (keeps its contype for now)
             self.assertRegex(result_xml, r'<geom[^>]*contype[^>]*mesh="shared"[^>]*>')
             # the collision geom was expanded into decomposed pieces
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="shared_collision_0"[^>]*class="collision"[^>]*>')
+            self.assertRegex(
+                result_xml,
+                r'<geom[^>]*mesh="shared_collision_0"[^>]*class="decomposed_collision"[^>]*>',
+            )
 
     def test_update_obj_assets_expands_scaled_sibling(self):
         # A mirrored link makes MuJoCo emit a scaled sibling mesh (same file, scale="1 -1 1",
@@ -535,19 +548,26 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             }
             result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
             # the mirrored sibling's whole-mesh collision geom is gone ...
-            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="leg1"[^>]*class="collision"[^>]*>')
+            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="leg1"[^>]*class="decomposed_collision"[^>]*>')
             # ... replaced by scaled decomposed pieces referencing per-sibling piece meshes
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="leg_collision_0__leg1"[^>]*class="collision"[^>]*>')
+            self.assertRegex(
+                result_xml,
+                r'<geom[^>]*mesh="leg_collision_0__leg1"[^>]*class="decomposed_collision"[^>]*>',
+            )
             # a scaled piece mesh asset exists, carrying the sibling's mirror scale
             self.assertRegex(result_xml, r'<mesh name="leg_collision_0__leg1"[^>]*scale="1 -1 1"[^>]*>')
             # the whole sibling mesh asset is dropped (no visual references it)
             self.assertNotRegex(result_xml, r'<mesh name="leg1"[ />]')
             # the unscaled (left) side still expands as before
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="leg_collision_0"[^>]*class="collision"[^>]*>')
+            self.assertRegex(
+                result_xml,
+                r'<geom[^>]*mesh="leg_collision_0"[^>]*class="decomposed_collision"[^>]*>',
+            )
 
     def test_update_non_obj_assets_visual_geom(self):
         # A geom with contype is a MuJoCo-imported <visual>; it is classified as visual and
-        # given explicit render attributes (contype=0 so it never collides) plus group 2.
+        # its raw import attributes (contype/conaffinity/group/density) are stripped so they
+        # don't override the <default class="visual"> block added by ensure_default_geom_classes.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
@@ -561,18 +581,18 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         assert 'class="visual"' in result_xml
         assert 'class="collision"' not in result_xml
-        # explicit visual attributes: visuals never collide and live in group 2
-        assert 'contype="0"' in result_xml
-        assert 'conaffinity="0"' in result_xml
-        assert 'group="2"' in result_xml
-        assert 'density="0"' in result_xml
+        # raw import attrs are stripped - physics attrs come from the visual class default
+        assert "contype=" not in result_xml
+        assert "conaffinity=" not in result_xml
+        assert "group=" not in result_xml
+        assert "density=" not in result_xml
         # visual keeps its rgba for rendering
         assert 'rgba="0.2 0.2 0.2 1"' in result_xml
 
     def test_update_non_obj_assets_collision_geom(self):
         # A geom without contype is a MuJoCo-imported <collision>; it is classified as
-        # collision, its rgba is dropped, and it gets explicit collision attributes
-        # (group 3, contype/conaffinity 1) tinted bright_orange for inspection.
+        # collision, its rgba is dropped. Physics attrs (group/contype/conaffinity/material)
+        # come from the <default class="collision"> block, not from individual geom attributes.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
@@ -587,11 +607,11 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         assert 'class="collision"' in result_xml
         assert 'class="visual"' not in result_xml
         assert 'rgba="0.2 0.2 0.2 1"' not in result_xml
-        assert 'group="3"' in result_xml
-        assert 'contype="1"' in result_xml
-        assert 'conaffinity="1"' in result_xml
-        assert 'material="bright_orange"' in result_xml
-        # the referenced material is auto-defined so the MJCF still loads
+        # no per-geom collision attrs - they come from the collision class default
+        assert "group=" not in result_xml
+        assert "contype=" not in result_xml
+        assert "conaffinity=" not in result_xml
+        # the bright_orange material is still added to <asset> so the class default can reference it
         self.assertRegex(result_xml, r'<material[^>]*name="bright_orange"')
 
     def test_update_non_obj_assets_keeps_existing_bright_orange_material(self):
@@ -632,7 +652,6 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         self.assertEqual(result_xml.count('class="visual"'), 1)
         self.assertEqual(result_xml.count('class="collision"'), 1)
-        # both geoms now carry an explicit contype (0 for visual, 1 for collision)
         self.assertRegex(result_xml, r'<geom[^>]*mesh="visual_mesh"[^>]*class="visual"[^>]*>')
         self.assertRegex(result_xml, r'<geom[^>]*mesh="collision_mesh"[^>]*class="collision"[^>]*>')
 
@@ -713,6 +732,91 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         assert "integrator" in result_xml
         assert "light" in result_xml
+
+    def test_add_mujoco_inputs_merges_default_into_existing(self):
+        # When the DOM already has a <default> and raw_inputs also contains one, the two
+        # must be merged into a single top-level <default> rather than creating a sibling.
+        # Having two top-level <default> elements is invalid in MJCF.
+        xml_string = (
+            '<?xml version="1.0"?><mujoco>' "<default>" '<joint armature="0.01"/>' "</default>" "<worldbody/></mujoco>"
+        )
+        raw_xml = (
+            '<?xml version="1.0"?><raw_inputs>'
+            "<default>"
+            '<default class="visual"><geom contype="0" group="2"/></default>'
+            "</default>"
+            "</raw_inputs>"
+        )
+        raw_dom = minidom.parseString(raw_xml)
+        raw_inputs = raw_dom.getElementsByTagName("raw_inputs")[0]
+        dom = minidom.parseString(xml_string)
+        result_dom = add_mujoco_inputs(dom, raw_inputs, None)
+        result_xml = result_dom.toxml()
+        # exactly ONE top-level <default> element
+        root_defaults = [
+            c for c in result_dom.documentElement.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "default"
+        ]
+        self.assertEqual(len(root_defaults), 1, "Expected a single top-level <default> element")
+        # both the original joint content and the user's class def are present
+        assert 'armature="0.01"' in result_xml
+        assert 'class="visual"' in result_xml
+
+    def test_add_mujoco_inputs_default_with_no_existing(self):
+        # When the DOM has no <default> and raw_inputs supplies one, a root <default>
+        # is created and the user's children are placed inside it.
+        xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
+        raw_xml = (
+            '<?xml version="1.0"?><raw_inputs>'
+            "<default>"
+            '<default class="visual"><geom contype="0" group="2"/></default>'
+            "</default>"
+            "</raw_inputs>"
+        )
+        raw_dom = minidom.parseString(raw_xml)
+        raw_inputs = raw_dom.getElementsByTagName("raw_inputs")[0]
+        dom = minidom.parseString(xml_string)
+        result_dom = add_mujoco_inputs(dom, raw_inputs, None)
+        result_xml = result_dom.toxml()
+        root_defaults = [
+            c for c in result_dom.documentElement.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "default"
+        ]
+        self.assertEqual(len(root_defaults), 1)
+        assert 'class="visual"' in result_xml
+
+    def test_add_mujoco_inputs_user_class_not_duplicated_by_ensure_default(self):
+        # Full pipeline simulation: DOM has a MuJoCo-generated <default> (with joint attrs),
+        # raw_inputs has a <default> with user class defs. After add_mujoco_inputs +
+        # ensure_default_geom_classes, there must be exactly one top-level <default> and
+        # each class name must appear exactly once.
+        xml_string = (
+            '<?xml version="1.0"?><mujoco>' '<default><joint armature="0.01"/></default>' "<worldbody/></mujoco>"
+        )
+        raw_xml = (
+            '<?xml version="1.0"?><raw_inputs>'
+            "<default>"
+            '<default class="visual"><geom contype="0" conaffinity="0" group="99" density="0"/></default>'
+            '<default class="collision"><geom group="3" type="mesh"/></default>'
+            "</default>"
+            "</raw_inputs>"
+        )
+        raw_dom = minidom.parseString(raw_xml)
+        raw_inputs = raw_dom.getElementsByTagName("raw_inputs")[0]
+        dom = minidom.parseString(xml_string)
+        dom = add_mujoco_inputs(dom, raw_inputs, None)
+        dom = ensure_default_geom_classes(dom)
+        result_xml = dom.toxml()
+        # single top-level <default>
+        root_defaults = [
+            c for c in dom.documentElement.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "default"
+        ]
+        self.assertEqual(len(root_defaults), 1)
+        # user's visual definition preserved (group=99), not overwritten with group=2
+        assert 'group="99"' in result_xml
+        self.assertNotIn('group="2"', result_xml)
+        # each class appears exactly once
+        self.assertEqual(result_xml.count(f'class="{VISUAL_CLASS_NAME}"'), 1)
+        self.assertEqual(result_xml.count(f'class="{COLLISION_CLASS_NAME}"'), 1)
+        self.assertEqual(result_xml.count(f'class="{DECOMPOSED_COLLISION_CLASS_NAME}"'), 1)
 
     def test_get_processed_mujoco_inputs_none_element(self):
         result = get_processed_mujoco_inputs(None)
@@ -2429,6 +2533,187 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
 
             assets_dir = os.path.join(output_dir, "assets")
             self.assertFalse(os.path.exists(assets_dir))
+
+    # --- ensure_default_geom_classes ---
+
+    def test_ensure_default_geom_classes_creates_all(self):
+        # When the MJCF has no <default> section, all three class blocks are created.
+        xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
+        dom = minidom.parseString(xml_string)
+        result_dom = ensure_default_geom_classes(dom)
+        result_xml = result_dom.toxml()
+        assert f'class="{VISUAL_CLASS_NAME}"' in result_xml
+        assert f'class="{COLLISION_CLASS_NAME}"' in result_xml
+        assert f'class="{DECOMPOSED_COLLISION_CLASS_NAME}"' in result_xml
+        # visual class has the correct geom attrs
+        for attr, val in VISUAL_CLASS_GEOM_ATTRS.items():
+            assert f'{attr}="{val}"' in result_xml
+        # collision class has the correct geom attrs
+        for attr, val in COLLISION_CLASS_GEOM_ATTRS.items():
+            assert f'{attr}="{val}"' in result_xml
+        # decomposed_collision class has the correct geom attrs (no material)
+        for attr, val in DECOMPOSED_COLLISION_CLASS_GEOM_ATTRS.items():
+            assert f'{attr}="{val}"' in result_xml
+        # bright_orange material is added to <asset> for the collision class to reference
+        self.assertRegex(result_xml, r'<material[^>]*name="bright_orange"')
+
+    def test_ensure_default_geom_classes_collision_is_mesh(self):
+        # The collision class sets type="mesh" as a fallback (matching the convention in the
+        # example MJCFs). Primitive collisions carry an explicit type that overrides it, so
+        # this only affects collision geoms that reference a mesh without an explicit type.
+        xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
+        dom = minidom.parseString(xml_string)
+        result_dom = ensure_default_geom_classes(dom)
+        collision_geom = None
+        for default_el in result_dom.getElementsByTagName("default"):
+            if default_el.getAttribute("class") == COLLISION_CLASS_NAME:
+                geoms = default_el.getElementsByTagName("geom")
+                self.assertEqual(len(geoms), 1)
+                collision_geom = geoms[0]
+        self.assertIsNotNone(collision_geom, "collision class default not found")
+        self.assertEqual(collision_geom.getAttribute("type"), "mesh")
+        self.assertEqual(collision_geom.getAttribute("contype"), "1")
+        self.assertEqual(collision_geom.getAttribute("conaffinity"), "1")
+
+    def test_ensure_default_geom_classes_decomposed_collision_is_mesh(self):
+        # Decomposed pieces are always meshes and reference a mesh by name only (obj2mjcf
+        # emits <geom mesh="..._collision_0" class="collision"/> with no explicit type). The
+        # decomposed_collision class MUST set type="mesh", otherwise MuJoCo falls back to its
+        # default type="sphere" and fits a sphere around each piece - so they render as spheres.
+        xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
+        dom = minidom.parseString(xml_string)
+        result_dom = ensure_default_geom_classes(dom)
+        decomposed_geom = None
+        for default_el in result_dom.getElementsByTagName("default"):
+            if default_el.getAttribute("class") == DECOMPOSED_COLLISION_CLASS_NAME:
+                geoms = default_el.getElementsByTagName("geom")
+                self.assertEqual(len(geoms), 1)
+                decomposed_geom = geoms[0]
+        self.assertIsNotNone(decomposed_geom, "decomposed_collision class default not found")
+        self.assertEqual(decomposed_geom.getAttribute("type"), "mesh")
+
+    def test_ensure_default_geom_classes_skips_user_defined_visual(self):
+        # When the user already defined class="visual", it is left untouched and only
+        # the missing collision and decomposed_collision classes are auto-generated.
+        xml_string = (
+            '<?xml version="1.0"?><mujoco>'
+            "<default>"
+            '<default class="visual"><geom group="99" contype="0" conaffinity="0" density="0"/></default>'
+            "</default>"
+            "<worldbody/></mujoco>"
+        )
+        dom = minidom.parseString(xml_string)
+        result_dom = ensure_default_geom_classes(dom)
+        result_xml = result_dom.toxml()
+        # user's definition preserved (group=99, not group=2)
+        assert 'group="99"' in result_xml
+        self.assertNotIn('group="2"', result_xml)
+        # exactly one visual default, plus auto-generated collision and decomposed_collision
+        self.assertEqual(result_xml.count(f'class="{VISUAL_CLASS_NAME}"'), 1)
+        assert f'class="{COLLISION_CLASS_NAME}"' in result_xml
+        assert f'class="{DECOMPOSED_COLLISION_CLASS_NAME}"' in result_xml
+
+    def test_ensure_default_geom_classes_skips_all_user_defined(self):
+        # When all three classes are already in the DOM, nothing is added or changed.
+        xml_string = (
+            '<?xml version="1.0"?><mujoco>'
+            "<default>"
+            '<default class="visual"><geom group="99"/></default>'
+            '<default class="collision"><geom group="88"/></default>'
+            '<default class="decomposed_collision"><geom group="77"/></default>'
+            "</default>"
+            "<worldbody/></mujoco>"
+        )
+        dom = minidom.parseString(xml_string)
+        result_dom = ensure_default_geom_classes(dom)
+        result_xml = result_dom.toxml()
+        # all three user definitions preserved unchanged
+        assert 'group="99"' in result_xml
+        assert 'group="88"' in result_xml
+        assert 'group="77"' in result_xml
+        # exactly one of each class
+        self.assertEqual(result_xml.count(f'class="{VISUAL_CLASS_NAME}"'), 1)
+        self.assertEqual(result_xml.count(f'class="{COLLISION_CLASS_NAME}"'), 1)
+        self.assertEqual(result_xml.count(f'class="{DECOMPOSED_COLLISION_CLASS_NAME}"'), 1)
+
+    def test_ensure_default_geom_classes_creates_root_default_if_absent(self):
+        # A <default> element is created at the root level when none exists.
+        xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
+        dom = minidom.parseString(xml_string)
+        result_dom = ensure_default_geom_classes(dom)
+        defaults = result_dom.documentElement.getElementsByTagName("default")
+        root_defaults = [d for d in defaults if d.parentNode == result_dom.documentElement]
+        self.assertEqual(len(root_defaults), 1)
+
+    def test_update_non_obj_assets_visual_geom_strips_import_attrs(self):
+        # Raw import attrs (contype/conaffinity/group/density) are removed from visual geoms
+        # so the <default class="visual"> block can supply them without being overridden.
+        xml_string = """<?xml version="1.0"?>
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="arm"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        dom = minidom.parseString(xml_string)
+        result_dom = update_non_obj_assets(dom, "/tmp/output/")
+        worldbody_geoms = result_dom.getElementsByTagName("worldbody")[0].getElementsByTagName("geom")
+        classified = [g for g in worldbody_geoms if g.getAttribute("class") == VISUAL_CLASS_NAME]
+        self.assertEqual(len(classified), 1)
+        geom = classified[0]
+        self.assertFalse(geom.hasAttribute("contype"))
+        self.assertFalse(geom.hasAttribute("conaffinity"))
+        self.assertFalse(geom.hasAttribute("group"))
+        self.assertFalse(geom.hasAttribute("density"))
+
+    def test_update_non_obj_assets_collision_geom_no_explicit_attrs(self):
+        # Collision geoms get class="collision" but no per-geom physics attrs; those come from
+        # the <default class="collision"> block created by ensure_default_geom_classes.
+        xml_string = """<?xml version="1.0"?>
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        dom = minidom.parseString(xml_string)
+        result_dom = update_non_obj_assets(dom, "/tmp/output/")
+        worldbody_geoms = result_dom.getElementsByTagName("worldbody")[0].getElementsByTagName("geom")
+        classified = [g for g in worldbody_geoms if g.getAttribute("class") == COLLISION_CLASS_NAME]
+        self.assertEqual(len(classified), 1)
+        geom = classified[0]
+        self.assertFalse(geom.hasAttribute("contype"))
+        self.assertFalse(geom.hasAttribute("conaffinity"))
+        self.assertFalse(geom.hasAttribute("group"))
+        self.assertFalse(geom.hasAttribute("material"))
+
+    def test_update_obj_assets_decomposed_uses_decomposed_collision_class(self):
+        # Expanded decomposed pieces use class="decomposed_collision", not class="collision",
+        # and carry no per-geom physics attrs (they come from the class default).
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_decomposed_mjcf(tmpdir, "finger")
+            xml_string = (
+                '<?xml version="1.0"?><mujoco><asset>'
+                '<mesh name="finger" file="finger.obj"/>'
+                '</asset><worldbody><body name="test">'
+                '<geom type="mesh" mesh="finger" pos="0 0 0" quat="1 0 0 0"/>'
+                "</body></worldbody></mujoco>"
+            )
+            dom = minidom.parseString(xml_string)
+            mesh_info_dict = {
+                "finger": {"scale": "1 1 1", "used_as_visual": False, "used_as_collision": True},
+            }
+            result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
+            worldbody_geoms = result_dom.getElementsByTagName("worldbody")[0].getElementsByTagName("geom")
+            decomposed = [g for g in worldbody_geoms if g.getAttribute("class") == DECOMPOSED_COLLISION_CLASS_NAME]
+            self.assertGreater(len(decomposed), 0)
+            for geom in decomposed:
+                self.assertFalse(geom.hasAttribute("contype"))
+                self.assertFalse(geom.hasAttribute("conaffinity"))
+                self.assertFalse(geom.hasAttribute("group"))
+                self.assertFalse(geom.hasAttribute("material"))
 
 
 if __name__ == "__main__":

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -508,6 +508,43 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             # the collision geom was expanded into decomposed pieces
             self.assertRegex(result_xml, r'<geom[^>]*mesh="shared_collision_0"[^>]*class="collision"[^>]*>')
 
+    def test_update_obj_assets_expands_scaled_sibling(self):
+        # A mirrored link makes MuJoCo emit a scaled sibling mesh (same file, scale="1 -1 1",
+        # auto-named e.g. "leg1") for the mirrored side. Its collision must also be decomposed,
+        # using scaled copies of the convex pieces - not left as a single whole mesh.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_decomposed_mjcf(tmpdir, "leg")
+            xml_string = (
+                '<?xml version="1.0"?><mujoco><asset>'
+                '<mesh name="leg" file="decomposed/leg/leg.obj"/>'
+                '<mesh name="leg1" file="decomposed/leg/leg.obj" scale="1 -1 1"/>'
+                '</asset><worldbody>'
+                '<body name="left">'
+                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="leg"/>'
+                '<geom type="mesh" mesh="leg"/>'
+                "</body>"
+                '<body name="right">'
+                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="leg"/>'
+                '<geom type="mesh" mesh="leg1"/>'
+                "</body>"
+                "</worldbody></mujoco>"
+            )
+            dom = minidom.parseString(xml_string)
+            mesh_info_dict = {
+                "leg": {"scale": "1 1 1", "used_as_visual": True, "used_as_collision": True},
+            }
+            result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
+            # the mirrored sibling's whole-mesh collision geom is gone ...
+            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="leg1"[^>]*class="collision"[^>]*>')
+            # ... replaced by scaled decomposed pieces referencing per-sibling piece meshes
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="leg_collision_0__leg1"[^>]*class="collision"[^>]*>')
+            # a scaled piece mesh asset exists, carrying the sibling's mirror scale
+            self.assertRegex(result_xml, r'<mesh name="leg_collision_0__leg1"[^>]*scale="1 -1 1"[^>]*>')
+            # the whole sibling mesh asset is dropped (no visual references it)
+            self.assertNotRegex(result_xml, r'<mesh name="leg1"[ />]')
+            # the unscaled (left) side still expands as before
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="leg_collision_0"[^>]*class="collision"[^>]*>')
+
     def test_update_non_obj_assets_visual_geom(self):
         # A geom with contype is a MuJoCo-imported <visual>; it is classified as visual and
         # given explicit render attributes (contype=0 so it never collides) plus group 2.

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -37,6 +37,7 @@ from mujoco_ros2_control import (
     get_processed_mujoco_inputs,
     DECOMPOSED_PATH_NAME,
     COMPOSED_PATH_NAME,
+    VISUAL_PATH_NAME,
     write_mujoco_scene,
     add_urdf_free_joint,
     get_xml_from_file,
@@ -405,51 +406,100 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
             self.assertIsNotNone(result_dom)
 
-    def test_update_obj_assets_tags_visual_and_collision(self):
-        # A visual-source geom (has contype) and a collision-source geom (no contype)
-        # that reference obj-converted meshes should have their expanded sub-geoms
-        # tagged class="visual" and class="collision" respectively.
+    def _write_decomposed_mjcf(self, tmpdir, name):
+        # Mimic obj2mjcf --decompose --save-mjcf output: meshes carry NO name attribute
+        # (MuJoCo derives the name from the file stem), a visual geom referencing the whole
+        # mesh, and convex collision-piece geoms. Layout: decomposed/<name>/<name>/<name>.xml
+        mesh_dir = os.path.join(tmpdir, "assets", DECOMPOSED_PATH_NAME, name, name)
+        os.makedirs(mesh_dir)
+        with open(os.path.join(mesh_dir, f"{name}.xml"), "w") as f:
+            f.write(
+                '<mujoco><asset>'
+                '<mesh file="{n}.obj"/>'
+                '<mesh file="{n}_collision_0.obj"/>'
+                '<mesh file="{n}_collision_1.obj"/>'
+                '</asset>'
+                '<worldbody><body>'
+                '<geom mesh="{n}" class="visual"/>'
+                '<geom mesh="{n}_collision_0" class="collision"/>'
+                '<geom mesh="{n}_collision_1" class="collision"/>'
+                '</body></worldbody></mujoco>'.format(n=name)
+            )
+
+    def test_update_obj_assets_expands_collision_only(self):
+        # A collision-only mesh is decomposed: its (no-contype) geom expands into the
+        # convex pieces; obj2mjcf's nameless piece meshes are all kept (not collapsed to a
+        # single empty name) and its visual sub-geom is not turned into a collision geom.
         with tempfile.TemporaryDirectory() as tmpdir:
-            composed = os.path.join(tmpdir, "assets", COMPOSED_PATH_NAME)
-            os.makedirs(os.path.join(tmpdir, "assets", DECOMPOSED_PATH_NAME))
-            for name in ("vis_mesh", "col_mesh"):
-                mesh_dir = os.path.join(composed, name)
-                os.makedirs(mesh_dir)
-                with open(os.path.join(mesh_dir, f"{name}.xml"), "w") as f:
-                    f.write(
-                        '<mujoco><asset><mesh name="{n}_0" file="{n}.obj"/></asset>'
-                        '<worldbody><body><geom mesh="{n}_0"/></body></worldbody></mujoco>'.format(n=name)
-                    )
+            self._write_decomposed_mjcf(tmpdir, "col_mesh")
             xml_string = (
                 '<?xml version="1.0"?><mujoco><asset>'
-                '<mesh name="vis_mesh" file="vis.obj"/><mesh name="col_mesh" file="col.obj"/>'
+                '<mesh name="col_mesh" file="col.obj"/>'
                 '</asset><worldbody><body name="test">'
-                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" '
-                'rgba="1 0 0 1" mesh="vis_mesh" pos="0 0 0" quat="1 0 0 0"/>'
                 '<geom type="mesh" mesh="col_mesh" pos="0 0 0" quat="1 0 0 0"/>'
                 "</body></worldbody></mujoco>"
             )
             dom = minidom.parseString(xml_string)
             mesh_info_dict = {
-                "vis_mesh": {
-                    "is_pre_generated": False,
-                    "filename": "/p/vis.obj",
-                    "scale": "1 1 1",
-                    "color": (1, 0, 0, 1),
-                },
-                "col_mesh": {
-                    "is_pre_generated": False,
-                    "filename": "/p/col.obj",
-                    "scale": "1 1 1",
-                    "color": (1, 1, 1, 1),
-                },
+                "col_mesh": {"scale": "1 1 1", "used_as_visual": False, "used_as_collision": True},
             }
-            result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
-            result_xml = result_dom.toxml()
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="vis_mesh_0"[^>]*class="visual"[^>]*>')
-            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_0"[^>]*class="collision"[^>]*>')
-            # raw import attrs stripped from the expanded visual geom
-            self.assertEqual(result_xml.count("contype"), 0)
+            result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*class="collision"[^>]*>')
+            # both convex piece mesh assets are present (not skipped as duplicate empty names)
+            self.assertIn("col_mesh_collision_0.obj", result_xml)
+            self.assertIn("col_mesh_collision_1.obj", result_xml)
+            # obj2mjcf's visual sub-geom (whole mesh) is not cloned as a collision geom
+            self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh"[^>]*class="collision"[^>]*>')
+
+    def test_update_obj_assets_visual_only_untouched(self):
+        # A visual-only mesh (not in the decomposed dir) is a plain reference: its geom
+        # and <mesh> asset are left as-is (no expansion).
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "assets", DECOMPOSED_PATH_NAME))
+            xml_string = (
+                '<?xml version="1.0"?><mujoco><asset>'
+                '<mesh name="vis_mesh" file="visual/vis_mesh.stl"/>'
+                '</asset><worldbody><body name="test">'
+                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" '
+                'rgba="1 0 0 1" mesh="vis_mesh"/>'
+                "</body></worldbody></mujoco>"
+            )
+            dom = minidom.parseString(xml_string)
+            mesh_info_dict = {
+                "vis_mesh": {"scale": "1 1 1", "used_as_visual": True, "used_as_collision": False},
+            }
+            result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
+            # the single mesh asset and its geom are untouched (still one reference)
+            self.assertRegex(result_xml, r'<mesh name="vis_mesh"')
+            self.assertEqual(result_xml.count('mesh="vis_mesh"'), 1)
+
+    def test_update_obj_assets_shared_keeps_visual_expands_collision(self):
+        # A shared mesh (used by both visual and collision): the whole <mesh> asset and
+        # the visual geom are kept; only the collision (no-contype) geom is expanded.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_decomposed_mjcf(tmpdir, "shared")
+            xml_string = (
+                '<?xml version="1.0"?><mujoco><asset>'
+                '<mesh name="shared" file="decomposed/shared/shared.obj"/>'
+                '</asset><worldbody><body name="test">'
+                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" '
+                'rgba="1 0 0 1" mesh="shared" pos="0 0 0" quat="1 0 0 0"/>'
+                '<geom type="mesh" mesh="shared" pos="0 0 0" quat="1 0 0 0"/>'
+                "</body></worldbody></mujoco>"
+            )
+            dom = minidom.parseString(xml_string)
+            mesh_info_dict = {
+                "shared": {"scale": "1 1 1", "used_as_visual": True, "used_as_collision": True},
+            }
+            result_xml = update_obj_assets(dom, tmpdir + "/", mesh_info_dict).toxml()
+            # exactly one mesh resolves to the name "shared" - our kept whole mesh; obj2mjcf's
+            # nameless re-emit (file decomposed/shared/shared/shared.obj) is deduped away
+            self.assertEqual(result_xml.count('name="shared"'), 1)
+            self.assertNotIn("shared/shared/shared.obj", result_xml)
+            # the visual geom still references the whole mesh (keeps its contype for now)
+            self.assertRegex(result_xml, r'<geom[^>]*contype[^>]*mesh="shared"[^>]*>')
+            # the collision geom was expanded into decomposed pieces
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="shared_collision_0"[^>]*class="collision"[^>]*>')
 
     def test_update_non_obj_assets_visual_geom(self):
         # A geom with contype is a MuJoCo-imported <visual>; it is classified as
@@ -529,6 +579,24 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         self.assertEqual(result_xml.count('class="visual"'), 1)
         self.assertEqual(result_xml.count('class="collision"'), 0)
+
+    def test_update_non_obj_assets_visual_rgba_from_mesh_info(self):
+        # When a mesh_info_dict is supplied, a plain visual mesh geom gets its rgba from
+        # the URDF color so it renders correctly without obj2mjcf materials.
+        xml_string = """<?xml version="1.0"?>
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="vis_mesh"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        dom = minidom.parseString(xml_string)
+        mesh_info_dict = {"vis_mesh": {"color": (1.0, 0.0, 0.0, 1.0)}}
+        result_dom = update_non_obj_assets(dom, "/tmp/output/", mesh_info_dict)
+        result_xml = result_dom.toxml()
+        self.assertRegex(result_xml, r'<geom[^>]*mesh="vis_mesh"[^>]*class="visual"[^>]*>')
+        assert 'rgba="1.0 0.0 0.0 1.0"' in result_xml
 
     def test_add_mujoco_inputs_both_none(self):
         xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
@@ -1866,6 +1934,9 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         self.assertEqual(result["model"]["scale"], "1.0 1.0 1.0")
         self.assertEqual(result["model"]["color"], (1.0, 1.0, 1.0, 1.0))
         self.assertFalse(result["model"]["is_pre_generated"])
+        # a visual-only mesh is flagged for visual use, not collision
+        self.assertTrue(result["model"]["used_as_visual"])
+        self.assertFalse(result["model"]["used_as_collision"])
         assert "package://test_package/meshes/model.dae" in updated_xml
 
     def test_extract_mesh_info_with_material_color(self):
@@ -1949,12 +2020,17 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         assert "collision_model" in result
         self.assertEqual(result["visual_model"]["color"], (1.0, 0.0, 0.0, 1.0))
         self.assertEqual(result["collision_model"]["color"], (1.0, 1.0, 1.0, 1.0))
+        # distinct meshes are flagged for their respective single use
+        self.assertTrue(result["visual_model"]["used_as_visual"])
+        self.assertFalse(result["visual_model"]["used_as_collision"])
+        self.assertTrue(result["collision_model"]["used_as_collision"])
+        self.assertFalse(result["collision_model"]["used_as_visual"])
         assert "package://test_package/meshes/collision_model.stl" in updated_xml
 
     def test_extract_mesh_info_shared_collision_mesh(self):
         # When the collision references the same mesh file as the visual (the
-        # fallback case), they share a single entry - no duplicate asset - and the
-        # visual's material color wins.
+        # fallback case), they share a single entry - one converted source, reused -
+        # flagged for both uses, with the visual's material color winning.
         urdf = """<?xml version="1.0"?>
 <robot name="test_robot">
   <link name="base_link">
@@ -1975,16 +2051,21 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         self.assertEqual(len(result), 1)
         assert "model" in result
         self.assertEqual(result["model"]["color"], (1.0, 0.0, 0.0, 1.0))
+        # one entry, reused for both visual and collision
+        self.assertTrue(result["model"]["used_as_visual"])
+        self.assertTrue(result["model"]["used_as_collision"])
 
     def test_extract_mesh_info_with_decompose_dict(self):
+        # decomposition applies to collision meshes, so the decompose pregen lookup is
+        # exercised through a <collision> mesh.
         urdf = """<?xml version="1.0"?>
 <robot name="test_robot">
   <link name="base_link">
-    <visual>
+    <collision>
       <geometry>
         <mesh filename="package://test_package/meshes/complex_mesh.stl"/>
       </geometry>
-    </visual>
+    </collision>
   </link>
 </robot>"""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2017,11 +2098,11 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         urdf = """<?xml version="1.0"?>
 <robot name="test_robot">
   <link name="base_link">
-    <visual>
+    <collision>
       <geometry>
         <mesh filename="package://test_package/meshes/complex_mesh.stl"/>
       </geometry>
-    </visual>
+    </collision>
   </link>
 </robot>"""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2046,7 +2127,8 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
 
             self.assertEqual(urdf, updated_xml)
 
-    def test_extract_mesh_with_compose_dict(self):
+    def test_extract_mesh_visual_pre_generated(self):
+        # A visual mesh resolves to a plain pre-generated asset in the visual dir.
         urdf = """<?xml version="1.0"?>
 <robot name="test_robot">
   <link name="base_link">
@@ -2058,9 +2140,9 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
   </link>
 </robot>"""
         with tempfile.TemporaryDirectory() as tmpdir:
-            composed_dir = os.path.join(tmpdir, COMPOSED_PATH_NAME, "complex_mesh")
-            os.makedirs(composed_dir)
-            mesh_file = os.path.join(composed_dir, "complex_mesh.obj")
+            visual_dir = os.path.join(tmpdir, VISUAL_PATH_NAME)
+            os.makedirs(visual_dir)
+            mesh_file = os.path.join(visual_dir, "complex_mesh.obj")
             with open(mesh_file, "w") as f:
                 f.write("# OBJ file")
 
@@ -2068,9 +2150,10 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             self.assertEqual(len(result), 1)
             assert "complex_mesh" in result
             self.assertTrue(result["complex_mesh"]["is_pre_generated"])
+            self.assertTrue(result["complex_mesh"]["used_as_visual"])
             self.assertEqual(result["complex_mesh"]["scale"], "1.0 1.0 1.0")
             self.assertEqual(result["complex_mesh"]["color"], (1.0, 1.0, 1.0, 1.0))
-            self.assertEqual(f"{composed_dir}/complex_mesh.obj", result["complex_mesh"]["filename"])
+            self.assertEqual(f"{visual_dir}/complex_mesh.obj", result["complex_mesh"]["filename"])
 
             # The updated_xml differs from urdf only for the new path
             assert f"{mesh_file}" in updated_xml
@@ -2078,6 +2161,66 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
                 result["complex_mesh"]["filename"], "package://test_package/meshes/complex_mesh.stl"
             )
             self.assertEqual(urdf, reverted_xml)
+
+    def test_extract_mesh_collision_direct_pre_generated(self):
+        # A collision mesh NOT named in a decompose_mesh input is used directly: its
+        # pre-generated asset is the plain composed mesh, not a decomposed one.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <collision>
+      <geometry>
+        <mesh filename="package://test_package/meshes/chunk.stl"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            composed_dir = os.path.join(tmpdir, COMPOSED_PATH_NAME)
+            os.makedirs(composed_dir)
+            mesh_file = os.path.join(composed_dir, "chunk.obj")
+            with open(mesh_file, "w") as f:
+                f.write("# OBJ file")
+
+            # empty decompose_dict -> the collision mesh is used directly (not decomposed)
+            result, updated_xml = extract_mesh_info(urdf, tmpdir, {})
+            self.assertEqual(len(result), 1)
+            assert "chunk" in result
+            self.assertTrue(result["chunk"]["is_pre_generated"])
+            self.assertTrue(result["chunk"]["used_as_collision"])
+            self.assertFalse(result["chunk"]["used_as_visual"])
+            self.assertEqual(f"{composed_dir}/chunk.obj", result["chunk"]["filename"])
+
+    def test_copy_pre_generated_meshes_collision_direct(self):
+        # A collision mesh used directly (not in decompose_dict) is copied as a single
+        # file into the composed dir, not decomposed.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = os.path.join(tmpdir, "source", COMPOSED_PATH_NAME)
+            output_dir = os.path.join(tmpdir, "output") + "/"
+            os.makedirs(source_dir)
+            mesh_file = os.path.join(source_dir, "chunk.obj")
+            with open(mesh_file, "w") as f:
+                f.write("# DIRECT COLLISION OBJ")
+
+            mesh_info_dict = {
+                "chunk": {
+                    "is_pre_generated": True,
+                    "filename": mesh_file,
+                    "scale": "1.0 1.0 1.0",
+                    "color": (1.0, 1.0, 1.0, 1.0),
+                    "used_as_visual": False,
+                    "used_as_collision": True,
+                }
+            }
+
+            copy_pre_generated_meshes(output_dir, mesh_info_dict, {})
+
+            expected_dst = os.path.join(output_dir, "assets", COMPOSED_PATH_NAME, "chunk.obj")
+            self.assertTrue(os.path.exists(expected_dst))
+            with open(expected_dst) as f:
+                self.assertEqual(f.read(), "# DIRECT COLLISION OBJ")
+            # not decomposed -> no metadata.json written
+            self.assertFalse(os.path.exists(os.path.join(output_dir, "assets", DECOMPOSED_PATH_NAME, "metadata.json")))
 
     def test_copy_pre_generated_meshes_decomposed(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2097,6 +2240,8 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
                     "filename": os.path.join(source_dir, "mesh_name", "mesh_name", "mesh_name.obj"),
                     "scale": "1.0 1.0 1.0",
                     "color": (1.0, 1.0, 1.0, 1.0),
+                    "used_as_visual": False,
+                    "used_as_collision": True,
                 }
             }
             decompose_dict = {"mesh_name": "0.05"}
@@ -2142,6 +2287,8 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
                     "filename": os.path.join(source_dir, "mesh_name", "mesh_name", "mesh_name.obj"),
                     "scale": "1.0 1.0 1.0",
                     "color": (1.0, 1.0, 1.0, 1.0),
+                    "used_as_visual": False,
+                    "used_as_collision": True,
                 }
             }
             decompose_dict = {"mesh_name": "0.10"}
@@ -2162,34 +2309,35 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
                 self.assertEqual(updated_data["previous_mesh_name"], 0.05)
                 self.assertEqual(updated_data["mesh_name"], 0.10)
 
-    def test_copy_pre_generated_meshes_composed(self):
+    def test_copy_pre_generated_meshes_visual(self):
+        # A plain visual mesh is copied as a single file into the visual dir.
         with tempfile.TemporaryDirectory() as tmpdir:
-            source_dir = os.path.join(tmpdir, "source")
+            source_dir = os.path.join(tmpdir, "source", VISUAL_PATH_NAME)
             output_dir = os.path.join(tmpdir, "output") + "/"
             os.makedirs(source_dir)
 
-            mesh_source_dir = os.path.join(source_dir, "mesh_name")
-            os.makedirs(mesh_source_dir)
-            mesh_file = os.path.join(mesh_source_dir, "mesh_name.obj")
+            mesh_file = os.path.join(source_dir, "mesh_name.obj")
             with open(mesh_file, "w") as f:
-                f.write("# COMPOSED OBJ content")
+                f.write("# VISUAL OBJ content")
 
             mesh_info_dict = {
                 "mesh_name": {
                     "is_pre_generated": True,
-                    "filename": os.path.join(source_dir, "mesh_name", "mesh_name.obj"),
+                    "filename": mesh_file,
                     "scale": "1.0 1.0 1.0",
                     "color": (1.0, 1.0, 1.0, 1.0),
+                    "used_as_visual": True,
+                    "used_as_collision": False,
                 }
             }
             decompose_dict = {}
 
             copy_pre_generated_meshes(output_dir, mesh_info_dict, decompose_dict)
 
-            expected_dst = os.path.join(output_dir, "assets", COMPOSED_PATH_NAME, "mesh_name", "mesh_name.obj")
+            expected_dst = os.path.join(output_dir, "assets", VISUAL_PATH_NAME, "mesh_name.obj")
             self.assertTrue(os.path.exists(expected_dst))
             with open(expected_dst) as f:
-                self.assertEqual(f.read(), "# COMPOSED OBJ content")
+                self.assertEqual(f.read(), "# VISUAL OBJ content")
 
     def test_copy_pre_generated_meshes_not_pre_generated(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -450,6 +450,13 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             self.assertIn("col_mesh_collision_1.obj", result_xml)
             # obj2mjcf's visual sub-geom (whole mesh) is not cloned as a collision geom
             self.assertNotRegex(result_xml, r'<geom[^>]*mesh="col_mesh"[^>]*class="collision"[^>]*>')
+            # decomposed collision pieces get the explicit collision separation attributes
+            # (group 3, contype/conaffinity 1) ...
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*group="3"[^>]*>')
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_collision_0"[^>]*contype="1"[^>]*>')
+            # ... but are NOT tinted bright_orange - they keep obj2mjcf's own decomposition
+            # materials, and no bright_orange material is injected for them.
+            self.assertNotIn('material="bright_orange"', result_xml)
 
     def test_update_obj_assets_visual_only_untouched(self):
         # A visual-only mesh (not in the decomposed dir) is a plain reference: its geom
@@ -502,8 +509,8 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             self.assertRegex(result_xml, r'<geom[^>]*mesh="shared_collision_0"[^>]*class="collision"[^>]*>')
 
     def test_update_non_obj_assets_visual_geom(self):
-        # A geom with contype is a MuJoCo-imported <visual>; it is classified as
-        # visual only (no collision clone) and its raw import attributes are stripped.
+        # A geom with contype is a MuJoCo-imported <visual>; it is classified as visual and
+        # given explicit render attributes (contype=0 so it never collides) plus group 2.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
@@ -517,16 +524,18 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         assert 'class="visual"' in result_xml
         assert 'class="collision"' not in result_xml
-        assert "contype" not in result_xml
-        assert "conaffinity" not in result_xml
-        assert 'group="1"' not in result_xml
-        assert 'density="0"' not in result_xml
+        # explicit visual attributes: visuals never collide and live in group 2
+        assert 'contype="0"' in result_xml
+        assert 'conaffinity="0"' in result_xml
+        assert 'group="2"' in result_xml
+        assert 'density="0"' in result_xml
         # visual keeps its rgba for rendering
         assert 'rgba="0.2 0.2 0.2 1"' in result_xml
 
     def test_update_non_obj_assets_collision_geom(self):
-        # A geom without contype is a MuJoCo-imported <collision>; it is classified
-        # as collision and its rgba (if any) is dropped.
+        # A geom without contype is a MuJoCo-imported <collision>; it is classified as
+        # collision, its rgba is dropped, and it gets explicit collision attributes
+        # (group 3, contype/conaffinity 1) tinted bright_orange for inspection.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
@@ -540,7 +549,33 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         assert 'class="collision"' in result_xml
         assert 'class="visual"' not in result_xml
-        assert "rgba" not in result_xml
+        assert 'rgba="0.2 0.2 0.2 1"' not in result_xml
+        assert 'group="3"' in result_xml
+        assert 'contype="1"' in result_xml
+        assert 'conaffinity="1"' in result_xml
+        assert 'material="bright_orange"' in result_xml
+        # the referenced material is auto-defined so the MJCF still loads
+        self.assertRegex(result_xml, r'<material[^>]*name="bright_orange"')
+
+    def test_update_non_obj_assets_keeps_existing_bright_orange_material(self):
+        # If the user already defines a bright_orange material, the converter must not add a
+        # duplicate (MuJoCo errors on repeated names).
+        xml_string = """<?xml version="1.0"?>
+<mujoco>
+  <asset>
+    <material name="bright_orange" rgba="0.9 0.4 0.1 1"/>
+  </asset>
+  <worldbody>
+    <body name="test">
+      <geom type="box" size="1 1 1"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        dom = minidom.parseString(xml_string)
+        result_xml = update_non_obj_assets(dom, "/tmp/output/").toxml()
+        self.assertEqual(result_xml.count('name="bright_orange"'), 1)
+        # the user's definition is preserved, not overwritten
+        assert 'rgba="0.9 0.4 0.1 1"' in result_xml
 
     def test_update_non_obj_assets_visual_and_collision(self):
         # Real case: a link with both a visual mesh and a collision mesh. The visual
@@ -560,7 +595,7 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result_xml = result_dom.toxml()
         self.assertEqual(result_xml.count('class="visual"'), 1)
         self.assertEqual(result_xml.count('class="collision"'), 1)
-        self.assertEqual(result_xml.count("contype"), 0)
+        # both geoms now carry an explicit contype (0 for visual, 1 for collision)
         self.assertRegex(result_xml, r'<geom[^>]*mesh="visual_mesh"[^>]*class="visual"[^>]*>')
         self.assertRegex(result_xml, r'<geom[^>]*mesh="collision_mesh"[^>]*class="collision"[^>]*>')
 


### PR DESCRIPTION
## Description

Recently, when creating different mujoco environments on the fly, I came across the same issue that the converter is using MuJoCo and I have some places the convex hulls are defined in the collision and I believe it is better that it resuses it and not to add different logic based on the URDF tag etc. The following cases are covered:

* If the visual and collision meshes are defined, the converter now uses meshes/information defined in the `collision` tag of the URDF
     1. Supports primitive types such as Box, Sphere, cylinder etc
     2. Supports the STL, DAE and OBJ files
     3.  Visual meshes are used for the visual part in MuJoCo and the Collision meshes are used for the collision detection.
     4. Visual meshes are set to group 2
     5. Collision meshes are set to group 3
* If the URDF only contains the `visual` meshes, but not the `collision` meshes in the collision tag, then the visual meshes are used for MuJoCo

Fixes some concerns listed in #120

With changes in main:

<img width="769" height="764" alt="kangaroo_visual_collision_mesh_groups_main" src="https://github.com/user-attachments/assets/fed4fbde-b49b-42a4-846c-378bba81be51" />

With proposed changes:

<img width="946" height="844" alt="kangaroo_visual_collision_mesh_groups" src="https://github.com/user-attachments/assets/9dc9a275-fe91-4cbe-8f72-3efe966d525d" />

### Is this user-facing behavior change?

Maybe yes

### Did you use Generative AI?

I did use it for certain parts to improve and also reiterate on ideas

