### PR TITLE
Fix scipy for openblas missing dependency

### DIFF
--- a/mujoco_ros2_control/scripts/requirements.txt
+++ b/mujoco_ros2_control/scripts/requirements.txt
@@ -9,7 +9,8 @@ mujoco==3.6.0
 obj2mjcf==0.0.25
 pillow==12.1.1
 PyOpenGL==3.1.10
-scipy==1.13
+scipy==1.15.3 ; python_version <  "3.11"
+scipy==1.17.1 ; python_version >= "3.11"
 termcolor==3.3.0
 trimesh==4.11.4
 typeguard==4.5.1


### PR DESCRIPTION
Should fix #203 the issue reported in #203

```
2026-06-04T06:51:09.2423922Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m Library npyrandom found: YES
2026-06-04T06:51:09.2425108Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m Run-time dependency pybind11 found: YES 3.0.1
2026-06-04T06:51:09.2426525Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m Run-time dependency scipy-openblas found: NO  (tried pkg-config)
2026-06-04T06:51:09.2428157Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m Run-time dependency openblas found: NO  (tried pkg-config and cmake)
2026-06-04T06:51:09.2432443Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m Run-time dependency openblas found: NO  (tried pkg-config and cmake)
2026-06-04T06:51:09.2433848Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m 
2026-06-04T06:51:09.2435518Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m ../scipy/meson.build:163:9: ERROR: Dependency "OpenBLAS" not found (tried pkg-config and cmake)
2026-06-04T06:51:09.2437041Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m 
2026-06-04T06:51:09.2438913Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m A full log can be found at /tmp/pip-install-npkrz2ft/scipy_97ba01574b824e94be8be6ed4172b19c/.mesonpy-8z7xy1hj/meson-logs/meson-log.txt
2026-06-04T06:51:09.2441007Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][31m   [NON-XML-CHAR-0x1B][0m [NON-XML-CHAR-0x1B][31m[end of output][NON-XML-CHAR-0x1B][0m
2026-06-04T06:51:09.2441698Z     [robot_description_to_mjcf.sh-1]   
2026-06-04T06:51:09.2442533Z     [robot_description_to_mjcf.sh-1]   [NON-XML-CHAR-0x1B][1;35mnote[NON-XML-CHAR-0x1B][0m: This error originates from a subprocess, and is likely not a problem with pip.
2026-06-04T06:51:09.2444412Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][1;31merror[NON-XML-CHAR-0x1B][0m: [NON-XML-CHAR-0x1B][1mmetadata-generation-failed[NON-XML-CHAR-0x1B][0m
2026-06-04T06:51:09.2445881Z     [robot_description_to_mjcf.sh-1] 
2026-06-04T06:51:09.2446733Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][31m×[NON-XML-CHAR-0x1B][0m Encountered error while generating package metadata.
2026-06-04T06:51:09.2448228Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][31m╰─>[NON-XML-CHAR-0x1B][0m See above for output.
2026-06-04T06:51:09.2448815Z     [robot_description_to_mjcf.sh-1] 
2026-06-04T06:51:09.2449740Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][1;35mnote[NON-XML-CHAR-0x1B][0m: This is an issue with the package mentioned above, not pip.
2026-06-04T06:51:09.2450756Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][1;36mhint[NON-XML-CHAR-0x1B][0m: See above for details.
2026-06-04T06:51:09.2451482Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][?25hSuccessfully installed dependencies in 18 seconds.
2026-06-04T06:51:09.2452233Z     [robot_description_to_mjcf.sh-1] Traceback (most recent call last):
2026-06-04T06:51:09.2454451Z     [robot_description_to_mjcf.sh-1]   File [NON-XML-CHAR-0x1B][35m"/home/runner/work/ros2_control_ci/ros2_control_ci/.work/target_ws/install/mujoco_ros2_control/lib/mujoco_ros2_control/make_mjcf_from_robot_description.py"[NON-XML-CHAR-0x1B][0m, line [NON-XML-CHAR-0x1B][35m21[NON-XML-CHAR-0x1B][0m, in [NON-XML-CHAR-0x1B][35m<module>[NON-XML-CHAR-0x1B][0m
2026-06-04T06:51:09.2456628Z     [robot_description_to_mjcf.sh-1]     import mujoco
2026-06-04T06:51:09.2457425Z     [robot_description_to_mjcf.sh-1] [NON-XML-CHAR-0x1B][1;35
```