### PR TITLE
Fix state passed into pose sensors

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -911,14 +911,14 @@ hardware_interface::return_type MujocoSystemInterface::read(const rclcpp::Time& 
   // pose sensor data
   for (auto& data : pose_sensor_data_)
   {
-    data.position.data.x() = mj_data_control_->sensordata[data.position.mj_sensor_index];
-    data.position.data.y() = mj_data_control_->sensordata[data.position.mj_sensor_index + 1];
-    data.position.data.z() = mj_data_control_->sensordata[data.position.mj_sensor_index + 2];
+    data.position.data.x() = control_state_.sensordata[data.position.mj_sensor_index];
+    data.position.data.y() = control_state_.sensordata[data.position.mj_sensor_index + 1];
+    data.position.data.z() = control_state_.sensordata[data.position.mj_sensor_index + 2];
 
-    data.orientation.data.w() = mj_data_control_->sensordata[data.orientation.mj_sensor_index];
-    data.orientation.data.x() = mj_data_control_->sensordata[data.orientation.mj_sensor_index + 1];
-    data.orientation.data.y() = mj_data_control_->sensordata[data.orientation.mj_sensor_index + 2];
-    data.orientation.data.z() = mj_data_control_->sensordata[data.orientation.mj_sensor_index + 3];
+    data.orientation.data.w() = control_state_.sensordata[data.orientation.mj_sensor_index];
+    data.orientation.data.x() = control_state_.sensordata[data.orientation.mj_sensor_index + 1];
+    data.orientation.data.y() = control_state_.sensordata[data.orientation.mj_sensor_index + 2];
+    data.orientation.data.z() = control_state_.sensordata[data.orientation.mj_sensor_index + 3];
   }
 
   // Publish Odometry

--- a/mujoco_ros2_control/tests/CMakeLists.txt
+++ b/mujoco_ros2_control/tests/CMakeLists.txt
@@ -7,6 +7,13 @@ target_link_libraries(test_mujoco_simulation
   rclcpp::rclcpp
 )
 
+ament_add_gtest(test_mujoco_system_interface test_mujoco_system_interface.cpp)
+target_link_libraries(test_mujoco_system_interface
+  mujoco_ros2_control
+  rclcpp::rclcpp
+  hardware_interface::hardware_interface
+)
+
 ament_add_gtest(test_plugin test_plugin.cpp)
 target_link_libraries(test_plugin
   mujoco_ros2_control

--- a/mujoco_ros2_control/tests/test_headless_init.cpp
+++ b/mujoco_ros2_control/tests/test_headless_init.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
@@ -113,6 +114,11 @@ protected:
   <actuator>
     <velocity name="actuator1" site="site1"/>
   </actuator>
+
+  <sensor>
+    <framepos name="pose_sensor_pos" objtype="site" objname="site1"/>
+    <framequat name="pose_sensor_quat" objtype="site" objname="site1"/>
+  </sensor>
 </mujoco>
 )";
     file.close();
@@ -256,6 +262,82 @@ TEST_F(HeadlessInitTest, SpeedFactorParamInitialization)
 
   // sim_time should have advanced from zero
   EXPECT_GT(test_data->time, 0.0) << "Simulation time did not advance with sim_speed_factor=0.5";
+}
+
+TEST_F(HeadlessInitTest, PoseSensorStateInterfacesRead)
+{
+  // Register a pose sensor mapped to the framepos/framequat sensors in the MJCF model.
+  hardware_interface::ComponentInfo sensor_info;
+  sensor_info.name = "pose_sensor";
+  sensor_info.parameters["mujoco_type"] = "pose";
+  for (const auto* interface_name :
+       { "position.x", "position.y", "position.z", "orientation.x", "orientation.y", "orientation.z", "orientation.w" })
+  {
+    hardware_interface::InterfaceInfo interface_info;
+    interface_info.name = interface_name;
+    sensor_info.state_interfaces.push_back(interface_info);
+  }
+  hardware_info_.sensors.push_back(sensor_info);
+
+#if ROS_DISTRO_HUMBLE
+  auto result = interface_->on_init(hardware_info_);
+#else
+  hardware_interface::HardwareComponentInterfaceParams params;
+  params.hardware_info = hardware_info_;
+  auto result = interface_->on_init(params);
+#endif
+  ASSERT_EQ(result, hardware_interface::CallbackReturn::SUCCESS);
+
+  // Wait for the model to load and for the physics loop to advance, so that the
+  // simulation has computed and published sensor data at least once.
+  auto start = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(2);
+  mjModel* test_model = nullptr;
+  mjData* test_data = nullptr;
+  while (std::chrono::steady_clock::now() - start < timeout)
+  {
+    interface_->get_model(test_model);
+    interface_->get_data(test_data);
+    if (test_model != nullptr && test_data != nullptr && test_data->time > 0.0)
+    {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_NE(test_model, nullptr) << "Model failed to initialize within timeout";
+  ASSERT_NE(test_data, nullptr) << "Data failed to initialize within timeout";
+  ASSERT_GT(test_data->time, 0.0) << "Simulation time did not advance within timeout";
+
+  // read() should pull the latest sensor values into the exported state interfaces.
+  interface_->read(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002));
+
+  // The pose sensor is the only component registered, so its interfaces are exported
+  // in registration order: position.x/y/z, orientation.x/y/z/w.
+  const auto state_interfaces = interface_->export_state_interfaces();
+  ASSERT_EQ(state_interfaces.size(), 7u);
+  ASSERT_EQ(state_interfaces[0].get_name(), "pose_sensor/position.x");
+  ASSERT_EQ(state_interfaces[6].get_name(), "pose_sensor/orientation.w");
+
+#if ROS_DISTRO_HUMBLE
+  const double position_x = state_interfaces[0].get_value();
+  const double qx = state_interfaces[3].get_value();
+  const double qy = state_interfaces[4].get_value();
+  const double qz = state_interfaces[5].get_value();
+  const double qw = state_interfaces[6].get_value();
+#else
+  const double position_x = state_interfaces[0].get_optional().value();
+  const double qx = state_interfaces[3].get_optional().value();
+  const double qy = state_interfaces[4].get_optional().value();
+  const double qz = state_interfaces[5].get_optional().value();
+  const double qw = state_interfaces[6].get_optional().value();
+#endif
+
+  // The site sits on a body that starts upright at x=0.2, so the pose should be a
+  // unit quaternion and a position near the initial pose.
+  const double tol = 1e-3;
+  const double quat_norm = std::sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+  EXPECT_NEAR(quat_norm, 1.0, tol);
+  EXPECT_NEAR(position_x, 0.2, tol);
 }
 
 TEST(SimDisplayTextTest, ComposesAllRowsWhenRunning)

--- a/mujoco_ros2_control/tests/test_headless_init.cpp
+++ b/mujoco_ros2_control/tests/test_headless_init.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
@@ -114,11 +113,6 @@ protected:
   <actuator>
     <velocity name="actuator1" site="site1"/>
   </actuator>
-
-  <sensor>
-    <framepos name="pose_sensor_pos" objtype="site" objname="site1"/>
-    <framequat name="pose_sensor_quat" objtype="site" objname="site1"/>
-  </sensor>
 </mujoco>
 )";
     file.close();
@@ -262,82 +256,6 @@ TEST_F(HeadlessInitTest, SpeedFactorParamInitialization)
 
   // sim_time should have advanced from zero
   EXPECT_GT(test_data->time, 0.0) << "Simulation time did not advance with sim_speed_factor=0.5";
-}
-
-TEST_F(HeadlessInitTest, PoseSensorStateInterfacesRead)
-{
-  // Register a pose sensor mapped to the framepos/framequat sensors in the MJCF model.
-  hardware_interface::ComponentInfo sensor_info;
-  sensor_info.name = "pose_sensor";
-  sensor_info.parameters["mujoco_type"] = "pose";
-  for (const auto* interface_name :
-       { "position.x", "position.y", "position.z", "orientation.x", "orientation.y", "orientation.z", "orientation.w" })
-  {
-    hardware_interface::InterfaceInfo interface_info;
-    interface_info.name = interface_name;
-    sensor_info.state_interfaces.push_back(interface_info);
-  }
-  hardware_info_.sensors.push_back(sensor_info);
-
-#if ROS_DISTRO_HUMBLE
-  auto result = interface_->on_init(hardware_info_);
-#else
-  hardware_interface::HardwareComponentInterfaceParams params;
-  params.hardware_info = hardware_info_;
-  auto result = interface_->on_init(params);
-#endif
-  ASSERT_EQ(result, hardware_interface::CallbackReturn::SUCCESS);
-
-  // Wait for the model to load and for the physics loop to advance, so that the
-  // simulation has computed and published sensor data at least once.
-  auto start = std::chrono::steady_clock::now();
-  auto timeout = std::chrono::seconds(2);
-  mjModel* test_model = nullptr;
-  mjData* test_data = nullptr;
-  while (std::chrono::steady_clock::now() - start < timeout)
-  {
-    interface_->get_model(test_model);
-    interface_->get_data(test_data);
-    if (test_model != nullptr && test_data != nullptr && test_data->time > 0.0)
-    {
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_NE(test_model, nullptr) << "Model failed to initialize within timeout";
-  ASSERT_NE(test_data, nullptr) << "Data failed to initialize within timeout";
-  ASSERT_GT(test_data->time, 0.0) << "Simulation time did not advance within timeout";
-
-  // read() should pull the latest sensor values into the exported state interfaces.
-  interface_->read(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002));
-
-  // The pose sensor is the only component registered, so its interfaces are exported
-  // in registration order: position.x/y/z, orientation.x/y/z/w.
-  const auto state_interfaces = interface_->export_state_interfaces();
-  ASSERT_EQ(state_interfaces.size(), 7u);
-  ASSERT_EQ(state_interfaces[0].get_name(), "pose_sensor/position.x");
-  ASSERT_EQ(state_interfaces[6].get_name(), "pose_sensor/orientation.w");
-
-#if ROS_DISTRO_HUMBLE
-  const double position_x = state_interfaces[0].get_value();
-  const double qx = state_interfaces[3].get_value();
-  const double qy = state_interfaces[4].get_value();
-  const double qz = state_interfaces[5].get_value();
-  const double qw = state_interfaces[6].get_value();
-#else
-  const double position_x = state_interfaces[0].get_optional().value();
-  const double qx = state_interfaces[3].get_optional().value();
-  const double qy = state_interfaces[4].get_optional().value();
-  const double qz = state_interfaces[5].get_optional().value();
-  const double qw = state_interfaces[6].get_optional().value();
-#endif
-
-  // The site sits on a body that starts upright at x=0.2, so the pose should be a
-  // unit quaternion and a position near the initial pose.
-  const double tol = 1e-3;
-  const double quat_norm = std::sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
-  EXPECT_NEAR(quat_norm, 1.0, tol);
-  EXPECT_NEAR(position_x, 0.2, tol);
 }
 
 TEST(SimDisplayTextTest, ComposesAllRowsWhenRunning)

--- a/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <thread>
+
+#include <hardware_interface/version.h>
+#include <mujoco/mujoco.h>
+#include <hardware_interface/hardware_info.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <mujoco_ros2_control/mujoco_system_interface.hpp>
+
+#define ROS_DISTRO_HUMBLE (HARDWARE_INTERFACE_VERSION_MAJOR < 3)
+
+namespace
+{
+
+// Pendulum model with framepos/framequat sensors on a site at the pendulum body origin.
+constexpr const char* kTestModel = R"(<?xml version="1.0"?>
+<mujoco model="test_system_interface">
+  <option timestep="0.002"/>
+
+  <worldbody>
+    <body name="pendulum" pos="0 0 1">
+      <joint name="hinge" type="hinge" axis="0 1 0"/>
+      <geom type="capsule" size="0.02" fromto="0 0 0 0.3 0 0" mass="1"/>
+      <site name="pendulum_site"/>
+    </body>
+  </worldbody>
+
+  <sensor>
+    <framepos name="pose_sensor_pos" objtype="site" objname="pendulum_site"/>
+    <framequat name="pose_sensor_quat" objtype="site" objname="pendulum_site"/>
+  </sensor>
+</mujoco>
+)";
+
+// Write to disk for testing
+const std::string kTestModelPath = "/tmp/test_mujoco_system_interface_model.xml";
+void write_test_model()
+{
+  std::ofstream file(kTestModelPath);
+  file << kTestModel;
+  file.close();
+}
+
+}  // namespace
+
+class MujocoSystemInterfaceTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  static void TearDownTestSuite()
+  {
+    if (rclcpp::ok())
+    {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override
+  {
+    write_test_model();
+    interface_ = std::make_shared<mujoco_ros2_control::MujocoSystemInterface>();
+  }
+
+  void TearDown() override
+  {
+    // Deactivate interface before destroying to stop threads cleanly
+    if (interface_)
+    {
+      rclcpp_lifecycle::State inactive_state(0, "inactive");
+      interface_->on_deactivate(inactive_state);
+      interface_.reset();
+    }
+
+    // Clean up test files if present
+    if (std::filesystem::exists(kTestModelPath))
+    {
+      std::filesystem::remove(kTestModelPath);
+    }
+  }
+
+  // Create the hardware info to initialize the interface with, in headless mode.
+  hardware_interface::HardwareInfo create_hardware_info()
+  {
+    hardware_interface::HardwareInfo info;
+    info.name = "test_mujoco_system_interface";
+    info.type = "system";
+    info.hardware_parameters["mujoco_model"] = kTestModelPath;
+    info.hardware_parameters["meshdir"] = "";
+    info.hardware_parameters["headless"] = "true";
+    info.hardware_parameters["disable_rendering"] = "true";
+    return info;
+  }
+
+  // Initialize the interface with the given hardware info.
+  hardware_interface::CallbackReturn initialize_interface(const hardware_interface::HardwareInfo& hardware_info)
+  {
+#if ROS_DISTRO_HUMBLE
+    return interface_->on_init(hardware_info);
+#else
+    hardware_interface::HardwareComponentInterfaceParams params;
+    params.hardware_info = hardware_info;
+    return interface_->on_init(params);
+#endif
+  }
+
+  // Helper function to poll a condition until it returns true or the timeout expires.
+  bool wait_until(std::function<bool()> condition, std::chrono::milliseconds timeout = std::chrono::seconds(5),
+                  std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      if (condition())
+        return true;
+      std::this_thread::sleep_for(poll_interval);
+    }
+    return condition();
+  }
+
+  std::shared_ptr<mujoco_ros2_control::MujocoSystemInterface> interface_;
+};
+
+TEST_F(MujocoSystemInterfaceTest, PoseSensorStateInterfacesRead)
+{
+  // Register a pose sensor mapped to the framepos/framequat sensors in the MJCF model.
+  auto hardware_info = create_hardware_info();
+  hardware_interface::ComponentInfo sensor_info;
+  sensor_info.name = "pose_sensor";
+  sensor_info.parameters["mujoco_type"] = "pose";
+  for (const auto* interface_name :
+       { "position.x", "position.y", "position.z", "orientation.x", "orientation.y", "orientation.z", "orientation.w" })
+  {
+    hardware_interface::InterfaceInfo interface_info;
+    interface_info.name = interface_name;
+    sensor_info.state_interfaces.push_back(interface_info);
+  }
+  hardware_info.sensors.push_back(sensor_info);
+
+  ASSERT_EQ(initialize_interface(hardware_info), hardware_interface::CallbackReturn::SUCCESS);
+
+  // Wait for the model to load and for the physics loop to advance, so that the
+  // simulation has computed and published sensor data at least once.
+  mjModel* model = nullptr;
+  mjData* data = nullptr;
+  ASSERT_TRUE(wait_until([&]() {
+    interface_->get_model(model);
+    interface_->get_data(data);
+    return model != nullptr && data != nullptr && data->time > 0.0;
+  })) << "Simulation did not start stepping";
+
+  // read() should pull the latest sensor values into the exported state interfaces.
+  interface_->read(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002));
+
+  // The pose sensor is the only component registered, so its interfaces are exported
+  // in registration order: position.x/y/z, orientation.x/y/z/w.
+  const auto state_interfaces = interface_->export_state_interfaces();
+  ASSERT_EQ(state_interfaces.size(), 7u);
+  ASSERT_EQ(state_interfaces[0].get_name(), "pose_sensor/position.x");
+  ASSERT_EQ(state_interfaces[1].get_name(), "pose_sensor/position.y");
+  ASSERT_EQ(state_interfaces[2].get_name(), "pose_sensor/position.z");
+  ASSERT_EQ(state_interfaces[3].get_name(), "pose_sensor/orientation.x");
+  ASSERT_EQ(state_interfaces[4].get_name(), "pose_sensor/orientation.y");
+  ASSERT_EQ(state_interfaces[5].get_name(), "pose_sensor/orientation.z");
+  ASSERT_EQ(state_interfaces[6].get_name(), "pose_sensor/orientation.w");
+
+#if ROS_DISTRO_HUMBLE
+  const double position_z = state_interfaces[2].get_value();
+  const double qx = state_interfaces[3].get_value();
+  const double qy = state_interfaces[4].get_value();
+  const double qz = state_interfaces[5].get_value();
+  const double qw = state_interfaces[6].get_value();
+#else
+  const double position_z = state_interfaces[2].get_optional().value();
+  const double qx = state_interfaces[3].get_optional().value();
+  const double qy = state_interfaces[4].get_optional().value();
+  const double qz = state_interfaces[5].get_optional().value();
+  const double qw = state_interfaces[6].get_optional().value();
+#endif
+
+  // The site sits at the pendulum body origin at height 1.0, so the pose should be
+  // a valid unit quaternion and a position fixed at the hinge point.
+  const double tol = 1e-3;
+  const double quat_norm = std::sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+  EXPECT_NEAR(quat_norm, 1.0, tol);
+  EXPECT_NEAR(position_z, 1.0, tol);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/mujoco_ros2_control_demos/demo_resources/robot/test_robot.xml
+++ b/mujoco_ros2_control_demos/demo_resources/robot/test_robot.xml
@@ -74,8 +74,8 @@
   </equality>
   <sensor>
     <rangefinder name="lidar" site="rf"/>
-    <framequat name="body_quat" objtype="site" objname="base"/>
-    <framepos name="body_pos" objtype="site" objname="base"/>
+    <framequat name="body_quat" objtype="site" objname="ee_link"/>
+    <framepos name="body_pos" objtype="site" objname="ee_link"/>
   </sensor>
   <keyframe>
     <key name="start_90" time="422.274" qpos="1.57 -1.57 -0.02 0.02" qvel="0 0 0 0" ctrl="1.57 -1.57 -0.02"/>


### PR DESCRIPTION
## Description

This PR addresses a bug that got through with https://github.com/ros-controls/mujoco_ros2_control/pull/224, in that the pose sensors were getting data from the wrong state data structure.

Also included a regression test since this was not caught in the former PR.

Fixes https://github.com/ros-controls/mujoco_ros2_control/issues/230

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes, Claude Fable 5 to help generate a test.

If there are more idiomatic uses of ros2_control syntax for the test, I'm open to suggestions. 