### PR TITLE
Support polling, streaming, and disabled cameras in camera plugin

### DIFF
--- a/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins.yaml
+++ b/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins.yaml
@@ -8,7 +8,7 @@
         type: "mujoco_ros2_control_plugins/CameraPlugin"
         camera_publish_rate: 6.0
         camera:
-          camera_type: streaming
+          policy: streaming
           frame_name: camera_color_optical_frame
           info_topic: /camera/color/camera_info
           image_topic: /camera/color/image_raw

--- a/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins.yaml
+++ b/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins.yaml
@@ -8,6 +8,7 @@
         type: "mujoco_ros2_control_plugins/CameraPlugin"
         camera_publish_rate: 6.0
         camera:
+          camera_type: streaming
           frame_name: camera_color_optical_frame
           info_topic: /camera/color/camera_info
           image_topic: /camera/color/image_raw

--- a/mujoco_ros2_control_plugins/CMakeLists.txt
+++ b/mujoco_ros2_control_plugins/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(realtime_tools REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(mujoco_ros2_control_msgs REQUIRED)
 find_package(glfw3 REQUIRED)
@@ -52,6 +53,7 @@ target_link_libraries(mujoco_ros2_control_plugins PUBLIC
   pluginlib::pluginlib
   ${sensor_msgs_TARGETS}
   ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
   ${visualization_msgs_TARGETS}
   ${mujoco_ros2_control_msgs_TARGETS}
   glfw

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -51,7 +51,7 @@
 namespace mujoco_ros2_control_plugins
 {
 
-enum class CameraType
+enum class CameraPolicy
 {
   DISABLED = 0,  // Publishing is disabled.
   STREAMING,     // Publishing is constant at the specified publish rate.
@@ -60,7 +60,7 @@ enum class CameraType
 
 struct CameraData
 {
-  CameraType type = CameraType::STREAMING;
+  CameraPolicy policy = CameraPolicy::STREAMING;
 
   // Set by the trigger service for polled cameras to request a one-shot capture.
   bool poll_requested{ false };
@@ -117,14 +117,14 @@ struct CameraData
  *     info_topic: <camera_name>/camera_info
  *     image_topic: <camera_name>/color
  *     depth_topic: <camera_name>/depth
- *     trigger_service_name: <camera_name>/trigger  # only used for polling camera type
+ *     trigger_service_name: <camera_name>/trigger  # only used for polling camera policy
  *
  * Implementation notes
  * --------------------
  * If the camera name, in the parameters, does not match any of the mujoco cameras
  * the data will not be published to ROS topics.
- * If no cameras parameters are given (but mujoco_camera_plugin and its type are declared)
- * the default type (streaming), topics, and frame are used automatically.
+ * If no camera parameters are given, but the mujoco_camera_plugin and its policy are
+ * declared, the default policy (streaming), topics, and frame are used automatically.
  *
  */
 class CameraPlugin : public MuJoCoROS2ControlPluginBase
@@ -173,9 +173,10 @@ private:
   void close();
 
   /**
-   * @brief Parses camera information from the mujoco model.
+   * @brief Parses camera information from the mujoco model and node parameters.
+   * @return true if registering cameras succeeds, otherwise false.
    */
-  void register_cameras();
+  bool register_cameras();
 
   /**
    * @brief Initializes the rendering context and starts processing.

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -112,7 +112,7 @@ struct CameraData
  *   # All cameras will publish data at the same rate
  *   camera_publish_rate: 6.0
  *   <camera_name>:
- *     camera_type: <camera_type>  # "disabled", "polled", or "streaming"
+ *     policy: <policy>  # "disabled", "polled", or "streaming"
  *     frame_name: ""
  *     info_topic: <camera_name>/camera_info
  *     image_topic: <camera_name>/color

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -61,7 +61,13 @@ enum class CameraType
 struct CameraData
 {
   CameraType type = CameraType::STREAMING;
-  bool triggered{ false };
+
+  // Set by the trigger service for polled cameras to request a one-shot capture.
+  bool poll_requested{ false };
+
+  // Set when this camera is selected to render on the next pass and is waiting
+  // for the rendering thread to consume it, then clear it when rendering occurs.
+  bool render_pending{ false };
 
   mjvCamera mjv_cam;
   mjrRect viewport;
@@ -137,12 +143,26 @@ public:
   void cleanup() override;
 
   /**
-   * @brief Manually force the cameras to publish their updates.
+   * @brief Synchronously run a single render/publish cycle in the calling thread.
    *
-   * This is included for test purposes only, as the plumbing to manually force a data
-   * sync in WIP.
+   * This mirrors what the rendering thread does on each pass: streaming cameras are
+   * always selected, and polled cameras are selected only if their trigger service has
+   * been called since the last cycle. It is intended for tests, where it lets the camera
+   * selection logic be exercised deterministically without relying on the asynchronous
+   * rendering thread or a live GL context.
    */
   void trigger_update();
+
+  /**
+   * @brief Whether the rendering thread has successfully initialized its GL context.
+   *
+   * Primarily useful for tests that need to wait for the asynchronous rendering thread to
+   * come up before forcing a render.
+   */
+  bool is_rendering_available() const
+  {
+    return publish_images_.load();
+  }
 
 private:
   // ROS interfaces
@@ -164,7 +184,7 @@ private:
   void update_loop();
 
   /**
-   * @brief Updates the camera images and publishes info, images, and depth maps.
+   * @brief Renders and publishes every camera that is flagged to render.
    */
   void update_cameras();
 
@@ -190,9 +210,16 @@ private:
   const mjModel* mj_model_;
   mjData* mj_camera_data_;
 
-  // Image publishing rate
+  // Image publishing rate (applies to streaming cameras only)
   double camera_publish_rate_{ 5.0 };
   rclcpp::Time last_publish_time_{ 0, 0, RCL_ROS_TIME };
+
+  // Whether any streaming camera is registered. This lets the update loop skip the
+  // streaming time check entirely when only polled/disabled cameras exist.
+  bool has_streaming_cameras_{ false };
+
+  // Whether at least one polled camera has a pending trigger request.
+  std::atomic_bool poll_pending_{ false };
 
   // Rendering options for the cameras, currently hard coded to defaults
   mjvOption mjv_opt_;
@@ -206,9 +233,14 @@ private:
   // Containers for camera data and ROS constructs
   std::vector<CameraData> cameras_;
 
+  // List of camera indices to render on a given pass.
+  // Reserved once to the camera count so we do not allocate.
+  std::vector<size_t> render_indices_;
+
   // Camera processing thread and objects for syncing
   std::thread rendering_thread_;
   std::atomic_bool publish_images_{ false };
+  std::atomic_bool stop_requested_{ false };
   std::mutex data_mutex_;
   std::condition_variable data_cv_;
   bool new_data_{ false };

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -44,14 +44,25 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 
 namespace mujoco_ros2_control_plugins
 {
 
+enum class CameraType
+{
+  DISABLED = 0,  // Publishing is disabled.
+  STREAMING,     // Publishing is constant at the specified publish rate.
+  POLLED         // Publishing happens only when triggered by a service.
+};
+
 struct CameraData
 {
+  CameraType type = CameraType::STREAMING;
+  bool triggered{ false };
+
   mjvCamera mjv_cam;
   mjrRect viewport;
 
@@ -60,6 +71,7 @@ struct CameraData
   std::string info_topic;
   std::string image_topic;
   std::string depth_topic;
+  std::string trigger_service_name;
 
   uint32_t width;
   uint32_t height;
@@ -75,6 +87,8 @@ struct CameraData
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_image_pub;
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr trigger_service;
+  rclcpp::CallbackGroup::SharedPtr service_callback_group_;
 };
 
 /**
@@ -94,17 +108,19 @@ struct CameraData
  *   # All cameras will publish data at the same rate
  *   camera_publish_rate: 6.0
  *   <camera_name>:
+ *     camera_type: <camera_type>  # "disabled", "polled", or "streaming"
  *     frame_name: ""
  *     info_topic: <camera_name>/camera_info
  *     image_topic: <camera_name>/color
  *     depth_topic: <camera_name>/depth
+ *     trigger_service: <camera_name>/trigger
  *
  * Implementation notes
  * --------------------
  * If the camera name, in the parameters, does not match any of the mujoco cameras
  * the data will not be published to ROS topics.
  * If no cameras parameters are given (but mujoco_camera_plugin and its type are declared)
- * the default topics and frame are used automatically
+ * the default type (streaming), topics, and frame are used automatically.
  *
  */
 class CameraPlugin : public MuJoCoROS2ControlPluginBase
@@ -153,6 +169,19 @@ private:
    */
   void update_cameras();
 
+  /**
+   * @brief Renders and publishes data for a specific camera.
+   * @param camera The camera data structure.
+   */
+  void render_and_publish_camera(CameraData& camera);
+
+  /**
+   * @brief Handles a polled camera trigger to render and publish messages.
+   * @param camera The camera data structure.
+   */
+  void handle_trigger(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                      std::shared_ptr<std_srvs::srv::Trigger::Response> response, const int camera_idx);
+
   rclcpp::Node::SharedPtr node_;
 
   // Ensures locked access to simulation data for rendering.
@@ -170,6 +199,10 @@ private:
   mjvOption mjv_opt_;
   mjvScene mjv_scn_;
   mjrContext mjr_con_;
+
+  // Scene parameters to keep around to avoid recomputing
+  float camera_near_distance_;
+  float camera_depth_scale_;
 
   // Containers for camera data and ROS constructs
   std::vector<CameraData> cameras_;

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -88,7 +88,6 @@ struct CameraData
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_image_pub;
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr trigger_service;
-  rclcpp::CallbackGroup::SharedPtr service_callback_group_;
 };
 
 /**
@@ -96,7 +95,7 @@ struct CameraData
  *
  * Camera topics can be named in the ROS 2 controls plugins YAML config file
  * and loaded as node parameters.
- * If any of the parameters are not specified default topic names will be assigned.
+ * If any of the parameters are not specified, default topic names will be assigned.
  * A user can provide topic names for multiple cameras as long as cameras are not named the same.
  * Name collision is resolved by last name in the yaml file.
  *
@@ -113,7 +112,7 @@ struct CameraData
  *     info_topic: <camera_name>/camera_info
  *     image_topic: <camera_name>/color
  *     depth_topic: <camera_name>/depth
- *     trigger_service: <camera_name>/trigger
+ *     trigger_service_name: <camera_name>/trigger
  *
  * Implementation notes
  * --------------------

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -84,7 +84,6 @@ struct CameraData
 
   std::vector<uint8_t> image_buffer;
   std::vector<float> depth_buffer;
-  std::vector<float> depth_buffer_flipped;
 
   sensor_msgs::msg::Image image;
   sensor_msgs::msg::Image depth_image;
@@ -191,8 +190,9 @@ private:
   /**
    * @brief Renders and publishes data for a specific camera.
    * @param camera The camera data structure.
+   * @param stamp Timestamp applied to all messages published this step.
    */
-  void render_and_publish_camera(CameraData& camera);
+  void render_and_publish_camera(CameraData& camera, const rclcpp::Time& stamp);
 
   /**
    * @brief Handles a polled camera trigger to render and publish messages.

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/camera_plugin.hpp
@@ -117,7 +117,7 @@ struct CameraData
  *     info_topic: <camera_name>/camera_info
  *     image_topic: <camera_name>/color
  *     depth_topic: <camera_name>/depth
- *     trigger_service_name: <camera_name>/trigger
+ *     trigger_service_name: <camera_name>/trigger  # only used for polling camera type
  *
  * Implementation notes
  * --------------------

--- a/mujoco_ros2_control_plugins/package.xml
+++ b/mujoco_ros2_control_plugins/package.xml
@@ -26,6 +26,7 @@
   <depend>pluginlib</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>mujoco_ros2_control_msgs</depend>

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -487,6 +487,7 @@ void CameraPlugin::update_cameras()
     if ((camera.type == CameraType::STREAMING) || (camera.type == CameraType::POLLED && camera.triggered))
     {
       render_and_publish_camera(camera);
+      camera.triggered &= false;
     }
   }
 }

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -125,6 +125,32 @@ void CameraPlugin::register_cameras()
 
     const std::string param_ns = param_prefix + cam_name + ".";
 
+    const std::string type_param = param_ns + "camera_type";
+    if (!node_->has_parameter(type_param))
+    {
+      node_->declare_parameter(type_param, "streaming");
+    }
+    std::string type_str = node_->get_parameter(type_param).as_string();
+    if (type_str == "streaming")
+    {
+      camera.type = CameraType::STREAMING;
+    }
+    else if (type_str == "polled")
+    {
+      camera.type = CameraType::POLLED;
+    }
+    else if (type_str == "disabled")
+    {
+      camera.type = CameraType::DISABLED;
+    }
+    else
+    {
+      RCLCPP_ERROR(node_->get_logger(), "Invalid camera type for camera '%s': '%s'. Disabling.", cam_name,
+                   type_str.c_str());
+      camera.type = CameraType::DISABLED;
+      type_str = "disabled";
+    }
+
     const std::string frame_param = param_ns + "frame_name";
     if (!node_->has_parameter(frame_param))
     {
@@ -150,17 +176,38 @@ void CameraPlugin::register_cameras()
     }
     camera.depth_topic = node_->get_parameter(param_ns + "depth_topic").as_string();
 
-    RCLCPP_INFO(node_->get_logger(), "Adding camera: '%s'", cam_name);
-    RCLCPP_INFO(node_->get_logger(), "    frame_name: '%s'", camera.frame_name.c_str());
-    RCLCPP_INFO(node_->get_logger(), "    info_topic: '%s'", camera.info_topic.c_str());
-    RCLCPP_INFO(node_->get_logger(), "    image_topic: '%s'", camera.image_topic.c_str());
-    RCLCPP_INFO(node_->get_logger(), "    depth_topic: '%s'", camera.depth_topic.c_str());
+    if (!node_->has_parameter(param_ns + "trigger_service_name"))
+    {
+      node_->declare_parameter(param_ns + "trigger_service_name", camera.name + "/trigger");
+    }
+    camera.trigger_service_name = node_->get_parameter(param_ns + "trigger_service_name").as_string();
 
-    // Configure publishers
+    RCLCPP_INFO(node_->get_logger(), "Adding camera: '%s'", cam_name);
+    RCLCPP_INFO(node_->get_logger(), "    camera_type: '%s'", type_str.c_str());
+    RCLCPP_INFO(node_->get_logger(), "    frame_name: '%s'", camera.frame_name.c_str());
+    if (camera.type != CameraType::DISABLED)
+    {
+      RCLCPP_INFO(node_->get_logger(), "    info_topic: '%s'", camera.info_topic.c_str());
+      RCLCPP_INFO(node_->get_logger(), "    image_topic: '%s'", camera.image_topic.c_str());
+      RCLCPP_INFO(node_->get_logger(), "    depth_topic: '%s'", camera.depth_topic.c_str());
+      if (camera.type == CameraType::POLLED)
+      {
+        RCLCPP_INFO(node_->get_logger(), "    trigger_service_name: '%s'", camera.trigger_service_name.c_str());
+      }
+    }
+
+    // Configure publishers and services
     camera.camera_info_pub = node_->create_publisher<sensor_msgs::msg::CameraInfo>(camera.info_topic, 1);
     camera.image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.image_topic, 1);
     camera.depth_image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.depth_topic, 1);
-
+    if (camera.type == CameraType::POLLED)
+    {
+      camera.trigger_service = node_->create_service<std_srvs::srv::Trigger>(
+          camera.trigger_service_name, [this, i](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                                                 std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+            this->handle_trigger(request, response, i);
+          });
+    }
     // Setup containers for color image data
     camera.image.header.frame_id = camera.frame_name;
 
@@ -427,65 +474,75 @@ void CameraPlugin::update_loop()
 
 void CameraPlugin::update_cameras()
 {
-  // Step 1: Done in the `update` cb to copy rendering data
-  // Rendering is done offscreen
+  // Done in the `update` cb to copy rendering data
+  // Rendering is done offscreen,
   mjr_setBuffer(mjFB_OFFSCREEN, &mjr_con_);
 
-  // Step 2: Render the scene and copy images to relevant camera data containers.
-  for (auto& camera : cameras_)
-  {
-    // Render scene
-    mjv_updateScene(mj_model_, mj_camera_data_, &mjv_opt_, NULL, &camera.mjv_cam, mjCAT_ALL, &mjv_scn_);
-    mjr_render(camera.viewport, &mjv_scn_, &mjr_con_);
-
-    // Copy image into relevant buffers
-    mjr_readPixels(camera.image_buffer.data(), camera.depth_buffer.data(), camera.viewport, &mjr_con_);
-  }
-
-  // Step 3: Adjust the images and copy depth data.
-  const float near = static_cast<float>(mj_model_->vis.map.znear * mj_model_->stat.extent);
+  camera_near_distance_ = static_cast<float>(mj_model_->vis.map.znear * mj_model_->stat.extent);
   const float far = static_cast<float>(mj_model_->vis.map.zfar * mj_model_->stat.extent);
-  const float depth_scale = 1.0f - near / far;
+  camera_depth_scale_ = 1.0f - camera_near_distance_ / far;
+
   for (auto& camera : cameras_)
   {
-    // Fix non-linear projections in the depth image and flip the data.
-    // https://github.com/google-deepmind/mujoco/blob/3.4.0/python/mujoco/renderer.py#L190
-    for (uint32_t h = 0; h < camera.height; h++)
+    if ((camera.type == CameraType::STREAMING) || (camera.type == CameraType::POLLED && camera.triggered))
     {
-      for (uint32_t w = 0; w < camera.width; w++)
-      {
-        auto idx = h * camera.width + w;
-        auto idx_flipped = (camera.height - 1 - h) * camera.width + w;
-        camera.depth_buffer[idx] = near / (1.0f - camera.depth_buffer[idx] * (depth_scale));
-        camera.depth_buffer_flipped[idx_flipped] = camera.depth_buffer[idx];
-      }
-    }
-    // Copy flipped data into the depth image message, floats -> unsigned chars
-    std::memcpy(&camera.depth_image.data[0], camera.depth_buffer_flipped.data(), camera.depth_image.data.size());
-
-    // OpenGL's coordinate system's origin is in the bottom left, so we invert the images row-by-row
-    auto row_size = camera.width * 3;
-    for (uint32_t h = 0; h < camera.height; h++)
-    {
-      auto src_idx = h * row_size;
-      auto dest_idx = (camera.height - 1 - h) * row_size;
-      std::memcpy(&camera.image.data[dest_idx], &camera.image_buffer[src_idx], row_size);
+      render_and_publish_camera(camera);
     }
   }
+}
 
-  // Step 4: Publish the images.
-  for (auto& camera : cameras_)
+void CameraPlugin::render_and_publish_camera(CameraData& camera)
+{
+  // Step 1: Render the scene and copy images to relevant camera data containers.
+  // Render scene
+  mjv_updateScene(mj_model_, mj_camera_data_, &mjv_opt_, NULL, &camera.mjv_cam, mjCAT_ALL, &mjv_scn_);
+  mjr_render(camera.viewport, &mjv_scn_, &mjr_con_);
+
+  // Copy image into relevant buffers
+  mjr_readPixels(camera.image_buffer.data(), camera.depth_buffer.data(), camera.viewport, &mjr_con_);
+
+  // Step 2: Adjust the images and copy depth data.
+  // Fix non-linear projections in the depth image and flip the data.
+  // https://github.com/google-deepmind/mujoco/blob/3.4.0/python/mujoco/renderer.py#L190
+  for (uint32_t h = 0; h < camera.height; h++)
   {
-    // Publish images and camera info
-    const auto time = node_->now();
-    camera.image.header.stamp = time;
-    camera.depth_image.header.stamp = time;
-    camera.camera_info.header.stamp = time;
-
-    camera.image_pub->publish(camera.image);
-    camera.depth_image_pub->publish(camera.depth_image);
-    camera.camera_info_pub->publish(camera.camera_info);
+    for (uint32_t w = 0; w < camera.width; w++)
+    {
+      auto idx = h * camera.width + w;
+      auto idx_flipped = (camera.height - 1 - h) * camera.width + w;
+      camera.depth_buffer[idx] = camera_near_distance_ / (1.0f - camera.depth_buffer[idx] * camera_depth_scale_);
+      camera.depth_buffer_flipped[idx_flipped] = camera.depth_buffer[idx];
+    }
   }
+  // Copy flipped data into the depth image message, floats -> unsigned chars
+  std::memcpy(&camera.depth_image.data[0], camera.depth_buffer_flipped.data(), camera.depth_image.data.size());
+
+  // OpenGL's coordinate system's origin is in the bottom left, so we invert the images row-by-row
+  auto row_size = camera.width * 3;
+  for (uint32_t h = 0; h < camera.height; h++)
+  {
+    auto src_idx = h * row_size;
+    auto dest_idx = (camera.height - 1 - h) * row_size;
+    std::memcpy(&camera.image.data[dest_idx], &camera.image_buffer[src_idx], row_size);
+  }
+
+  // Step 3: Publish the images and camera info.
+  const auto time = node_->now();
+  camera.image.header.stamp = time;
+  camera.depth_image.header.stamp = time;
+  camera.camera_info.header.stamp = time;
+
+  camera.image_pub->publish(camera.image);
+  camera.depth_image_pub->publish(camera.depth_image);
+  camera.camera_info_pub->publish(camera.camera_info);
+}
+
+void CameraPlugin::handle_trigger(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                  std::shared_ptr<std_srvs::srv::Trigger::Response> response, const int camera_idx)
+{
+  auto& camera = cameras_.at(camera_idx);
+  camera.triggered = true;
+  response->success = true;
 }
 
 }  // namespace mujoco_ros2_control_plugins

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -67,21 +67,59 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
     return;
   }
 
-  // Check if it is time to publish
+  // Streaming cameras render on a fixed-rate clock; polled cameras render as soon as a
+  // trigger has been received. Both are serviced here, on the sim thread, because this is
+  // the only place we can safely snapshot the live mjData without racing the simulation.
   // TODO: Support per-camera publish rates?
-  auto now = node_->get_clock()->now();
-  if ((now - last_publish_time_).seconds() < (1.0 / camera_publish_rate_))
+  const auto now = node_->get_clock()->now();
+  const bool stream_due =
+      has_streaming_cameras_ && (now - last_publish_time_).seconds() >= (1.0 / camera_publish_rate_);
+  const bool poll_due = poll_pending_.load();
+
+  // Nothing to do this step: avoid taking the lock or copying data.
+  if (!stream_due && !poll_due)
   {
     return;
   }
-  last_publish_time_ = now;
 
+  bool any_selected = false;
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
-    mjv_copyData(mj_camera_data_, model_arg, data);
-    new_data_ = true;
+
+    // Flag streaming cameras when their interval is due and any polled cameras that have a
+    // pending trigger (consuming the one-shot request so they render exactly once).
+    for (auto& camera : cameras_)
+    {
+      if (camera.type == CameraType::STREAMING && stream_due)
+      {
+        camera.render_pending = true;
+        any_selected = true;
+      }
+      else if (camera.type == CameraType::POLLED && camera.poll_requested)
+      {
+        camera.poll_requested = false;
+        camera.render_pending = true;
+        any_selected = true;
+      }
+    }
+    poll_pending_ = false;
+    if (stream_due)
+    {
+      last_publish_time_ = now;
+    }
+
+    // Only snapshot the simulation data when there is actually a camera to render.
+    if (any_selected)
+    {
+      mjv_copyData(mj_camera_data_, model_arg, data);
+      new_data_ = true;
+    }
   }
-  data_cv_.notify_one();
+
+  if (any_selected)
+  {
+    data_cv_.notify_one();
+  }
 }
 
 void CameraPlugin::cleanup()
@@ -92,6 +130,19 @@ void CameraPlugin::cleanup()
 void CameraPlugin::trigger_update()
 {
   std::lock_guard<std::mutex> lock(data_mutex_);
+  // Force every streaming camera and consume any pending polls, then render synchronously.
+  for (auto& camera : cameras_)
+  {
+    if (camera.type == CameraType::STREAMING)
+    {
+      camera.render_pending = true;
+    }
+    else if (camera.type == CameraType::POLLED && camera.poll_requested)
+    {
+      camera.poll_requested = false;
+      camera.render_pending = true;
+    }
+  }
   update_cameras();
 }
 
@@ -249,12 +300,19 @@ void CameraPlugin::register_cameras()
     // Add to list of cameras
     cameras_.push_back(camera);
   }
+
+  has_streaming_cameras_ = std::any_of(cameras_.begin(), cameras_.end(),
+                                       [](const CameraData& cam) { return cam.type == CameraType::STREAMING; });
+
+  // Reserve once so the per-pass render bookkeeping in `update_cameras()` never allocates.
+  render_indices_.reserve(cameras_.size());
 }
 
 void CameraPlugin::close()
 {
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
+    stop_requested_ = true;
     publish_images_ = false;
   }
   data_cv_.notify_one();
@@ -436,8 +494,13 @@ void CameraPlugin::update_loop()
   RCLCPP_INFO(node_->get_logger(), "Resized offscreen buffer to %d x %d", max_width, max_height);
 
   // Only process images once all data has been initialized, and do it until told to stop.
-  publish_images_ = true;
-  while (rclcpp::ok() && publish_images_)
+  // Publishing is enabled under the lock so that a shutdown requested during the (possibly
+  // slow) initialization above is observed here rather than being clobbered.
+  {
+    std::lock_guard<std::mutex> lock(data_mutex_);
+    publish_images_ = !stop_requested_;
+  }
+  while (rclcpp::ok() && !stop_requested_)
   {
     std::unique_lock<std::mutex> lock(data_mutex_);
 
@@ -445,10 +508,10 @@ void CameraPlugin::update_loop()
     // images. Note that condition_variables can be awoken spuriously, so the additional
     // checks are necessary to avoid doing work excepting when updated rendering data has
     // been made available.
-    data_cv_.wait(lock, [this] { return new_data_ || !publish_images_; });
+    data_cv_.wait(lock, [this] { return new_data_ || stop_requested_; });
 
     // Shutdown triggered, kill the loop and clean up.
-    if (!publish_images_)
+    if (stop_requested_)
     {
       break;
     }
@@ -457,6 +520,7 @@ void CameraPlugin::update_loop()
 
     update_cameras();
   }
+  publish_images_ = false;
 
   mjv_freeScene(&mjv_scn_);
   mjr_freeContext(&mjr_con_);
@@ -474,21 +538,32 @@ void CameraPlugin::update_loop()
 
 void CameraPlugin::update_cameras()
 {
-  // Done in the `update` cb to copy rendering data
-  // Rendering is done offscreen,
+  // Gather the cameras flagged for rendering this pass, clearing the flag as we go.
+  render_indices_.clear();
+  for (size_t i = 0; i < cameras_.size(); ++i)
+  {
+    auto& camera = cameras_[i];
+    if (camera.render_pending)
+    {
+      camera.render_pending = false;
+      render_indices_.push_back(i);
+    }
+  }
+  if (render_indices_.empty())
+  {
+    return;
+  }
+
+  // Rendering is done offscreen using the data snapshot taken in `update`.
   mjr_setBuffer(mjFB_OFFSCREEN, &mjr_con_);
 
   camera_near_distance_ = static_cast<float>(mj_model_->vis.map.znear * mj_model_->stat.extent);
   const float far = static_cast<float>(mj_model_->vis.map.zfar * mj_model_->stat.extent);
   camera_depth_scale_ = 1.0f - camera_near_distance_ / far;
 
-  for (auto& camera : cameras_)
+  for (const auto idx : render_indices_)
   {
-    if ((camera.type == CameraType::STREAMING) || (camera.type == CameraType::POLLED && camera.triggered))
-    {
-      render_and_publish_camera(camera);
-      camera.triggered &= false;
-    }
+    render_and_publish_camera(cameras_[idx]);
   }
 }
 
@@ -541,8 +616,12 @@ void CameraPlugin::render_and_publish_camera(CameraData& camera)
 void CameraPlugin::handle_trigger(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
                                   std::shared_ptr<std_srvs::srv::Trigger::Response> response, const int camera_idx)
 {
-  auto& camera = cameras_.at(camera_idx);
-  camera.triggered = true;
+  {
+    std::lock_guard<std::mutex> lock(data_mutex_);
+    cameras_.at(camera_idx).poll_requested = true;
+  }
+  // Wake the fast path in `update()` so the request is picked up on the next sim step.
+  poll_pending_.store(true);
   response->success = true;
 }
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -200,7 +200,7 @@ bool CameraPlugin::register_cameras()
     }
     else
     {
-      RCLCPP_ERROR(node_->get_logger(), "Invalid policy for camera '%s': '%s'", cam_name);
+      RCLCPP_ERROR(node_->get_logger(), "Invalid policy for camera '%s'", cam_name);
       return false;
     }
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -236,17 +236,18 @@ bool CameraPlugin::register_cameras()
     camera.trigger_service_name = node_->get_parameter(param_ns + "trigger_service_name").as_string();
 
     RCLCPP_INFO(node_->get_logger(), "Adding camera: '%s'", cam_name);
-    RCLCPP_INFO(node_->get_logger(), "    camera_type: '%s'", policy_str.c_str());
+    RCLCPP_INFO(node_->get_logger(), "    policy: '%s'", policy_str.c_str());
     RCLCPP_INFO(node_->get_logger(), "    frame_name: '%s'", camera.frame_name.c_str());
-    if (camera.policy != CameraPolicy::DISABLED)
+    if (camera.policy == CameraPolicy::DISABLED)
     {
-      RCLCPP_INFO(node_->get_logger(), "    info_topic: '%s'", camera.info_topic.c_str());
-      RCLCPP_INFO(node_->get_logger(), "    image_topic: '%s'", camera.image_topic.c_str());
-      RCLCPP_INFO(node_->get_logger(), "    depth_topic: '%s'", camera.depth_topic.c_str());
-      if (camera.policy == CameraPolicy::POLLED)
-      {
-        RCLCPP_INFO(node_->get_logger(), "    trigger_service_name: '%s'", camera.trigger_service_name.c_str());
-      }
+      continue;
+    }
+    RCLCPP_INFO(node_->get_logger(), "    info_topic: '%s'", camera.info_topic.c_str());
+    RCLCPP_INFO(node_->get_logger(), "    image_topic: '%s'", camera.image_topic.c_str());
+    RCLCPP_INFO(node_->get_logger(), "    depth_topic: '%s'", camera.depth_topic.c_str());
+    if (camera.policy == CameraPolicy::POLLED)
+    {
+      RCLCPP_INFO(node_->get_logger(), "    trigger_service_name: '%s'", camera.trigger_service_name.c_str());
     }
 
     // Configure publishers and services

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -39,7 +39,11 @@ bool CameraPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjDa
   RCLCPP_INFO(node_->get_logger(), "CameraPlugin initializing cameras...");
 
   // Read the mj_model_, identify the number of cameras, and populate containers for them.
-  register_cameras();
+  if (!register_cameras())
+  {
+    RCLCPP_ERROR(node_->get_logger(), "Failed to register cameras.");
+    return false;
+  }
   if (cameras_.empty())
   {
     return true;
@@ -74,7 +78,7 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
   const auto now = node_->get_clock()->now();
   const bool stream_due =
       has_streaming_cameras_ && (now - last_publish_time_).seconds() >= (1.0 / camera_publish_rate_);
-  const bool poll_due = poll_pending_.load();
+  const bool poll_due = poll_pending_.exchange(false);
 
   // Nothing to do this step: avoid taking the lock or copying data.
   if (!stream_due && !poll_due)
@@ -90,19 +94,19 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
     // pending trigger (consuming the one-shot request so they render exactly once).
     for (auto& camera : cameras_)
     {
-      if (camera.type == CameraType::STREAMING && stream_due)
+      if (camera.policy == CameraPolicy::STREAMING && stream_due)
       {
         camera.render_pending = true;
         any_selected = true;
       }
-      else if (camera.type == CameraType::POLLED && camera.poll_requested)
+      else if (camera.policy == CameraPolicy::POLLED && camera.poll_requested)
       {
         camera.poll_requested = false;
         camera.render_pending = true;
         any_selected = true;
       }
     }
-    poll_pending_ = false;
+
     if (stream_due)
     {
       last_publish_time_ = now;
@@ -133,11 +137,11 @@ void CameraPlugin::trigger_update()
   // Force every streaming camera and consume any pending polls, then render synchronously.
   for (auto& camera : cameras_)
   {
-    if (camera.type == CameraType::STREAMING)
+    if (camera.policy == CameraPolicy::STREAMING)
     {
       camera.render_pending = true;
     }
-    else if (camera.type == CameraType::POLLED && camera.poll_requested)
+    else if (camera.policy == CameraPolicy::POLLED && camera.poll_requested)
     {
       camera.poll_requested = false;
       camera.render_pending = true;
@@ -146,7 +150,7 @@ void CameraPlugin::trigger_update()
   update_cameras();
 }
 
-void CameraPlugin::register_cameras()
+bool CameraPlugin::register_cameras()
 {
   const std::string param_prefix = "mujoco_plugins.mujoco_camera_plugin.";
 
@@ -176,30 +180,28 @@ void CameraPlugin::register_cameras()
 
     const std::string param_ns = param_prefix + cam_name + ".";
 
-    const std::string type_param = param_ns + "camera_type";
-    if (!node_->has_parameter(type_param))
+    const std::string policy_param = param_ns + "policy";
+    if (!node_->has_parameter(policy_param))
     {
-      node_->declare_parameter(type_param, "streaming");
+      node_->declare_parameter(policy_param, "streaming");
     }
-    std::string type_str = node_->get_parameter(type_param).as_string();
-    if (type_str == "streaming")
+    std::string policy_str = node_->get_parameter(policy_param).as_string();
+    if (policy_str == "streaming")
     {
-      camera.type = CameraType::STREAMING;
+      camera.policy = CameraPolicy::STREAMING;
     }
-    else if (type_str == "polled")
+    else if (policy_str == "polled")
     {
-      camera.type = CameraType::POLLED;
+      camera.policy = CameraPolicy::POLLED;
     }
-    else if (type_str == "disabled")
+    else if (policy_str == "disabled")
     {
-      camera.type = CameraType::DISABLED;
+      camera.policy = CameraPolicy::DISABLED;
     }
     else
     {
-      RCLCPP_ERROR(node_->get_logger(), "Invalid camera type for camera '%s': '%s'. Disabling.", cam_name,
-                   type_str.c_str());
-      camera.type = CameraType::DISABLED;
-      type_str = "disabled";
+      RCLCPP_ERROR(node_->get_logger(), "Invalid policy for camera '%s': '%s'", cam_name);
+      return false;
     }
 
     const std::string frame_param = param_ns + "frame_name";
@@ -234,14 +236,14 @@ void CameraPlugin::register_cameras()
     camera.trigger_service_name = node_->get_parameter(param_ns + "trigger_service_name").as_string();
 
     RCLCPP_INFO(node_->get_logger(), "Adding camera: '%s'", cam_name);
-    RCLCPP_INFO(node_->get_logger(), "    camera_type: '%s'", type_str.c_str());
+    RCLCPP_INFO(node_->get_logger(), "    camera_type: '%s'", policy_str.c_str());
     RCLCPP_INFO(node_->get_logger(), "    frame_name: '%s'", camera.frame_name.c_str());
-    if (camera.type != CameraType::DISABLED)
+    if (camera.policy != CameraPolicy::DISABLED)
     {
       RCLCPP_INFO(node_->get_logger(), "    info_topic: '%s'", camera.info_topic.c_str());
       RCLCPP_INFO(node_->get_logger(), "    image_topic: '%s'", camera.image_topic.c_str());
       RCLCPP_INFO(node_->get_logger(), "    depth_topic: '%s'", camera.depth_topic.c_str());
-      if (camera.type == CameraType::POLLED)
+      if (camera.policy == CameraPolicy::POLLED)
       {
         RCLCPP_INFO(node_->get_logger(), "    trigger_service_name: '%s'", camera.trigger_service_name.c_str());
       }
@@ -251,7 +253,7 @@ void CameraPlugin::register_cameras()
     camera.camera_info_pub = node_->create_publisher<sensor_msgs::msg::CameraInfo>(camera.info_topic, 1);
     camera.image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.image_topic, 1);
     camera.depth_image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.depth_topic, 1);
-    if (camera.type == CameraType::POLLED)
+    if (camera.policy == CameraPolicy::POLLED)
     {
       camera.trigger_service = node_->create_service<std_srvs::srv::Trigger>(
           camera.trigger_service_name, [this, i](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
@@ -301,10 +303,12 @@ void CameraPlugin::register_cameras()
   }
 
   has_streaming_cameras_ = std::any_of(cameras_.begin(), cameras_.end(),
-                                       [](const CameraData& cam) { return cam.type == CameraType::STREAMING; });
+                                       [](const CameraData& cam) { return cam.policy == CameraPolicy::STREAMING; });
 
   // Reserve once so the per-pass render bookkeeping in `update_cameras()` never allocates.
   render_indices_.reserve(cameras_.size());
+
+  return true;
 }
 
 void CameraPlugin::close()
@@ -560,9 +564,13 @@ void CameraPlugin::update_cameras()
   const float far = static_cast<float>(mj_model_->vis.map.zfar * mj_model_->stat.extent);
   camera_depth_scale_ = 1.0f - camera_near_distance_ / far;
 
+  // Use the snapshotted data's timestamp in the ROS header, as that is when the data was actually pulled.
+  const rclcpp::Duration duration = rclcpp::Duration::from_seconds(mj_camera_data_->time);
+  rclcpp::Time stamp(duration.nanoseconds(), RCL_ROS_TIME);
+
   for (const auto idx : render_indices_)
   {
-    render_and_publish_camera(cameras_[idx], node_->now());
+    render_and_publish_camera(cameras_[idx], stamp);
   }
 }
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -273,7 +273,6 @@ void CameraPlugin::register_cameras()
     // Depth image data
     camera.depth_image.header.frame_id = camera.frame_name;
     camera.depth_buffer.resize(camera.width * camera.height);
-    camera.depth_buffer_flipped.resize(camera.width * camera.height);
     camera.depth_image.data.resize(camera.width * camera.height * sizeof(float));
     camera.depth_image.width = camera.width;
     camera.depth_image.height = camera.height;
@@ -563,11 +562,11 @@ void CameraPlugin::update_cameras()
 
   for (const auto idx : render_indices_)
   {
-    render_and_publish_camera(cameras_[idx]);
+    render_and_publish_camera(cameras_[idx], node_->now());
   }
 }
 
-void CameraPlugin::render_and_publish_camera(CameraData& camera)
+void CameraPlugin::render_and_publish_camera(CameraData& camera, const rclcpp::Time& stamp)
 {
   // Step 1: Render the scene and copy images to relevant camera data containers.
   // Render scene
@@ -578,35 +577,32 @@ void CameraPlugin::render_and_publish_camera(CameraData& camera)
   mjr_readPixels(camera.image_buffer.data(), camera.depth_buffer.data(), camera.viewport, &mjr_con_);
 
   // Step 2: Adjust the images and copy depth data.
-  // Fix non-linear projections in the depth image and flip the data.
+  // Fix non-linear depth buffer and flip it vertically (OpenGL's origin is the bottom left)
   // https://github.com/google-deepmind/mujoco/blob/3.4.0/python/mujoco/renderer.py#L190
-  for (uint32_t h = 0; h < camera.height; h++)
+  auto* depth_out = reinterpret_cast<float*>(camera.depth_image.data.data());
+  for (uint32_t h = 0; h < camera.height; ++h)
   {
-    for (uint32_t w = 0; w < camera.width; w++)
+    const float* src_row = camera.depth_buffer.data() + static_cast<size_t>(h) * camera.width;
+    float* dst_row = depth_out + static_cast<size_t>(camera.height - 1 - h) * camera.width;
+    for (uint32_t w = 0; w < camera.width; ++w)
     {
-      auto idx = h * camera.width + w;
-      auto idx_flipped = (camera.height - 1 - h) * camera.width + w;
-      camera.depth_buffer[idx] = camera_near_distance_ / (1.0f - camera.depth_buffer[idx] * camera_depth_scale_);
-      camera.depth_buffer_flipped[idx_flipped] = camera.depth_buffer[idx];
+      dst_row[w] = camera_near_distance_ / (1.0f - src_row[w] * camera_depth_scale_);
     }
   }
-  // Copy flipped data into the depth image message, floats -> unsigned chars
-  std::memcpy(&camera.depth_image.data[0], camera.depth_buffer_flipped.data(), camera.depth_image.data.size());
 
   // OpenGL's coordinate system's origin is in the bottom left, so we invert the images row-by-row
-  auto row_size = camera.width * 3;
-  for (uint32_t h = 0; h < camera.height; h++)
+  const auto row_size = camera.width * 3;
+  for (uint32_t h = 0; h < camera.height; ++h)
   {
-    auto src_idx = h * row_size;
-    auto dest_idx = (camera.height - 1 - h) * row_size;
+    const auto src_idx = h * row_size;
+    const auto dest_idx = (camera.height - 1 - h) * row_size;
     std::memcpy(&camera.image.data[dest_idx], &camera.image_buffer[src_idx], row_size);
   }
 
   // Step 3: Publish the images and camera info.
-  const auto time = node_->now();
-  camera.image.header.stamp = time;
-  camera.depth_image.header.stamp = time;
-  camera.camera_info.header.stamp = time;
+  camera.image.header.stamp = stamp;
+  camera.depth_image.header.stamp = stamp;
+  camera.camera_info.header.stamp = stamp;
 
   camera.image_pub->publish(camera.image);
   camera.depth_image_pub->publish(camera.depth_image);

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -26,6 +26,7 @@
 
 #include <mujoco/mujoco.h>
 #include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 #include <mujoco_ros2_control_plugins/camera_plugin.hpp>
 
@@ -106,6 +107,22 @@ protected:
     ASSERT_NE(model_, nullptr) << "mj_loadXML failed: " << error;
     data_ = mj_makeData(model_);
     ASSERT_NE(data_, nullptr);
+  }
+
+  // Calls a Trigger service and returns whether the call succeeded.
+  bool call_trigger(const std::string& service_name)
+  {
+    auto client = node_->create_client<std_srvs::srv::Trigger>(service_name);
+    if (!client->wait_for_service(std::chrono::seconds(2)))
+    {
+      return false;
+    }
+    auto future = client->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
+    if (future.wait_for(std::chrono::seconds(2)) != std::future_status::ready)
+    {
+      return false;
+    }
+    return future.get()->success;
   }
 
   std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
@@ -193,6 +210,110 @@ TEST_F(CameraPluginTest, InitAndPublish)
   ASSERT_TRUE(received_image);
   ASSERT_TRUE(received_depth);
   ASSERT_TRUE(received_info);
+
+  plugin.cleanup();
+}
+
+// Only polled cameras should expose a trigger service; streaming cameras should not.
+TEST_F(CameraPluginTest, OnlyPolledCamerasCreateTriggerService)
+{
+  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.stream_cam.camera_type",
+                                  std::string("streaming"));
+  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.camera_type", std::string("polled"));
+  load_model(R"(<?xml version="1.0"?>
+<mujoco model="two_cameras">
+  <worldbody>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <camera name="stream_cam" pos="0 -1 1" xyaxes="1 0 0 0 0.707 0.707"
+            fovy="60" resolution="64 48"/>
+    <camera name="poll_cam" pos="0 1 1" xyaxes="-1 0 0 0 0.707 -0.707"
+            fovy="60" resolution="64 48"/>
+  </worldbody>
+</mujoco>
+)");
+  ASSERT_EQ(model_->ncam, 2);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));
+
+  // The polled camera's trigger service must come up.
+  auto poll_client = node_->create_client<std_srvs::srv::Trigger>("/camera_plugin/poll_cam/trigger");
+  EXPECT_TRUE(poll_client->wait_for_service(std::chrono::seconds(2)));
+
+  // The streaming camera must not have a trigger service registered.
+  const auto services = node_->get_service_names_and_types();
+  EXPECT_EQ(services.count("/camera_plugin/stream_cam/trigger"), 0u);
+
+  // Both cameras still publish their image/info topics.
+  EXPECT_EQ(plugin_node_->count_publishers("/camera_plugin/stream_cam/color"), 1u);
+  EXPECT_EQ(plugin_node_->count_publishers("/camera_plugin/poll_cam/color"), 1u);
+
+  plugin.cleanup();
+}
+
+// A polled camera must publish only in response to a trigger, never on the streaming clock,
+// and exactly once per trigger.
+TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
+{
+  load_model(R"(<?xml version="1.0"?>
+<mujoco model="polled_only">
+  <worldbody>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <camera name="poll_cam" pos="0 -1 1" xyaxes="1 0 0 0 0.707 0.707"
+            fovy="60" resolution="64 48"/>
+  </worldbody>
+</mujoco>
+)");
+  ASSERT_EQ(model_->ncam, 1);
+
+  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.camera_type", std::string("polled"));
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));
+
+  std::atomic<int> image_count{ 0 };
+  auto image_sub = node_->create_subscription<sensor_msgs::msg::Image>(
+      "/camera_plugin/poll_cam/color", 10, [&](sensor_msgs::msg::Image::SharedPtr) { ++image_count; });
+
+  // Wait for the rendering thread to come up (so a forced render is safe).
+  for (auto i = 0; i < 50 && !plugin.is_rendering_available(); ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  ASSERT_TRUE(plugin.is_rendering_available()) << "Rendering context unavailable in this environment";
+
+  // Without a trigger, running render cycles must not publish anything for a polled camera.
+  for (auto i = 0; i < 5; ++i)
+  {
+    plugin.trigger_update();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_EQ(image_count.load(), 0);
+
+  // Trigger once; the next render cycle should publish exactly one image.
+  ASSERT_TRUE(call_trigger("/camera_plugin/poll_cam/trigger"));
+  plugin.trigger_update();
+  for (auto i = 0; i < 20 && image_count.load() < 1; ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_EQ(image_count.load(), 1);
+
+  // The trigger is one-shot: subsequent render cycles without a new trigger publish nothing more.
+  for (auto i = 0; i < 5; ++i)
+  {
+    plugin.trigger_update();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_EQ(image_count.load(), 1);
 
   plugin.cleanup();
 }

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -217,9 +217,8 @@ TEST_F(CameraPluginTest, InitAndPublish)
 // Only polled cameras should expose a trigger service; streaming cameras should not.
 TEST_F(CameraPluginTest, OnlyPolledCamerasCreateTriggerService)
 {
-  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.stream_cam.camera_type",
-                                  std::string("streaming"));
-  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.camera_type", std::string("polled"));
+  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.stream_cam.policy", std::string("streaming"));
+  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.policy", std::string("polled"));
   load_model(R"(<?xml version="1.0"?>
 <mujoco model="two_cameras">
   <worldbody>
@@ -274,7 +273,7 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
 )");
   ASSERT_EQ(model_->ncam, 1);
 
-  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.camera_type", std::string("polled"));
+  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.policy", std::string("polled"));
 
   mujoco_ros2_control_plugins::CameraPlugin plugin;
   EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));


### PR DESCRIPTION
## Description

This PR adds more options to the camera plugin, specifically to allow "polled" cameras that only render and publish when calling a `std_srvs/Trigger` service.

Generally, there is now a new parameter where you can specify that cameras are streaming, polled, or disabled if you don't even want them to render/publish.

I also snuck in a change where you don't need an intermediate buffer of depth data to flip the coordinates; it can all be done in place. This speeds things up about ~33%!

### Is this user-facing behavior change?

No, the defaults are still that every camera is streaming.

### Did you use Generative AI?

Yes, I used Claude Opus 4.8 to help me iterate, debug, and write tests, but with extensive manual review, testing, and modification/cleanup.