### PR TITLE
Fix race condition on sim-display overlay text

### DIFF
--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -1276,8 +1276,7 @@ void MujocoSimulation::update_sim_display()
   sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, title, content);
 
   // Publish only after the vector is fully written; the release store pairs with
-  // the render thread's load so it never swaps a half-written vector. Publishing
-  // before writing was the heap-corruption race (bad_alloc / free: invalid pointer).
+  // the render thread's load.
   sim_->newtextrequest.store(1, std::memory_order_release);
 }
 

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -1249,16 +1249,13 @@ void MujocoSimulation::update_sim_display()
     return;
   }
 
-  // Only write user_texts_new_ when the render thread has consumed the previous
-  // update (newtextrequest == 0). Use compare_exchange to atomically claim the
-  // slot: if it fails, the render thread hasn't swapped yet, so skip this
-  // update — the display will be refreshed on the next physics step instead.
-  // This avoids a data race: the render thread swaps user_texts_new_ (without
-  // holding any mutex) while we clear/populate it.
-  int expected = 0;
-  if (!sim_->newtextrequest.compare_exchange_strong(expected, 1))
+  // Lock-free handoff to the render thread, which swaps user_texts_new_ without
+  // holding sim_->mtx (Simulate::Render runs outside the lock). newtextrequest is
+  // the single-producer/single-consumer flag: 0 = physics may write, 1 = render
+  // may consume. Skip if the last update hasn't been consumed yet.
+  if (sim_->newtextrequest.load(std::memory_order_acquire) != 0)
   {
-    return;  // render thread hasn't consumed the last update yet, skip
+    return;
   }
 
   // Desired speed: from parameter override when set, otherwise from the UI slider.
@@ -1277,6 +1274,11 @@ void MujocoSimulation::update_sim_display()
 
   sim_->user_texts_new_.clear();
   sim_->user_texts_new_.emplace_back(mjFONT_NORMAL, mjGRID_TOPRIGHT, title, content);
+
+  // Publish only after the vector is fully written; the release store pairs with
+  // the render thread's load so it never swaps a half-written vector. Publishing
+  // before writing was the heap-corruption race (bad_alloc / free: invalid pointer).
+  sim_->newtextrequest.store(1, std::memory_order_release);
 }
 
 }  // namespace mujoco_ros2_control


### PR DESCRIPTION
Fix heap corruption from a data race on the sim-display overlay text

## Problem

`update_sim_display()` (physics thread) publishes the `newtextrequest` flag before writing `user_texts_new_`. The render thread swaps that vector as soon as it sees `newtextrequest == 1` — and it does so outside `sim_->mtx` (Simulate::Render() runs after the mutex block in simulate.cc). So the render thread can clear()/swap() user_texts_new_ while the physics thread is still populating it: concurrent modification of a std::vector<std::tuple<…, std::string, std::string>>, which corrupts the heap and intermittently crashes in the render loop.

```
[ros2_control_node-2] terminate called after throwing an instance of 'std::bad_alloc'
[ros2_control_node-2]   what():  std::bad_alloc
[ros2_control_node-2] #2  mujoco_ros2_control::MujocoSystemInterface::PhysicsLoop()
[ros2_control_node-2] #1  mujoco_ros2_control::MujocoSystemInterface::update_sim_display()
[ros2_control_node-2] #9  mujoco::Simulate::Render()
[ros2_control_node-2] #0  __libc_free
[ros2_control_node-2] Segmentation fault (Address not mapped to object [0x3337353729])
```
(The fault address 0x3337353729 is ASCII "37357)" — a half-written overlay string being dereferenced as a pointer.)

## Fix

Order the handoff correctly using the existing `newtextrequest` atomic as a single-producer (physics) / single-consumer (render) flag: write the vector first, then publish with a release store, and only write when the previous update has been consumed (acquire load). The render thread's swap can no longer observe a partially-written vector.

No new synchronization is added; worst case a text update is skipped and refreshed on the next physics tick.