### PR TITLE
MuJoCo free joints state publisher plugin

### DIFF
--- a/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins.yaml
+++ b/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins.yaml
@@ -4,6 +4,10 @@
       heart_beat_plugin:
         type: "mujoco_ros2_control_plugins/HeartbeatPublisherPlugin"
         update_rate: 1.0
+      free_joint_state_publisher:
+        type: "mujoco_ros2_control_plugins/FreeJointStatePublisherPlugin"
+        frame_id: ""
+        publish_rate: 50.0
       mujoco_camera_plugin:
         type: "mujoco_ros2_control_plugins/CameraPlugin"
         camera_publish_rate: 6.0

--- a/mujoco_ros2_control_msgs/CMakeLists.txt
+++ b/mujoco_ros2_control_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ set(msg_files
   msg/ExternalWrench.msg
   msg/ExternalWrenchArray.msg
   msg/FreeJointState.msg
+  msg/FreeJointStateArray.msg
 )
 
 set(srv_files

--- a/mujoco_ros2_control_msgs/msg/FreeJointStateArray.msg
+++ b/mujoco_ros2_control_msgs/msg/FreeJointStateArray.msg
@@ -1,0 +1,10 @@
+# Snapshot of the pose and velocity of one or more MuJoCo free-joint bodies, as published by
+# the FreeJointStatePublisherPlugin.
+
+# Time the snapshot was taken and, in `frame_id`, the reference frame every entry's
+# `pose.header.frame_id` / `twist.header.frame_id` is expressed in: empty means the world frame,
+# otherwise the name of the MuJoCo body the poses/twists are relative to.
+std_msgs/Header header
+
+# One entry per published free-joint body.
+FreeJointState[] free_joints

--- a/mujoco_ros2_control_plugins/CMakeLists.txt
+++ b/mujoco_ros2_control_plugins/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(mujoco_ros2_control_plugins INTERFACE
 add_library(mujoco_ros2_control_plugins_impl SHARED
   src/heartbeat_publisher_plugin.cpp
   src/external_wrench_plugin.cpp
+  src/free_joint_state_publisher_plugin.cpp
   src/camera_plugin.cpp
   src/mujoco_3d_lidar_plugin.cpp
   # TODO: Remove once this has been fully deprecated

--- a/mujoco_ros2_control_plugins/CMakeLists.txt
+++ b/mujoco_ros2_control_plugins/CMakeLists.txt
@@ -110,6 +110,22 @@ if(BUILD_TESTING)
     "LINKER:--pop-state"
   )
 
+  ament_add_gtest(test_free_joint_state_publisher_plugin
+    test/test_free_joint_state_publisher_plugin.cpp
+  )
+  target_include_directories(test_free_joint_state_publisher_plugin PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_free_joint_state_publisher_plugin
+    mujoco_ros2_control_plugins_impl
+    ${mujoco_ros2_control_msgs_TARGETS}
+  )
+  target_link_options(test_free_joint_state_publisher_plugin PUBLIC
+    "LINKER:--push-state,--no-as-needed"
+    "$<TARGET_LINKER_FILE:tinyxml2::tinyxml2>"
+    "LINKER:--pop-state"
+  )
+
   ament_add_gtest(test_camera_plugin
     test/test_camera_plugin.cpp
   )

--- a/mujoco_ros2_control_plugins/README.md
+++ b/mujoco_ros2_control_plugins/README.md
@@ -14,6 +14,7 @@ Full documentation is maintained in RST format:
 |---|---|
 | `HeartbeatPublisherPlugin` | Publishes a heartbeat string to `/mujoco_heartbeat` at 1 Hz |
 | `ExternalWrenchPlugin` | Applies external wrenches to MuJoCo bodies via a ROS 2 service |
+| `FreeJointStatePublisherPlugin` | Publishes the pose/velocity of free-joint bodies to a topic, in a selectable reference frame |
 
 ## Quick Start
 

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -285,6 +285,90 @@ ExternalWrench Parameters
            force_arrow_scale: 0.01      # 100 N  → 1 m arrow
            torque_arrow_scale: 0.1      # 10 N·m → 1 m arrow
 
+FreeJointStatePublisherPlugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Publishes the pose and velocity of every MuJoCo free-joint body (loose objects, unattached
+links, etc.) or a user-selected subset to a single topic, in a user-selectable reference
+frame.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 0
+
+   * - **Topic**
+     - ``free_joint_states`` (``mujoco_ros2_control_msgs/msg/FreeJointStateArray``), configurable
+       via the ``topic`` parameter
+
+Each published entry uses the same ``FreeJointState`` layout as the ``~/set_free_joint_state``
+service (see :ref:`simulation_topics_and_services`), so a received message's ``free_joints``
+field can be fed straight into a ``SetFreeJointState`` request to reproduce the snapshotted
+state.
+
+Frame semantics
+^^^^^^^^^^^^^^^
+
+When ``frame_id`` is empty (the default), poses and twists are expressed in the **world** frame.
+When it names another MuJoCo body, poses are expressed relative to that body's current world
+pose, and twists are rotated into that body's current world orientation — the reference body's
+own velocity is **not** subtracted, exactly mirroring how ``~/set_free_joint_state`` interprets a
+non-empty ``frame_id``. This means a message published in frame ``X`` can be sent straight back
+to ``~/set_free_joint_state`` with the same ``frame_id`` to recover the identical world-frame
+state.
+
+If ``frame_id`` names an unknown body, the plugin logs an error and falls back to the world frame
+(published entries then carry an empty ``frame_id``, reflecting the frame actually used).
+
+FreeJointStatePublisher Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 25 15 15 45
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``frame_id``
+     - ``string``
+     - ``""``
+     - Name of the MuJoCo body every published pose/twist is expressed relative to. Empty means
+       the world frame.
+   * - ``body_names``
+     - ``string[]``
+     - ``[]``
+     - Names of the free-joint bodies to publish. Empty means every free-joint body in the model.
+       An unknown or non-free-joint name here fails plugin initialization.
+   * - ``topic``
+     - ``string``
+     - ``free_joint_states``
+     - Output topic name.
+   * - ``publish_rate``
+     - ``double``
+     - ``50.0``
+     - Publish frequency in Hz.
+
+**Example configuration**
+
+.. code-block:: yaml
+
+   /**:
+     ros__parameters:
+       mujoco_plugins:
+         free_joint_state_publisher:
+           type: "mujoco_ros2_control_plugins/FreeJointStatePublisherPlugin"
+           frame_id: ""              # world frame; set to a body name to publish relative poses
+           body_names: []            # empty = all free-joint bodies
+           topic: "free_joint_states"
+           publish_rate: 50.0
+
+**Example: monitoring free-joint bodies**
+
+.. code-block:: bash
+
+   ros2 topic echo /mujoco_ros2_control_node/free_joint_state_publisher/free_joint_states
+
 RangefinderLidarPlugin
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins.xml
+++ b/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins.xml
@@ -29,6 +29,17 @@
       Multiple concurrent wrenches on different or the same bodies are supported.
     </description>
   </class>
+  <class name="mujoco_ros2_control_plugins/FreeJointStatePublisherPlugin"
+         type="mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin"
+         base_class_type="mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase">
+    <description>
+      Publishes the pose and velocity of every MuJoCo free-joint body (or a user-selected subset,
+      via the body_names parameter) to a single topic, as
+      mujoco_ros2_control_msgs/msg/FreeJointStateArray. The reference frame the poses/twists are
+      expressed in is chosen with the frame_id parameter; it defaults to the world frame when
+      unset.
+    </description>
+  </class>
   <class name="mujoco_ros2_control_plugins/Mujoco3dLidarPlugin"
          type="mujoco_ros2_control_plugins::Mujoco3dLidarPlugin"
          base_class_type="mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase">

--- a/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.cpp
@@ -1,0 +1,236 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "free_joint_state_publisher_plugin.hpp"
+
+#include <algorithm>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace mujoco_ros2_control_plugins
+{
+
+bool FreeJointStatePublisherPlugin::collect_free_joint_entries(const std::vector<std::string>& body_names)
+{
+  entries_.clear();
+
+  // Enumerate every free joint in the model
+  std::vector<FreeJointEntry> all_free_joints;
+  for (int i = 0; i < model_->njnt; ++i)
+  {
+    if (model_->jnt_type[i] == mjJNT_FREE)
+    {
+      FreeJointEntry entry;
+      entry.body_id = model_->jnt_bodyid[i];
+      const char* name = mj_id2name(model_, mjOBJ_BODY, entry.body_id);
+      entry.body_name = name ? name : "";
+      entry.qpos_adr = model_->jnt_qposadr[i];
+      entry.qvel_adr = model_->jnt_dofadr[i];
+      all_free_joints.push_back(entry);
+    }
+  }
+
+  if (body_names.empty())
+  {
+    entries_ = std::move(all_free_joints);
+    return true;
+  }
+
+  entries_.reserve(body_names.size());
+  for (const auto& requested_name : body_names)
+  {
+    const auto it = std::find_if(all_free_joints.begin(), all_free_joints.end(),
+                                 [&requested_name](const FreeJointEntry& e) { return e.body_name == requested_name; });
+    if (it == all_free_joints.end())
+    {
+      RCLCPP_ERROR(logger_, "body_names entry '%s' is not a body driven by a free joint in this MuJoCo model.",
+                   requested_name.c_str());
+      return false;
+    }
+    entries_.push_back(*it);
+  }
+  return true;
+}
+
+int FreeJointStatePublisherPlugin::resolve_frame_id(const std::string& frame_id) const
+{
+  if (frame_id.empty())
+  {
+    return -1;
+  }
+
+  const int body_id = mj_name2id(model_, mjOBJ_BODY, frame_id.c_str());
+  if (body_id == -1)
+  {
+    RCLCPP_ERROR(logger_, "Unknown frame_id body name: '%s'. Falling back to the world frame.", frame_id.c_str());
+  }
+  return body_id;
+}
+
+bool FreeJointStatePublisherPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* /*data*/)
+{
+  node_ = node;
+  model_ = model;
+  logger_ = node_->get_logger().get_child(node->get_sub_namespace());
+
+  if (!node_->has_parameter("frame_id"))
+  {
+    node_->declare_parameter("frame_id", std::string(""));
+  }
+  if (!node_->has_parameter("body_names"))
+  {
+    node_->declare_parameter("body_names", std::vector<std::string>{});
+  }
+  if (!node_->has_parameter("topic"))
+  {
+    node_->declare_parameter("topic", std::string("free_joint_states"));
+  }
+  if (!node_->has_parameter("publish_rate"))
+  {
+    node_->declare_parameter("publish_rate", 50.0);
+  }
+
+  const std::string frame_id = node_->get_parameter("frame_id").as_string();
+  const std::vector<std::string> body_names = node_->get_parameter("body_names").as_string_array();
+  const std::string topic = node_->get_parameter("topic").as_string();
+  const double publish_rate = node_->get_parameter("publish_rate").as_double();
+
+  if (publish_rate <= 0.0)
+  {
+    RCLCPP_ERROR(logger_, "publish_rate must be > 0, got %f.", publish_rate);
+    return false;
+  }
+
+  if (!collect_free_joint_entries(body_names))
+  {
+    return false;
+  }
+
+  // Resolved once here: the reference body's identity never changes
+  frame_body_id_ = resolve_frame_id(frame_id);
+  effective_frame_id_ = (frame_body_id_ == -1) ? "" : frame_id;
+
+  publish_period_ = rclcpp::Duration::from_seconds(1.0 / publish_rate);
+  last_publish_time_ = node_->get_clock()->now();
+
+  message_.free_joints.resize(entries_.size());
+  for (std::size_t i = 0; i < entries_.size(); ++i)
+  {
+    message_.free_joints[i].name = entries_[i].body_name;
+  }
+
+  publisher_raw_ = node_->create_publisher<FreeJointStateArray>(topic, rclcpp::SystemDefaultsQoS());
+  publisher_ = std::make_unique<realtime_tools::RealtimePublisher<FreeJointStateArray>>(publisher_raw_);
+
+  RCLCPP_INFO(logger_,
+              "FreeJointStatePublisherPlugin initialized: publishing %zu free-joint bod%s to '%s' at %.1f Hz "
+              "in the '%s' frame.",
+              entries_.size(), entries_.size() == 1 ? "y" : "ies", publisher_raw_->get_topic_name(), publish_rate,
+              effective_frame_id_.empty() ? "world" : effective_frame_id_.c_str());
+
+  return true;
+}
+
+void FreeJointStatePublisherPlugin::update(const mjModel* /*model*/, mjData* data)
+{
+  const rclcpp::Time now = node_->get_clock()->now();
+  if (now - last_publish_time_ < publish_period_)
+  {
+    return;
+  }
+  last_publish_time_ = now;
+
+  // Pre-compute the reference frame's inverse world pose/orientation once per publish, reused
+  // for every body below.
+  mjtNum inv_frame_pos[3] = { 0.0, 0.0, 0.0 };
+  mjtNum inv_frame_quat[4] = { 1.0, 0.0, 0.0, 0.0 };
+  mjtNum neg_frame_quat[4] = { 1.0, 0.0, 0.0, 0.0 };
+  if (frame_body_id_ != -1)
+  {
+    mju_negPose(inv_frame_pos, inv_frame_quat, data->xpos + 3 * frame_body_id_, data->xquat + 4 * frame_body_id_);
+    mju_negQuat(neg_frame_quat, data->xquat + 4 * frame_body_id_);
+  }
+
+  message_.header.stamp = now;
+
+  for (std::size_t i = 0; i < entries_.size(); ++i)
+  {
+    const FreeJointEntry& entry = entries_[i];
+    auto& out = message_.free_joints[i];
+
+    const mjtNum* world_pos = data->qpos + entry.qpos_adr;
+    const mjtNum* world_quat = data->qpos + entry.qpos_adr + 3;
+    const mjtNum* world_linvel = data->qvel + entry.qvel_adr;
+    const mjtNum* world_angvel = data->qvel + entry.qvel_adr + 3;
+
+    mjtNum rel_pos[3];
+    mjtNum rel_quat[4];
+    mjtNum rel_linvel[3];
+    mjtNum rel_angvel[3];
+
+    if (frame_body_id_ == -1)
+    {
+      mju_copy3(rel_pos, world_pos);
+      mju_copy4(rel_quat, world_quat);
+      mju_copy3(rel_linvel, world_linvel);
+      mju_copy3(rel_angvel, world_angvel);
+    }
+    else
+    {
+      // (world = frame ∘ relative): relative = frame⁻¹ ∘ world.
+      mju_mulPose(rel_pos, rel_quat, inv_frame_pos, inv_frame_quat, world_pos, world_quat);
+      mju_rotVecQuat(rel_linvel, world_linvel, neg_frame_quat);
+      mju_rotVecQuat(rel_angvel, world_angvel, neg_frame_quat);
+    }
+
+    out.pose.header.stamp = now;
+    out.pose.header.frame_id = effective_frame_id_;
+    out.pose.pose.position.x = rel_pos[0];
+    out.pose.pose.position.y = rel_pos[1];
+    out.pose.pose.position.z = rel_pos[2];
+    out.pose.pose.orientation.w = rel_quat[0];
+    out.pose.pose.orientation.x = rel_quat[1];
+    out.pose.pose.orientation.y = rel_quat[2];
+    out.pose.pose.orientation.z = rel_quat[3];
+
+    out.twist.header.stamp = now;
+    out.twist.header.frame_id = effective_frame_id_;
+    out.twist.twist.linear.x = rel_linvel[0];
+    out.twist.twist.linear.y = rel_linvel[1];
+    out.twist.twist.linear.z = rel_linvel[2];
+    out.twist.twist.angular.x = rel_angvel[0];
+    out.twist.twist.angular.y = rel_angvel[1];
+    out.twist.twist.angular.z = rel_angvel[2];
+  }
+
+#if REALTIME_TOOLS_VERSION_MAJOR > 2
+  publisher_->try_publish(message_);
+#else
+  publisher_->tryPublish(message_);
+#endif
+}
+
+void FreeJointStatePublisherPlugin::cleanup()
+{
+  RCLCPP_INFO(logger_, "FreeJointStatePublisherPlugin cleanup.");
+  publisher_.reset();
+  publisher_raw_.reset();
+  node_.reset();
+}
+
+}  // namespace mujoco_ros2_control_plugins
+
+// Export the plugin
+PLUGINLIB_EXPORT_CLASS(mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin,
+                       mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase)

--- a/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.hpp
@@ -1,0 +1,105 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_ROS2_CONTROL_PLUGINS__FREE_JOINT_STATE_PUBLISHER_PLUGIN_HPP_
+#define MUJOCO_ROS2_CONTROL_PLUGINS__FREE_JOINT_STATE_PUBLISHER_PLUGIN_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <mujoco_ros2_control_msgs/msg/free_joint_state_array.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <realtime_tools/realtime_publisher.hpp>
+
+#include "mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp"
+
+namespace mujoco_ros2_control_plugins
+{
+
+/**
+ * @brief Plugin that publishes the pose and velocity of every MuJoCo free-joint body (or a
+ *        user-selected subset) to a single topic, in a user-selectable reference frame.
+ *
+ * Publishes mujoco_ros2_control_msgs/msg/FreeJointStateArray on the configurable ``topic``
+ * parameter.
+ *
+ * Parameters
+ * ----------
+ *   frame_id      - Name of the MuJoCo body every published pose/twist is expressed relative to.
+ *                   Empty (the default) means the world frame.
+ *   body_names    - Names of the free-joint bodies to publish. Empty (the default) means every
+ *                   free-joint body in the model.
+ *   topic         - Output topic name. Defaults to "free_joint_states".
+ *   publish_rate  - Publish frequency in Hz. Defaults to 50.0.
+ *
+ * Frame semantics
+ * ---------------
+ * When `frame_id` names another body, poses are expressed relative to that body's current world
+ * pose, and twists are rotated into that body's current world orientation *without* subtracting
+ * the reference body's own velocity.
+ */
+class FreeJointStatePublisherPlugin : public MuJoCoROS2ControlPluginBase
+{
+public:
+  FreeJointStatePublisherPlugin() = default;
+  ~FreeJointStatePublisherPlugin() override = default;
+
+  bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
+  void update(const mjModel* model, mjData* data) override;
+  void cleanup() override;
+
+private:
+  using FreeJointStateArray = mujoco_ros2_control_msgs::msg::FreeJointStateArray;
+
+  /// A single free-joint body cached at init() time.
+  struct FreeJointEntry
+  {
+    int body_id{ -1 };
+    std::string body_name;
+    int qpos_adr{ -1 };  /// Index into mjData::qpos
+    int qvel_adr{ -1 };  /// Index into mjData::qvel
+  };
+
+  /// Scans the model for free joints and populates entries_, applying the body_names filter
+  /// (if any). Returns false (logging an error) if a requested body name is invalid.
+  bool collect_free_joint_entries(const std::vector<std::string>& body_names);
+
+  /// Resolves frame_id to a body id (-1 for world)
+  int resolve_frame_id(const std::string& frame_id) const;
+
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Logger logger_{ rclcpp::get_logger("FreeJointStatePublisherPlugin") };
+
+  const mjModel* model_{ nullptr };
+
+  rclcpp::Publisher<FreeJointStateArray>::SharedPtr publisher_raw_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<FreeJointStateArray>> publisher_;
+
+  std::vector<FreeJointEntry> entries_;
+
+  /// Reference frame body id resolved once in init(); -1 means the world frame.
+  int frame_body_id_{ -1 };
+  std::string effective_frame_id_;
+
+  rclcpp::Duration publish_period_{ 0, 0 };
+  rclcpp::Time last_publish_time_{ 0, 0, RCL_ROS_TIME };
+
+  /// Reused across update() calls to avoid reallocating the entries vector every publish.
+  FreeJointStateArray message_;
+};
+
+}  // namespace mujoco_ros2_control_plugins
+
+#endif  // MUJOCO_ROS2_CONTROL_PLUGINS__FREE_JOINT_STATE_PUBLISHER_PLUGIN_HPP_

--- a/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
@@ -1,0 +1,358 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <mujoco/mujoco.h>
+#include <mujoco_ros2_control_msgs/msg/free_joint_state_array.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "free_joint_state_publisher_plugin.hpp"
+
+namespace
+{
+// Two free bodies (free_a, free_b) plus a fixed reference body (ref_frame) offset and rotated
+// from the world origin, used to exercise non-world reference frame transforms.
+constexpr const char* kMjcf = R"(
+<mujoco model="free_joint_state_publisher_test">
+  <worldbody>
+    <body name="ref_frame" pos="1 0 0" quat="0.70710678 0 0 0.70710678">
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <body name="free_a" pos="0 0 1">
+      <freejoint/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+    <body name="free_b" pos="2 0 1">
+      <freejoint/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+}  // namespace
+
+class FreeJointStatePublisherPluginTest : public ::testing::Test
+{
+protected:
+  using FreeJointStateArray = mujoco_ros2_control_msgs::msg::FreeJointStateArray;
+
+  static void SetUpTestCase()
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  static void TearDownTestCase()
+  {
+    if (rclcpp::ok())
+    {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override
+  {
+    node_ = std::make_shared<rclcpp::Node>("free_joint_state_publisher_test_node");
+    plugin_node_ = node_->create_sub_node("free_joint_state_publisher_plugin");
+
+    executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+
+    char error[1024] = { 0 };
+    mjSpec* spec = mj_parseXMLString(kMjcf, nullptr, error, sizeof(error));
+    ASSERT_NE(spec, nullptr) << error;
+
+    model_ = mj_compile(spec, nullptr);
+    if (model_ == nullptr)
+    {
+      const char* ce = mjs_getError(spec);
+      mj_deleteSpec(spec);
+      FAIL() << (ce ? ce : "mj_compile failed");
+    }
+    mj_deleteSpec(spec);
+
+    data_ = mj_makeData(model_);
+    ASSERT_NE(data_, nullptr);
+    mj_forward(model_, data_);
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable())
+    {
+      spin_thread_.join();
+    }
+    executor_.reset();
+    plugin_node_.reset();
+    node_.reset();
+    mj_deleteData(data_);
+    data_ = nullptr;
+    mj_deleteModel(model_);
+    model_ = nullptr;
+  }
+
+  /// Sets the qpos/qvel of the free joint driving `body_name`. Fails the test if the body is
+  /// not driven by a free joint.
+  void setFreeJointState(const std::string& body_name, const mjtNum pos[3], const mjtNum quat[4],
+                        const mjtNum linvel[3], const mjtNum angvel[3])
+  {
+    const int body_id = mj_name2id(model_, mjOBJ_BODY, body_name.c_str());
+    ASSERT_GE(body_id, 0) << body_name;
+    for (int i = 0; i < model_->njnt; ++i)
+    {
+      if (model_->jnt_bodyid[i] == body_id && model_->jnt_type[i] == mjJNT_FREE)
+      {
+        const int qadr = model_->jnt_qposadr[i];
+        const int vadr = model_->jnt_dofadr[i];
+        data_->qpos[qadr + 0] = pos[0];
+        data_->qpos[qadr + 1] = pos[1];
+        data_->qpos[qadr + 2] = pos[2];
+        data_->qpos[qadr + 3] = quat[0];
+        data_->qpos[qadr + 4] = quat[1];
+        data_->qpos[qadr + 5] = quat[2];
+        data_->qpos[qadr + 6] = quat[3];
+        data_->qvel[vadr + 0] = linvel[0];
+        data_->qvel[vadr + 1] = linvel[1];
+        data_->qvel[vadr + 2] = linvel[2];
+        data_->qvel[vadr + 3] = angvel[0];
+        data_->qvel[vadr + 4] = angvel[1];
+        data_->qvel[vadr + 5] = angvel[2];
+        return;
+      }
+    }
+    FAIL() << body_name << " is not driven by a free joint";
+  }
+
+  /// Pre-declares and sets a parameter on plugin_node_ before init(), matching how launch
+  /// parameter files set plugin parameters ahead of load_mujoco_plugins().
+  template <typename T>
+  void setParam(const std::string& name, const T& value)
+  {
+    if (!plugin_node_->has_parameter(name))
+    {
+      plugin_node_->declare_parameter(name, rclcpp::ParameterValue(value));
+    }
+    plugin_node_->set_parameter(rclcpp::Parameter(name, value));
+  }
+
+  /// Subscribes to `topic` on plugin_node_ (matching the publisher's node) and spins until a
+  /// message arrives or the timeout elapses. Returns nullptr on timeout.
+  FreeJointStateArray::SharedPtr waitForMessage(const std::string& topic,
+                                                mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin& plugin)
+  {
+    std::atomic<bool> received{ false };
+    FreeJointStateArray::SharedPtr last_msg;
+    auto sub = plugin_node_->create_subscription<FreeJointStateArray>(
+        topic, 10, [&](FreeJointStateArray::SharedPtr msg) {
+          last_msg = msg;
+          received = true;
+        });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!received && std::chrono::steady_clock::now() < deadline)
+    {
+      plugin.update(model_, data_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return last_msg;
+  }
+
+  mjModel* model_{ nullptr };
+  mjData* data_{ nullptr };
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr plugin_node_;
+
+private:
+  std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+TEST_F(FreeJointStatePublisherPluginTest, InitSucceeds)
+{
+  mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
+  plugin.cleanup();
+}
+
+TEST_F(FreeJointStatePublisherPluginTest, WorldFrameDefaultsPublishAllFreeBodies)
+{
+  const mjtNum pos_a[3] = { 1.0, 2.0, 3.0 };
+  const mjtNum quat_a[4] = { std::cos(0.5236), 0.0, 0.0, std::sin(0.5236) };  // 60 deg about Z
+  const mjtNum linvel_a[3] = { 0.1, 0.2, 0.3 };
+  const mjtNum angvel_a[3] = { 0.0, 0.0, 0.5 };
+  setFreeJointState("free_a", pos_a, quat_a, linvel_a, angvel_a);
+
+  const mjtNum pos_b[3] = { -1.0, 0.0, 0.5 };
+  const mjtNum quat_b[4] = { 1.0, 0.0, 0.0, 0.0 };
+  const mjtNum zero3[3] = { 0.0, 0.0, 0.0 };
+  setFreeJointState("free_b", pos_b, quat_b, zero3, zero3);
+  mj_forward(model_, data_);
+
+  mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  auto msg = waitForMessage("free_joint_states", plugin);
+  ASSERT_NE(msg, nullptr) << "No FreeJointStateArray received";
+  ASSERT_EQ(msg->free_joints.size(), 2u);
+
+  std::map<std::string, mujoco_ros2_control_msgs::msg::FreeJointState> by_name;
+  for (const auto& entry : msg->free_joints)
+  {
+    by_name[entry.name] = entry;
+  }
+  ASSERT_EQ(by_name.count("free_a"), 1u);
+  ASSERT_EQ(by_name.count("free_b"), 1u);
+
+  const auto& a = by_name["free_a"];
+  EXPECT_EQ(a.pose.header.frame_id, "");
+  EXPECT_NEAR(a.pose.pose.position.x, pos_a[0], 1e-9);
+  EXPECT_NEAR(a.pose.pose.position.y, pos_a[1], 1e-9);
+  EXPECT_NEAR(a.pose.pose.position.z, pos_a[2], 1e-9);
+  EXPECT_NEAR(a.pose.pose.orientation.w, quat_a[0], 1e-9);
+  EXPECT_NEAR(a.pose.pose.orientation.x, quat_a[1], 1e-9);
+  EXPECT_NEAR(a.pose.pose.orientation.y, quat_a[2], 1e-9);
+  EXPECT_NEAR(a.pose.pose.orientation.z, quat_a[3], 1e-9);
+  EXPECT_NEAR(a.twist.twist.linear.x, linvel_a[0], 1e-9);
+  EXPECT_NEAR(a.twist.twist.linear.y, linvel_a[1], 1e-9);
+  EXPECT_NEAR(a.twist.twist.linear.z, linvel_a[2], 1e-9);
+  EXPECT_NEAR(a.twist.twist.angular.z, angvel_a[2], 1e-9);
+
+  const auto& b = by_name["free_b"];
+  EXPECT_NEAR(b.pose.pose.position.x, pos_b[0], 1e-9);
+  EXPECT_NEAR(b.pose.pose.position.z, pos_b[2], 1e-9);
+
+  plugin.cleanup();
+}
+
+TEST_F(FreeJointStatePublisherPluginTest, BodyNamesFilterRestrictsPublishedBodies)
+{
+  setParam("body_names", std::vector<std::string>{ "free_b" });
+
+  mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  auto msg = waitForMessage("free_joint_states", plugin);
+  ASSERT_NE(msg, nullptr);
+  ASSERT_EQ(msg->free_joints.size(), 1u);
+  EXPECT_EQ(msg->free_joints[0].name, "free_b");
+
+  plugin.cleanup();
+}
+
+TEST_F(FreeJointStatePublisherPluginTest, NonWorldFrameTransformsPoseAndTwistRoundTrip)
+{
+  const mjtNum pos_a[3] = { 0.0, 0.0, 1.0 };
+  const mjtNum quat_a[4] = { 1.0, 0.0, 0.0, 0.0 };
+  const mjtNum linvel_a[3] = { 0.5, 0.0, 0.0 };
+  const mjtNum angvel_a[3] = { 0.0, 0.0, 1.0 };
+  setFreeJointState("free_a", pos_a, quat_a, linvel_a, angvel_a);
+  const mjtNum zero3[3] = { 0.0, 0.0, 0.0 };
+  const mjtNum ident_quat[4] = { 1.0, 0.0, 0.0, 0.0 };
+  setFreeJointState("free_b", zero3, ident_quat, zero3, zero3);
+  mj_forward(model_, data_);
+
+  setParam("frame_id", std::string("ref_frame"));
+  setParam("body_names", std::vector<std::string>{ "free_a" });
+
+  mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  auto msg = waitForMessage("free_joint_states", plugin);
+  ASSERT_NE(msg, nullptr);
+  ASSERT_EQ(msg->free_joints.size(), 1u);
+  const auto& entry = msg->free_joints[0];
+  EXPECT_EQ(entry.pose.header.frame_id, "ref_frame");
+  EXPECT_EQ(entry.twist.header.frame_id, "ref_frame");
+
+  // Round trip test
+  const int ref_id = mj_name2id(model_, mjOBJ_BODY, "ref_frame");
+  ASSERT_GE(ref_id, 0);
+  const mjtNum rel_pos[3] = { entry.pose.pose.position.x, entry.pose.pose.position.y,
+                             entry.pose.pose.position.z };
+  const mjtNum rel_quat[4] = { entry.pose.pose.orientation.w, entry.pose.pose.orientation.x,
+                              entry.pose.pose.orientation.y, entry.pose.pose.orientation.z };
+  mjtNum recomposed_pos[3];
+  mjtNum recomposed_quat[4];
+  mju_mulPose(recomposed_pos, recomposed_quat, data_->xpos + 3 * ref_id, data_->xquat + 4 * ref_id, rel_pos, rel_quat);
+  EXPECT_NEAR(recomposed_pos[0], pos_a[0], 1e-6);
+  EXPECT_NEAR(recomposed_pos[1], pos_a[1], 1e-6);
+  EXPECT_NEAR(recomposed_pos[2], pos_a[2], 1e-6);
+  EXPECT_NEAR(recomposed_quat[0], quat_a[0], 1e-6);
+  EXPECT_NEAR(recomposed_quat[1], quat_a[1], 1e-6);
+  EXPECT_NEAR(recomposed_quat[2], quat_a[2], 1e-6);
+  EXPECT_NEAR(recomposed_quat[3], quat_a[3], 1e-6);
+
+  // Same round trip for twist
+  const mjtNum rel_linvel[3] = { entry.twist.twist.linear.x, entry.twist.twist.linear.y, entry.twist.twist.linear.z };
+  const mjtNum rel_angvel[3] = { entry.twist.twist.angular.x, entry.twist.twist.angular.y,
+                                entry.twist.twist.angular.z };
+  mjtNum recomposed_linvel[3];
+  mjtNum recomposed_angvel[3];
+  mju_rotVecQuat(recomposed_linvel, rel_linvel, data_->xquat + 4 * ref_id);
+  mju_rotVecQuat(recomposed_angvel, rel_angvel, data_->xquat + 4 * ref_id);
+  EXPECT_NEAR(recomposed_linvel[0], linvel_a[0], 1e-6);
+  EXPECT_NEAR(recomposed_linvel[1], linvel_a[1], 1e-6);
+  EXPECT_NEAR(recomposed_linvel[2], linvel_a[2], 1e-6);
+  EXPECT_NEAR(recomposed_angvel[2], angvel_a[2], 1e-6);
+
+  plugin.cleanup();
+}
+
+TEST_F(FreeJointStatePublisherPluginTest, UnknownFrameIdFallsBackToWorld)
+{
+  const mjtNum pos_a[3] = { 3.0, 4.0, 5.0 };
+  const mjtNum quat_a[4] = { 1.0, 0.0, 0.0, 0.0 };
+  const mjtNum zero3[3] = { 0.0, 0.0, 0.0 };
+  setFreeJointState("free_a", pos_a, quat_a, zero3, zero3);
+  setFreeJointState("free_b", zero3, quat_a, zero3, zero3);
+  mj_forward(model_, data_);
+
+  setParam("frame_id", std::string("nonexistent_body"));
+  setParam("body_names", std::vector<std::string>{ "free_a" });
+
+  mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_)) << "init() must not fail on an unknown frame_id";
+
+  auto msg = waitForMessage("free_joint_states", plugin);
+  ASSERT_NE(msg, nullptr);
+  ASSERT_EQ(msg->free_joints.size(), 1u);
+  const auto& entry = msg->free_joints[0];
+  EXPECT_EQ(entry.pose.header.frame_id, "") << "Should fall back to the world frame";
+  EXPECT_NEAR(entry.pose.pose.position.x, pos_a[0], 1e-9);
+  EXPECT_NEAR(entry.pose.pose.position.y, pos_a[1], 1e-9);
+  EXPECT_NEAR(entry.pose.pose.position.z, pos_a[2], 1e-9);
+
+  plugin.cleanup();
+}
+
+TEST_F(FreeJointStatePublisherPluginTest, InitRejectsUnknownBodyNameInFilter)
+{
+  setParam("body_names", std::vector<std::string>{ "nonexistent_body" });
+
+  mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
+  EXPECT_FALSE(plugin.init(plugin_node_, model_, data_));
+}

--- a/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
@@ -118,7 +118,7 @@ protected:
   /// Sets the qpos/qvel of the free joint driving `body_name`. Fails the test if the body is
   /// not driven by a free joint.
   void setFreeJointState(const std::string& body_name, const mjtNum pos[3], const mjtNum quat[4],
-                        const mjtNum linvel[3], const mjtNum angvel[3])
+                         const mjtNum linvel[3], const mjtNum angvel[3])
   {
     const int body_id = mj_name2id(model_, mjOBJ_BODY, body_name.c_str());
     ASSERT_GE(body_id, 0) << body_name;
@@ -166,8 +166,8 @@ protected:
   {
     std::atomic<bool> received{ false };
     FreeJointStateArray::SharedPtr last_msg;
-    auto sub = plugin_node_->create_subscription<FreeJointStateArray>(
-        topic, 10, [&](FreeJointStateArray::SharedPtr msg) {
+    auto sub =
+        plugin_node_->create_subscription<FreeJointStateArray>(topic, 10, [&](FreeJointStateArray::SharedPtr msg) {
           last_msg = msg;
           received = true;
         });
@@ -291,10 +291,9 @@ TEST_F(FreeJointStatePublisherPluginTest, NonWorldFrameTransformsPoseAndTwistRou
   // Round trip test
   const int ref_id = mj_name2id(model_, mjOBJ_BODY, "ref_frame");
   ASSERT_GE(ref_id, 0);
-  const mjtNum rel_pos[3] = { entry.pose.pose.position.x, entry.pose.pose.position.y,
-                             entry.pose.pose.position.z };
+  const mjtNum rel_pos[3] = { entry.pose.pose.position.x, entry.pose.pose.position.y, entry.pose.pose.position.z };
   const mjtNum rel_quat[4] = { entry.pose.pose.orientation.w, entry.pose.pose.orientation.x,
-                              entry.pose.pose.orientation.y, entry.pose.pose.orientation.z };
+                               entry.pose.pose.orientation.y, entry.pose.pose.orientation.z };
   mjtNum recomposed_pos[3];
   mjtNum recomposed_quat[4];
   mju_mulPose(recomposed_pos, recomposed_quat, data_->xpos + 3 * ref_id, data_->xquat + 4 * ref_id, rel_pos, rel_quat);
@@ -308,8 +307,7 @@ TEST_F(FreeJointStatePublisherPluginTest, NonWorldFrameTransformsPoseAndTwistRou
 
   // Same round trip for twist
   const mjtNum rel_linvel[3] = { entry.twist.twist.linear.x, entry.twist.twist.linear.y, entry.twist.twist.linear.z };
-  const mjtNum rel_angvel[3] = { entry.twist.twist.angular.x, entry.twist.twist.angular.y,
-                                entry.twist.twist.angular.z };
+  const mjtNum rel_angvel[3] = { entry.twist.twist.angular.x, entry.twist.twist.angular.y, entry.twist.twist.angular.z };
   mjtNum recomposed_linvel[3];
   mjtNum recomposed_angvel[3];
   mju_rotVecQuat(recomposed_linvel, rel_linvel, data_->xquat + 4 * ref_id);


### PR DESCRIPTION
## Description

This PR offers a plugin that can publish the data of the free joints in the simulation scene. Very useful to know the state and also for the testing purposs.

### Is this user-facing behavior change?
NO

### Did you use Generative AI?
YES, Claude 

