### PR TITLE
Make CI tests more robust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
         run: |
           docker run --rm \
             -e EGL_PLATFORM=surfaceless \
+            -e LIBGL_ALWAYS_SOFTWARE=1 \
+            -e MESA_LOADER_DRIVER_OVERRIDE=llvmpipe \
             ${{ steps.meta.outputs.tags }} \
             bash -c "
               colcon test &&
@@ -105,6 +107,8 @@ jobs:
             -w /workspace \
             -e SCCACHE_DIR=/workspace/.sccache \
             -e EGL_PLATFORM=surfaceless \
+            -e LIBGL_ALWAYS_SOFTWARE=1 \
+            -e MESA_LOADER_DRIVER_OVERRIDE=llvmpipe \
             mujoco_ros2_control_pixi:ci \
             bash -c "
               pixi run setup-colcon && \

--- a/mujoco_extensions/mujoco_3d_lidar/src/3dlidar.cpp
+++ b/mujoco_extensions/mujoco_3d_lidar/src/3dlidar.cpp
@@ -296,6 +296,9 @@ Lidar::Lidar(const mjModel* m, mjData* d, int instance, int resolution[2], mjtNu
     result_buf_.resize(dimension_, -1.0);
     rotated_vecs_copy_.resize(dimension_ * 3);
   }
+
+  // Set the time point to a valid number
+  d->plugin_state[m->plugin_stateadr[instance]] = 0.0;
 }
 
 Lidar::~Lidar()

--- a/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.cpp
@@ -305,9 +305,11 @@ void Mujoco3dLidarPlugin::update(const mjModel* /* model */, mjData* data)
 {
   for (Lidar3dConfig& lidar : lidar_sensors_)
   {
-    // Check for new sensor data, and skip if not yet computed or if it is stale
+    // Check for new sensor data, and skip if not yet computed, stale, or otherwise
+    // invalid. This will explicitly skip the 0th timepoint, since that is not a valid
+    // point for a scan, anyway.
     mjtNum compute_time = data->plugin_state[lidar.plugin_stateadr];
-    if (compute_time < 0.0 || compute_time == lidar.last_published_time)
+    if (!(compute_time > lidar.last_published_time))
     {
       continue;
     }

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -30,9 +30,14 @@
 
 #include "camera_plugin.hpp"
 
+using namespace std::chrono_literals;
+
 class CameraPluginTest : public ::testing::Test
 {
 protected:
+  static constexpr auto WAIT_TIMEOUT = 2s;
+  static constexpr auto POLL_INTERVAL = 20ms;
+
   static void SetUpTestSuite()
   {
     if (!rclcpp::ok())
@@ -109,16 +114,16 @@ protected:
     ASSERT_NE(data_, nullptr);
   }
 
-  // Blocks until the rendering thread has finished initializing its GL context, or skip
-  // the test if the context never comes up because of a bad CI instance...
+  // Blocks until the rendering thread has finished initializing its GL context.
   void wait_for_rendering(mujoco_ros2_control_plugins::CameraPlugin& plugin)
   {
-    for (int i = 0; i < 100 && !plugin.is_rendering_available(); ++i)
+    const auto deadline = std::chrono::steady_clock::now() + WAIT_TIMEOUT;
+    while (!plugin.is_rendering_available() && std::chrono::steady_clock::now() < deadline)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      std::this_thread::sleep_for(POLL_INTERVAL);
     }
     // TODO: We could optionally skip the test in CI if this happens consistently. Though
-    // for now we hope that failures do to uninitialized contexts will be extremely rare.
+    // for now we hope that failures due to uninitialized contexts will be extremely rare.
     // https://github.com/ros-controls/mujoco_ros2_control/issues/216
     ASSERT_TRUE(plugin.is_rendering_available()) << "OpenGL rendering unavailable in this environment!!! Failing...";
   }
@@ -128,23 +133,24 @@ protected:
   void wait_for_subscriber_match(const Subs&... subs)
   {
     auto all_matched = [&]() { return ((subs->get_publisher_count() > 0) && ...); };
-    for (int i = 0; i < 50 && !all_matched(); ++i)
+    const auto deadline = std::chrono::steady_clock::now() + WAIT_TIMEOUT;
+    while (!all_matched() && std::chrono::steady_clock::now() < deadline)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      std::this_thread::sleep_for(POLL_INTERVAL);
     }
-    ASSERT_TRUE(all_matched()) << "Subscribers never matched publishers within 2 s";
+    ASSERT_TRUE(all_matched()) << "Subscribers never matched publishers within timeout";
   }
 
   // Calls a Trigger service and returns whether the call succeeded.
   bool call_trigger(const std::string& service_name)
   {
     auto client = node_->create_client<std_srvs::srv::Trigger>(service_name);
-    if (!client->wait_for_service(std::chrono::seconds(2)))
+    if (!client->wait_for_service(WAIT_TIMEOUT))
     {
       return false;
     }
     auto future = client->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
-    if (future.wait_for(std::chrono::seconds(2)) != std::future_status::ready)
+    if (future.wait_for(WAIT_TIMEOUT) != std::future_status::ready)
     {
       return false;
     }
@@ -205,7 +211,7 @@ TEST_F(CameraPluginTest, InitAndPublish)
   // GLFW is not initialized, and No OpenGL framebuffer will be available so we make the init fall back on to EGL.
   EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));
 
-  // Wait for the rendering thread to come up... If it doesn't we're going to skip this
+  // Wait for the rendering thread to come up
   wait_for_rendering(plugin);
 
   // Verify publishers were created
@@ -228,13 +234,11 @@ TEST_F(CameraPluginTest, InitAndPublish)
   wait_for_subscriber_match(image_sub, depth_sub, info_sub);
 
   // Force a publish and verify we get results
-  plugin.trigger_update();
-  for (auto i = 0; i < 20; ++i)
+  const auto deadline = std::chrono::steady_clock::now() + WAIT_TIMEOUT;
+  while (!(received_image && received_depth && received_info) && std::chrono::steady_clock::now() < deadline)
   {
-    if (received_image && received_depth && received_info)
-      break;
     plugin.trigger_update();
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(POLL_INTERVAL);
   }
 
   ASSERT_TRUE(received_image);
@@ -271,7 +275,7 @@ TEST_F(CameraPluginTest, OnlyPolledCamerasCreateTriggerService)
 
   // The polled camera's trigger service must come up.
   auto poll_client = node_->create_client<std_srvs::srv::Trigger>("/camera_plugin/poll_cam/trigger");
-  EXPECT_TRUE(poll_client->wait_for_service(std::chrono::seconds(2)));
+  EXPECT_TRUE(poll_client->wait_for_service(WAIT_TIMEOUT));
 
   // The streaming camera must not have a trigger service registered.
   const auto services = node_->get_service_names_and_types();
@@ -312,7 +316,7 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   auto image_sub = node_->create_subscription<sensor_msgs::msg::Image>(
       "/camera_plugin/poll_cam/color", 10, [&](sensor_msgs::msg::Image::SharedPtr) { ++image_count; });
 
-  // Wait for the rendering thread to come up... If it doesn't we're going to skip this
+  // Wait for the rendering thread to come up
   wait_for_rendering(plugin);
 
   // Ensure publishers are connected to subscribers
@@ -322,16 +326,19 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   for (auto i = 0; i < 5; ++i)
   {
     plugin.trigger_update();
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    std::this_thread::sleep_for(POLL_INTERVAL);
   }
   EXPECT_EQ(image_count.load(), 0);
 
   // Trigger once; the next render cycle should publish exactly one image.
   ASSERT_TRUE(call_trigger("/camera_plugin/poll_cam/trigger"));
   plugin.trigger_update();
-  for (auto i = 0; i < 20 && image_count.load() < 1; ++i)
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    const auto deadline = std::chrono::steady_clock::now() + WAIT_TIMEOUT;
+    while (image_count.load() < 1 && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(POLL_INTERVAL);
+    }
   }
   EXPECT_EQ(image_count.load(), 1);
 
@@ -339,7 +346,7 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   for (auto i = 0; i < 5; ++i)
   {
     plugin.trigger_update();
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    std::this_thread::sleep_for(POLL_INTERVAL);
   }
   EXPECT_EQ(image_count.load(), 1);
 

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -109,6 +109,33 @@ protected:
     ASSERT_NE(data_, nullptr);
   }
 
+  // Blocks until the rendering thread has finished initializing its GL context, or skip
+  // the test if the context never comes up because of a bad CI instance...
+  void wait_for_rendering(mujoco_ros2_control_plugins::CameraPlugin& plugin)
+  {
+    for (int i = 0; i < 50 && !plugin.is_rendering_available(); ++i)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!plugin.is_rendering_available())
+    {
+      plugin.cleanup();
+      GTEST_SKIP() << "OpenGL rendering unavailable in this environment!!! Skipping tests...";
+    }
+  }
+
+  // Block until every subscription in the list has matched at least one publisher.
+  template <typename... Subs>
+  void wait_for_subscriber_match(const Subs&... subs)
+  {
+    auto all_matched = [&]() { return ((subs->get_publisher_count() > 0) && ...); };
+    for (int i = 0; i < 50 && !all_matched(); ++i)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(all_matched()) << "Subscribers never matched publishers within 2 s";
+  }
+
   // Calls a Trigger service and returns whether the call succeeded.
   bool call_trigger(const std::string& service_name)
   {
@@ -178,7 +205,9 @@ TEST_F(CameraPluginTest, InitAndPublish)
   mujoco_ros2_control_plugins::CameraPlugin plugin;
   // GLFW is not initialized, and No OpenGL framebuffer will be available so we make the init fall back on to EGL.
   EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Wait for the rendering thread to come up... If it doesn't we're going to skip this
+  wait_for_rendering(plugin);
 
   // Verify publishers were created
   EXPECT_EQ(plugin_node_->count_publishers("/camera_plugin/test_cam/color"), 1u);
@@ -190,12 +219,14 @@ TEST_F(CameraPluginTest, InitAndPublish)
   std::atomic<bool> received_depth{ false };
   std::atomic<bool> received_info{ false };
   auto image_sub = node_->create_subscription<sensor_msgs::msg::Image>(
-      "/camera_plugin/test_cam/color", 1, [&](sensor_msgs::msg::Image::SharedPtr msg) { received_image = true; });
+      "/camera_plugin/test_cam/color", 1, [&](sensor_msgs::msg::Image::SharedPtr) { received_image = true; });
   auto depth_sub = node_->create_subscription<sensor_msgs::msg::Image>(
-      "/camera_plugin/test_cam/depth", 1, [&](sensor_msgs::msg::Image::SharedPtr msg) { received_depth = true; });
+      "/camera_plugin/test_cam/depth", 1, [&](sensor_msgs::msg::Image::SharedPtr) { received_depth = true; });
   auto info_sub = node_->create_subscription<sensor_msgs::msg::CameraInfo>(
-      "/camera_plugin/test_cam/camera_info", 1,
-      [&](sensor_msgs::msg::CameraInfo::SharedPtr msg) { received_info = true; });
+      "/camera_plugin/test_cam/camera_info", 1, [&](sensor_msgs::msg::CameraInfo::SharedPtr) { received_info = true; });
+
+  // Ensure publishers are connected to subscribers
+  wait_for_subscriber_match(image_sub, depth_sub, info_sub);
 
   // Force a publish and verify we get results
   plugin.trigger_update();
@@ -282,12 +313,11 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   auto image_sub = node_->create_subscription<sensor_msgs::msg::Image>(
       "/camera_plugin/poll_cam/color", 10, [&](sensor_msgs::msg::Image::SharedPtr) { ++image_count; });
 
-  // Wait for the rendering thread to come up (so a forced render is safe).
-  for (auto i = 0; i < 50 && !plugin.is_rendering_available(); ++i)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-  ASSERT_TRUE(plugin.is_rendering_available()) << "Rendering context unavailable in this environment";
+  // Wait for the rendering thread to come up... If it doesn't we're going to skip this
+  wait_for_rendering(plugin);
+
+  // Ensure publishers are connected to subscribers
+  wait_for_subscriber_match(image_sub);
 
   // Without a trigger, running render cycles must not publish anything for a polled camera.
   for (auto i = 0; i < 5; ++i)

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -113,15 +113,14 @@ protected:
   // the test if the context never comes up because of a bad CI instance...
   void wait_for_rendering(mujoco_ros2_control_plugins::CameraPlugin& plugin)
   {
-    for (int i = 0; i < 50 && !plugin.is_rendering_available(); ++i)
+    for (int i = 0; i < 100 && !plugin.is_rendering_available(); ++i)
     {
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
     }
-    if (!plugin.is_rendering_available())
-    {
-      plugin.cleanup();
-      GTEST_SKIP() << "OpenGL rendering unavailable in this environment!!! Skipping tests...";
-    }
+    // TODO: We could optionally skip the test in CI if this happens consistently. Though
+    // for now we hope that failures do to uninitialized contexts will be extremely rare.
+    // https://github.com/ros-controls/mujoco_ros2_control/issues/216
+    ASSERT_TRUE(plugin.is_rendering_available()) << "OpenGL rendering unavailable in this environment!!! Failing...";
   }
 
   // Block until every subscription in the list has matched at least one publisher.


### PR DESCRIPTION
## Description

Fixes #236 and #216

* Lidar should instantiate the timestamps to a valid, non nan number so that we don't get the negative value if the first update comes before the plugin as finished its compute.
* Rendering contexts in CI are... difficult. For now we ensure that we're using software rendering and llvmpipe in the running image, hopefully that makes mesa more predictable for the camera tests. I also added subscriber connection checks since we've seen errors there, too.
