### PR TITLE
Add base twist plugin for commanding the mobile base

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -85,6 +85,11 @@ namespace mujoco_ros2_control
  * Specifically, it stages `ctrl`, `qfrc_applied`, and `xfrc_applied`. Cartesian forces from
  * `xfrc_applied` compete with inputs from Simulate's drag function, so they are resolved
  * separately. This only takes the control staging mutex and never blocks on physics stepping.
+ * It also stages `qvel`: the system interface NaN-fills `qvel` before every plugin's
+ * `update()` runs, so any DOF a plugin leaves untouched is NaN here and any DOF it writes a
+ * finite value into is a requested hard velocity override (see
+ * `MuJoCoROS2ControlPluginBase::update()`'s doc comment). Non-NaN entries are applied as a
+ * direct `qvel` write, bypassing the normal dynamics for that DOF.
  *
  * `overwrite_physics_data(...)` will completely replace the data for the sim. Should be used
  * with extreme caution.
@@ -273,7 +278,11 @@ public:
    * Specifically, copies `control_data->ctrl` and `control_data->qfrc_applied` into staging
    * buffers which the physics loop copies into `mj_data_` immediately before each step.
    * `control_data->xfrc_applied` is copied into `xfrc_plugin_desired_` to avoid conflicts
-   * from the simulate app. This does not lock the sim mutex and never waits on stepping.
+   * from the simulate app. `control_data->qvel` is copied into `qvel_override_staged_`;
+   * entries that are not NaN are plugin-requested velocity overrides (see
+   * `MuJoCoROS2ControlPluginBase::update()`'s doc comment for the NaN convention this
+   * relies on) and are applied as direct `qvel` writes before the next `mj_step`. This does
+   * not lock the sim mutex and never waits on stepping.
    */
   void apply_control_data(mjData* control_data);
 
@@ -430,6 +439,11 @@ private:
   std::vector<mjtNum> xfrc_viewer_capture_;  // Tracks forces from the viewer
   std::vector<mjtNum> xfrc_last_written_;    // tracks the last value written to xfrc_applied
 
+  // qvel as staged by apply_control_data: sized nv, NaN by default. A plugin requests a
+  // velocity override on a DOF by writing a finite value into control_data->qvel during its
+  // update()
+  std::vector<mjtNum> qvel_override_staged_;
+
   // Guards only the snapshot pointer swap and snapshot_ready_ flag.
   // Lock order: sim_mutex_ (if needed) is always taken before this one.
   std::mutex data_exchange_mutex_;
@@ -440,8 +454,9 @@ private:
   std::atomic<bool> snapshot_refresh_requested_{ true };
 
   // Guards the staged control inputs (ctrl_staged_, qfrc_applied_staged_, xfrc_plugin_desired_,
-  // control_inputs_staged_). Separate from data_exchange_mutex_ so that staging commands in
-  // write() and applying them before each physics step never queue behind a full mjData copy.
+  // control_inputs_staged_, qvel_override_staged_). Separate from data_exchange_mutex_ so
+  // that staging commands in write() and applying them before each physics step never queue
+  // behind a full mjData copy.
   // Critical sections are all small buffer copies.
   // Lock order: sim_mutex_ (if needed) before this one; never held with data_exchange_mutex_.
   std::mutex control_staging_mutex_;

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <cerrno>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -32,6 +33,7 @@
 #include <fstream>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <new>
 #include <stdexcept>
@@ -715,6 +717,7 @@ bool MujocoSimulation::initialize(rclcpp::Node::SharedPtr node, const std::strin
     xfrc_plugin_desired_.assign(6 * mj_model_->nbody, 0.0);
     xfrc_viewer_capture_.assign(6 * mj_model_->nbody, 0.0);
     xfrc_last_written_.assign(6 * mj_model_->nbody, 0.0);
+    qvel_override_staged_.assign(mj_model_->nv, std::numeric_limits<mjtNum>::quiet_NaN());
 
     if (mj_data_ && snapshot_write_ && snapshot_read_)
     {
@@ -860,6 +863,7 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state)
     std::fill(ctrl_staged_.begin(), ctrl_staged_.end(), 0.0);
     std::fill(qfrc_applied_staged_.begin(), qfrc_applied_staged_.end(), 0.0);
     std::fill(xfrc_plugin_desired_.begin(), xfrc_plugin_desired_.end(), 0.0);
+    std::fill(qvel_override_staged_.begin(), qvel_override_staged_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
   }
   std::fill(xfrc_viewer_capture_.begin(), xfrc_viewer_capture_.end(), 0.0);
   std::fill(xfrc_last_written_.begin(), xfrc_last_written_.end(), 0.0);
@@ -1243,6 +1247,7 @@ void MujocoSimulation::apply_control_data(mjData* control_data)
   mju_copy(ctrl_staged_.data(), control_data->ctrl, static_cast<int>(mj_model_->nu));
   mju_copy(qfrc_applied_staged_.data(), control_data->qfrc_applied, static_cast<int>(mj_model_->nv));
   mju_copy(xfrc_plugin_desired_.data(), control_data->xfrc_applied, 6 * static_cast<int>(mj_model_->nbody));
+  mju_copy(qvel_override_staged_.data(), control_data->qvel, static_cast<int>(mj_model_->nv));
   control_inputs_staged_ = true;
 }
 
@@ -1297,6 +1302,15 @@ void MujocoSimulation::apply_staged_control_inputs()
   mju_copy(mj_data_->xfrc_applied, xfrc_viewer_capture_.data(), nbody6);
   mju_addTo(mj_data_->xfrc_applied, xfrc_plugin_desired_.data(), nbody6);
   mju_copy(xfrc_last_written_.data(), mj_data_->xfrc_applied, nbody6);
+
+  // Apply plugin-requested velocity overrides as direct qvel writes
+  for (int i = 0; i < static_cast<int>(mj_model_->nv); ++i)
+  {
+    if (std::isfinite(qvel_override_staged_[i]))
+    {
+      mj_data_->qvel[i] = qvel_override_staged_[i];
+    }
+  }
 }
 
 // simulate in background thread (while rendering in main thread)

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1034,8 +1034,7 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
   // out xfrc_applied so plugins can update as needed. qvel is NaN-filled rather than zeroed: a plugin
   // requests a hard velocity override on a DOF by writing a finite value into it.
   mju_zero(control_data->xfrc_applied, 6 * static_cast<int>(simulation_->model()->nbody));
-  std::fill(control_data->qvel, control_data->qvel + simulation_->model()->nv,
-            std::numeric_limits<mjtNum>::quiet_NaN());
+  std::fill(control_data->qvel, control_data->qvel + simulation_->model()->nv, std::numeric_limits<mjtNum>::quiet_NaN());
   for (auto& plugin : plugin_instances_)
   {
     plugin->update(simulation_->model(), control_data);

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1031,8 +1031,11 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
   // Update plugins.
   // Clear plugin data, then let each plugin update as needed, in order. This enables plugins to read and
   // rewrite control inputs immediately before they are sent to the simulation. Namely, we have to zero
-  // out xfrc_applied so plugins can update as needed.
+  // out xfrc_applied so plugins can update as needed. qvel is NaN-filled rather than zeroed: a plugin
+  // requests a hard velocity override on a DOF by writing a finite value into it.
   mju_zero(control_data->xfrc_applied, 6 * static_cast<int>(simulation_->model()->nbody));
+  std::fill(control_data->qvel, control_data->qvel + simulation_->model()->nv,
+            std::numeric_limits<mjtNum>::quiet_NaN());
   for (auto& plugin : plugin_instances_)
   {
     plugin->update(simulation_->model(), control_data);

--- a/mujoco_ros2_control_demos/README.md
+++ b/mujoco_ros2_control_demos/README.md
@@ -7,7 +7,7 @@ This package provides ready-to-use tutorials that show how to use MuJoCo with ro
 
 Full tutorial documentation is maintained in RST format:
 
-- **[Demos and Tutorials](doc/tutorials.rst)** — step-by-step tutorials covering basic robot setup, MJCF generation, PID control, and transmissions.
+- **[Demos and Tutorials](doc/tutorials.rst)** — step-by-step tutorials covering basic robot setup, MJCF generation, PID control, transmissions, and the base velocity plugin.
 
 ## Quick Start
 
@@ -23,6 +23,9 @@ ros2 launch mujoco_ros2_control_demos 03_pid_control.launch.py
 
 # Tutorial 4 – Transmissions
 ros2 launch mujoco_ros2_control_demos 04_transmissions.launch.py
+
+# Tutorial 5 – Base Velocity Plugin
+ros2 launch mujoco_ros2_control_demos 05_base_velocity_plugin.launch.py
 ```
 
 All tutorials support `headless:=true` to run without the MuJoCo viewer.

--- a/mujoco_ros2_control_demos/config/controllers_base_velocity.yaml
+++ b/mujoco_ros2_control_demos/config/controllers_base_velocity.yaml
@@ -1,0 +1,14 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100
+
+joint_state_broadcaster:
+  ros__parameters:
+    type: joint_state_broadcaster/JointStateBroadcaster
+
+arm_position_controller:
+  ros__parameters:
+    type: forward_command_controller/ForwardCommandController
+    interface_name: position
+    joints:
+      - arm_joint

--- a/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins_base_velocity.yaml
+++ b/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins_base_velocity.yaml
@@ -5,15 +5,3 @@
         type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
         body: base_link
         cmd_vel_topic: /cmd_vel
-        # Higher than the default (200.0): a proportional-only velocity servo has an inherent
-        # steady-state droop under a sustained disturbance (creep velocity = disturbance force /
-        # kv_linear), so a higher gain holds the base tighter against the mounted arm's reaction
-        # forces while swinging, without sacrificing responsiveness to commanded velocities.
-        kv_linear: 2000.0
-        # Lower than the default (50.0): kv_yaw is a proportional-only gain with no damping term,
-        # so it's only stable up to roughly 2*Izz/control_period for the body it's driving. The
-        # mounted arm's own (stiff, position-controlled) joint reduces the base's *effective*
-        # rotational inertia as seen by the yaw loop within a single control cycle, which lowered
-        # that stability ceiling below the default -- at kv_yaw=50 a commanded yaw rate diverged
-        # into a runaway oscillation instead of converging.
-        kv_yaw: 10.0

--- a/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins_base_velocity.yaml
+++ b/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins_base_velocity.yaml
@@ -3,20 +3,17 @@
     mujoco_plugins:
       base_velocity_plugin:
         type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
-    # A plugin's own parameters (declared through the sub-node given to init()) are
-    # node-level, not namespaced by the plugin's instance name -- sub-nodes only extend
-    # the namespace of topics/services/actions, not parameters (see rclcpp::Node::create_sub_node).
-    body: base_link
-    cmd_vel_topic: /cmd_vel
-    # Higher than the default (200.0): a proportional-only velocity servo has an inherent
-    # steady-state droop under a sustained disturbance (creep velocity = disturbance force /
-    # kv_linear), so a higher gain holds the base tighter against the mounted arm's reaction
-    # forces while swinging, without sacrificing responsiveness to commanded velocities.
-    kv_linear: 2000.0
-    # Lower than the default (50.0): kv_yaw is a proportional-only gain with no damping term,
-    # so it's only stable up to roughly 2*Izz/control_period for the body it's driving. The
-    # mounted arm's own (stiff, position-controlled) joint reduces the base's *effective*
-    # rotational inertia as seen by the yaw loop within a single control cycle, which lowered
-    # that stability ceiling below the default -- at kv_yaw=50 a commanded yaw rate diverged
-    # into a runaway oscillation instead of converging.
-    kv_yaw: 10.0
+        body: base_link
+        cmd_vel_topic: /cmd_vel
+        # Higher than the default (200.0): a proportional-only velocity servo has an inherent
+        # steady-state droop under a sustained disturbance (creep velocity = disturbance force /
+        # kv_linear), so a higher gain holds the base tighter against the mounted arm's reaction
+        # forces while swinging, without sacrificing responsiveness to commanded velocities.
+        kv_linear: 2000.0
+        # Lower than the default (50.0): kv_yaw is a proportional-only gain with no damping term,
+        # so it's only stable up to roughly 2*Izz/control_period for the body it's driving. The
+        # mounted arm's own (stiff, position-controlled) joint reduces the base's *effective*
+        # rotational inertia as seen by the yaw loop within a single control cycle, which lowered
+        # that stability ceiling below the default -- at kv_yaw=50 a commanded yaw rate diverged
+        # into a runaway oscillation instead of converging.
+        kv_yaw: 10.0

--- a/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins_base_velocity.yaml
+++ b/mujoco_ros2_control_demos/config/mujoco_ros2_control_plugins_base_velocity.yaml
@@ -1,0 +1,22 @@
+/**:
+  ros__parameters:
+    mujoco_plugins:
+      base_velocity_plugin:
+        type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
+    # A plugin's own parameters (declared through the sub-node given to init()) are
+    # node-level, not namespaced by the plugin's instance name -- sub-nodes only extend
+    # the namespace of topics/services/actions, not parameters (see rclcpp::Node::create_sub_node).
+    body: base_link
+    cmd_vel_topic: /cmd_vel
+    # Higher than the default (200.0): a proportional-only velocity servo has an inherent
+    # steady-state droop under a sustained disturbance (creep velocity = disturbance force /
+    # kv_linear), so a higher gain holds the base tighter against the mounted arm's reaction
+    # forces while swinging, without sacrificing responsiveness to commanded velocities.
+    kv_linear: 2000.0
+    # Lower than the default (50.0): kv_yaw is a proportional-only gain with no damping term,
+    # so it's only stable up to roughly 2*Izz/control_period for the body it's driving. The
+    # mounted arm's own (stiff, position-controlled) joint reduces the base's *effective*
+    # rotational inertia as seen by the yaw loop within a single control cycle, which lowered
+    # that stability ceiling below the default -- at kv_yaw=50 a commanded yaw rate diverged
+    # into a runaway oscillation instead of converging.
+    kv_yaw: 10.0

--- a/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.urdf
+++ b/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.urdf
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="mobile_base">
+
+  <xacro:arg name="headless" default="false"/>
+
+  <link name="world"/>
+
+  <!-- Nominal fixed joint only, so robot_state_publisher has a valid tree rooted at "world".
+       base_link's *actual* pose comes from the MJCF <freejoint>, published separately as
+       odometry by mujoco_ros2_control (odom_free_joint_name, defaulting to
+       "floating_base_joint", which matches the MJCF freejoint name), not from this joint. -->
+  <link name="base_link"/>
+  <joint name="base_footprint_joint" type="fixed">
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+
+  <link name="arm_link">
+    <inertial>
+      <origin xyz="0.15 0 0" rpy="0 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.02"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <cylinder radius="0.025" length="0.3"/>
+      </geometry>
+      <origin rpy="0 1.5708 0" xyz="0.15 0 0"/>
+    </visual>
+  </link>
+  <joint name="arm_joint" type="revolute">
+    <parent link="base_link"/>
+    <child link="arm_link"/>
+    <origin rpy="0 0 0" xyz="0 0 0.05"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.7" upper="0.7" velocity="3.14" effort="200"/>
+  </joint>
+
+  <ros2_control name="MujocoSystem" type="system">
+    <hardware>
+      <plugin>mujoco_ros2_control/MujocoSystemInterface</plugin>
+      <param name="mujoco_model">$(find mujoco_ros2_control_demos)/demo_resources/scenes/scene_mobile_base.xml</param>
+      <param name="headless">$(arg headless)</param>
+      <param name="sim_speed_factor">1.0</param>
+    </hardware>
+    <!-- Actuated purely to demonstrate that swinging a mounted joint doesn't drag the base
+         around: BaseVelocityPlugin holds the base's velocity at whatever is commanded on
+         cmd_vel (zero, by default) regardless of what's disturbing it. -->
+    <joint name="arm_joint">
+      <command_interface name="position"/>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+
+</robot>

--- a/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.urdf
+++ b/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.urdf
@@ -10,7 +10,7 @@
        odometry by mujoco_ros2_control (odom_free_joint_name, defaulting to
        "floating_base_joint", which matches the MJCF freejoint name), not from this joint. -->
   <link name="base_link"/>
-  <joint name="base_footprint_joint" type="fixed">
+  <joint name="world_to_base_joint" type="fixed">
     <parent link="world"/>
     <child link="base_link"/>
   </joint>

--- a/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.xml
+++ b/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.xml
@@ -2,8 +2,9 @@
   <worldbody>
     <body name="base_link" pos="0 0 0.11">
       <freejoint name="floating_base_joint"/>
-      <!-- mass=20kg gives the base plenty of inertia to resist external disturbances until
-           BaseVelocityPlugin's servo corrects the velocity error back out. -->
+      <!-- mass=20kg is just a physically plausible value for settling under gravity; it has no
+           bearing on the driven DOFs, since BaseVelocityPlugin overrides their velocity
+           directly rather than servoing a force against the body's mass. -->
       <inertial pos="0 0 0" mass="20.0" diaginertia="0.1667 0.2833 0.4167"/>
       <!-- Chassis: doesn't touch the ground (the wheels below reach lower and take the floor
            contact instead), but still collides normally with the wall obstacle. -->
@@ -11,14 +12,12 @@
       <!-- Forward-direction marker (cosmetic only, no collision) -->
       <geom name="heading_marker" type="box" size="0.03 0.03 0.01" pos="0.18 0 0.06" rgba="0.9 0.2 0.1 1"
             contype="0" conaffinity="0"/>
-      <!-- Wheels: the base's actual ground contact. friction="0 0 0" here (and on the floor
-           geom in scene_mobile_base.xml: MuJoCo combines contact friction as the max of the
-           two geoms, so both need it set) means the ground can't exert any tangential force on
-           the base at all. BaseVelocityPlugin is the *only* thing that can change the base's
-           velocity: with zero friction, an external push just becomes a permanent velocity
-           error that the servo drives back toward the commanded value (zero, if nothing is
-           being published on cmd_vel), since there's no friction to damp the disturbance out
-           on its own. -->
+      <!-- Wheels: the base's actual ground contact. BaseVelocityPlugin drives the base by
+           overriding its free-joint velocity directly, not through wheel-ground contact, so
+           friction="0 0 0" here (and on the floor geom in scene_mobile_base.xml) is no longer
+           functionally required; it's kept simply so the wheels can never exert any
+           tangential force on the base at all, leaving the velocity override as the sole thing
+           that can change its planar velocity. -->
       <geom name="wheel_fl" type="cylinder" size="0.08 0.03" pos="0.15 0.18 -0.02" quat="0.7071068 0.7071068 0 0"
             rgba="0.1 0.1 0.1 1" friction="0 0 0"/>
       <geom name="wheel_fr" type="cylinder" size="0.08 0.03" pos="0.15 -0.18 -0.02" quat="0.7071068 0.7071068 0 0"
@@ -30,13 +29,12 @@
       <!-- Mounted arm: swinging it (via arm_joint's position actuator below) creates a
            reaction force/torque on the base through the joint, unrelated to ground
            friction, since it acts directly between the two bodies. BaseVelocityPlugin
-           measures the base's own velocity regardless of what disturbs it, so it corrects
-           this the same way it corrects an external push: the base should stay close to
-           put while the arm moves, and only actually travel once cmd_vel commands it to.
-           The joint is range-limited to a back-and-forth sweep rather than a continuous
-           spin, since a real arm reaches to poses and doesn't windmill, and a bounded sweep's
-           disturbance is largely self-cancelling over a full swing rather than compounding
-           in one direction the way gravity acting on a continuously spinning mass would. -->
+           overrides the base's driven DOFs directly every cycle, so this reaction has no
+           path to influence them at all: the base stays exactly in place while the arm
+           moves, and only travels once cmd_vel commands it to. The joint is range-limited
+           to a back-and-forth sweep rather than a continuous spin simply because a real arm
+           reaches to poses and doesn't windmill; it has no bearing on the base's motion
+           either way now that the override makes the base immune to the reaction forces. -->
       <body name="arm_link" pos="0 0 0.05">
         <joint name="arm_joint" type="hinge" axis="0 1 0" pos="0 0 0" range="-0.7 0.7" limited="true"/>
         <inertial pos="0.15 0 0" mass="2.0" diaginertia="0.001 0.02 0.02"/>

--- a/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.xml
+++ b/mujoco_ros2_control_demos/demo_resources/mobile_base/mobile_base.xml
@@ -1,0 +1,50 @@
+<mujoco model="mobile_base">
+  <worldbody>
+    <body name="base_link" pos="0 0 0.11">
+      <freejoint name="floating_base_joint"/>
+      <!-- mass=20kg gives the base plenty of inertia to resist external disturbances until
+           BaseVelocityPlugin's servo corrects the velocity error back out. -->
+      <inertial pos="0 0 0" mass="20.0" diaginertia="0.1667 0.2833 0.4167"/>
+      <!-- Chassis: doesn't touch the ground (the wheels below reach lower and take the floor
+           contact instead), but still collides normally with the wall obstacle. -->
+      <geom name="chassis" type="box" size="0.2 0.15 0.05" rgba="0.2 0.6 0.9 1"/>
+      <!-- Forward-direction marker (cosmetic only, no collision) -->
+      <geom name="heading_marker" type="box" size="0.03 0.03 0.01" pos="0.18 0 0.06" rgba="0.9 0.2 0.1 1"
+            contype="0" conaffinity="0"/>
+      <!-- Wheels: the base's actual ground contact. friction="0 0 0" here (and on the floor
+           geom in scene_mobile_base.xml: MuJoCo combines contact friction as the max of the
+           two geoms, so both need it set) means the ground can't exert any tangential force on
+           the base at all. BaseVelocityPlugin is the *only* thing that can change the base's
+           velocity: with zero friction, an external push just becomes a permanent velocity
+           error that the servo drives back toward the commanded value (zero, if nothing is
+           being published on cmd_vel), since there's no friction to damp the disturbance out
+           on its own. -->
+      <geom name="wheel_fl" type="cylinder" size="0.08 0.03" pos="0.15 0.18 -0.02" quat="0.7071068 0.7071068 0 0"
+            rgba="0.1 0.1 0.1 1" friction="0 0 0"/>
+      <geom name="wheel_fr" type="cylinder" size="0.08 0.03" pos="0.15 -0.18 -0.02" quat="0.7071068 0.7071068 0 0"
+            rgba="0.1 0.1 0.1 1" friction="0 0 0"/>
+      <geom name="wheel_rl" type="cylinder" size="0.08 0.03" pos="-0.15 0.18 -0.02" quat="0.7071068 0.7071068 0 0"
+            rgba="0.1 0.1 0.1 1" friction="0 0 0"/>
+      <geom name="wheel_rr" type="cylinder" size="0.08 0.03" pos="-0.15 -0.18 -0.02" quat="0.7071068 0.7071068 0 0"
+            rgba="0.1 0.1 0.1 1" friction="0 0 0"/>
+      <!-- Mounted arm: swinging it (via arm_joint's position actuator below) creates a
+           reaction force/torque on the base through the joint, unrelated to ground
+           friction, since it acts directly between the two bodies. BaseVelocityPlugin
+           measures the base's own velocity regardless of what disturbs it, so it corrects
+           this the same way it corrects an external push: the base should stay close to
+           put while the arm moves, and only actually travel once cmd_vel commands it to.
+           The joint is range-limited to a back-and-forth sweep rather than a continuous
+           spin, since a real arm reaches to poses and doesn't windmill, and a bounded sweep's
+           disturbance is largely self-cancelling over a full swing rather than compounding
+           in one direction the way gravity acting on a continuously spinning mass would. -->
+      <body name="arm_link" pos="0 0 0.05">
+        <joint name="arm_joint" type="hinge" axis="0 1 0" pos="0 0 0" range="-0.7 0.7" limited="true"/>
+        <inertial pos="0.15 0 0" mass="2.0" diaginertia="0.001 0.02 0.02"/>
+        <geom name="arm_geom" type="capsule" fromto="0 0 0 0.3 0 0" size="0.025" rgba="0.9 0.6 0.1 1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="arm_joint" joint="arm_joint" kp="200" ctrlrange="-0.7 0.7"/>
+  </actuator>
+</mujoco>

--- a/mujoco_ros2_control_demos/demo_resources/scenes/scene_mobile_base.xml
+++ b/mujoco_ros2_control_demos/demo_resources/scenes/scene_mobile_base.xml
@@ -1,0 +1,33 @@
+<mujoco model="mobile_base_scene">
+  <include file="../mobile_base/mobile_base.xml"/>
+
+  <statistic center="0 0 0.3" extent="5"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="120" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
+    <!-- Zero friction matching the wheel geoms (see mobile_base.xml): both need it set,
+         since MuJoCo combines contact friction as the max of the two. The ground can't exert
+         any tangential force on the base at all; only BaseVelocityPlugin's servo can change
+         its velocity. -->
+    <geom conaffinity="1" contype="1" material="groundplane" name="floor" pos="0 0 0" size="0 0 0.01" type="plane"
+          friction="0 0 0"/>
+    <!-- Obstacle: BaseVelocityPlugin only replaces wheel-ground propulsion, so driving
+         into this wall still stops the base like a normal collision would. Placed a few
+         metres out to give room to brake (release/re-publish cmd_vel) before reaching it
+         rather than colliding at full commanded speed. -->
+    <geom name="wall" type="box" pos="4.0 0 0.25" size="0.05 1.0 0.25" rgba="0.6 0.2 0.2 1"/>
+  </worldbody>
+</mujoco>

--- a/mujoco_ros2_control_demos/demo_resources/scenes/scene_mobile_base.xml
+++ b/mujoco_ros2_control_demos/demo_resources/scenes/scene_mobile_base.xml
@@ -18,16 +18,16 @@
 
   <worldbody>
     <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
-    <!-- Zero friction matching the wheel geoms (see mobile_base.xml): both need it set,
-         since MuJoCo combines contact friction as the max of the two. The ground can't exert
-         any tangential force on the base at all; only BaseVelocityPlugin's servo can change
-         its velocity. -->
+    <!-- Zero friction matching the wheel geoms (see mobile_base.xml). No longer functionally
+         required for propulsion (BaseVelocityPlugin overrides the base's qvel directly), kept
+         so the ground can never exert any tangential force on the base either. -->
     <geom conaffinity="1" contype="1" material="groundplane" name="floor" pos="0 0 0" size="0 0 0.01" type="plane"
           friction="0 0 0"/>
-    <!-- Obstacle: BaseVelocityPlugin only replaces wheel-ground propulsion, so driving
-         into this wall still stops the base like a normal collision would. Placed a few
-         metres out to give room to brake (release/re-publish cmd_vel) before reaching it
-         rather than colliding at full commanded speed. -->
+    <!-- Obstacle: BaseVelocityPlugin's velocity override outranks the contact solver, so
+         driving into this wall will NOT stop the base the way a normal collision would;
+         it pushes through/climbs it instead. Placed a few metres out to give room to
+         observe this (or to release/re-publish cmd_vel before reaching it) rather than
+         colliding at full commanded speed immediately after launch. -->
     <geom name="wall" type="box" pos="4.0 0 0.25" size="0.05 1.0 0.25" rgba="0.6 0.2 0.2 1"/>
   </worldbody>
 </mujoco>

--- a/mujoco_ros2_control_demos/doc/tutorials.rst
+++ b/mujoco_ros2_control_demos/doc/tutorials.rst
@@ -88,9 +88,17 @@ Tutorial 5: Base Velocity Plugin
 
 Demonstrates driving a mobile/floating-base robot with ``BaseVelocityPlugin``: a free-floating,
 wheeled chassis (MJCF ``<freejoint>``) carrying a 1-DOF arm, driven from a ``cmd_vel`` topic via a
-velocity servo. The wheels and ground have zero friction, so the ground can never exert any
-tangential force on the base -- only the servo can change its velocity. Collisions with the wall
-in the scene are still handled by the physics engine as normal.
+hard velocity override applied directly to the chassis's free-joint ``qvel`` every cycle. The
+wheels and ground have zero friction, which is now largely cosmetic -- propulsion no longer goes
+through wheel-ground contact at all, so it does not depend on friction either way.
+
+.. warning::
+
+   Because the override is kinematic, it outranks the contact solver: the wall in the scene will
+   **not** stop the base -- it will push through or climb it rather than being stopped by contact,
+   since the commanded velocity is reasserted every cycle regardless of collisions. This is the
+   trade-off for exact, disturbance-immune velocity tracking; see the ``BaseVelocityPlugin``
+   documentation for details.
 
 .. code-block:: bash
 
@@ -99,10 +107,11 @@ in the scene are still handled by the physics engine as normal.
    # In another terminal, drive the base:
    ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.5}, angular: {z: 0.2}}" --rate 10
 
-**Disturbance rejection**: swinging the mounted arm creates a reaction force/torque on the base
+**Disturbance immunity**: swinging the mounted arm creates a reaction force/torque on the base
 through the joint, unrelated to ground friction, since it acts directly between the two bodies.
-``BaseVelocityPlugin`` measures the base's own velocity regardless of what disturbs it, so with no
-``cmd_vel`` active the base should stay close to put while the arm moves, rather than drifting off.
+Because ``BaseVelocityPlugin`` overrides the base's driven DOFs directly rather than servoing
+against them, this reaction has *no* effect on the base's velocity at all -- not approximately,
+exactly none -- so with no ``cmd_vel`` active the base stays exactly in place while the arm moves.
 The arm's joint is range-limited to a back-and-forth sweep rather than a continuous spin:
 
 .. code-block:: bash
@@ -110,9 +119,9 @@ The arm's joint is range-limited to a back-and-forth sweep rather than a continu
    ros2 topic pub /arm_position_controller/commands std_msgs/msg/Float64MultiArray "data: [0.7]"
    ros2 topic pub /arm_position_controller/commands std_msgs/msg/Float64MultiArray "data: [-0.7]"
 
-**Key concepts:** ``BaseVelocityPlugin`` velocity servo, driving a MJCF ``<freejoint>`` body,
-disturbance rejection against reaction forces from a moving mounted joint, floating-base odometry
-(``odom_free_joint_name``).
+**Key concepts:** ``BaseVelocityPlugin`` free-joint velocity override, driving a MJCF
+``<freejoint>`` body, immunity to reaction forces from a moving mounted joint, floating-base
+odometry (``odom_free_joint_name``).
 
 **Resources:** ``demo_resources/scenes/scene_mobile_base.xml``, ``demo_resources/mobile_base/mobile_base.xml``,
 ``demo_resources/mobile_base/mobile_base.urdf``, ``config/mujoco_ros2_control_plugins_base_velocity.yaml``

--- a/mujoco_ros2_control_demos/doc/tutorials.rst
+++ b/mujoco_ros2_control_demos/doc/tutorials.rst
@@ -83,6 +83,43 @@ Demonstrates ``ros2_control`` transmissions with mechanical reduction ratios.
 **Resources:** ``demo_resources/robot/test_robot.urdf`` with ``use_transmissions:=true``
 
 
+Tutorial 5: Base Velocity Plugin
+---------------------------------
+
+Demonstrates driving a mobile/floating-base robot with ``BaseVelocityPlugin``: a free-floating,
+wheeled chassis (MJCF ``<freejoint>``) carrying a 1-DOF arm, driven from a ``cmd_vel`` topic via a
+velocity servo. The wheels and ground have zero friction, so the ground can never exert any
+tangential force on the base -- only the servo can change its velocity. Collisions with the wall
+in the scene are still handled by the physics engine as normal.
+
+.. code-block:: bash
+
+   ros2 launch mujoco_ros2_control_demos 05_base_velocity_plugin.launch.py
+
+   # In another terminal, drive the base:
+   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.5}, angular: {z: 0.2}}" --rate 10
+
+**Disturbance rejection**: swinging the mounted arm creates a reaction force/torque on the base
+through the joint, unrelated to ground friction, since it acts directly between the two bodies.
+``BaseVelocityPlugin`` measures the base's own velocity regardless of what disturbs it, so with no
+``cmd_vel`` active the base should stay close to put while the arm moves, rather than drifting off.
+The arm's joint is range-limited to a back-and-forth sweep rather than a continuous spin:
+
+.. code-block:: bash
+
+   ros2 topic pub /arm_position_controller/commands std_msgs/msg/Float64MultiArray "data: [0.7]"
+   ros2 topic pub /arm_position_controller/commands std_msgs/msg/Float64MultiArray "data: [-0.7]"
+
+**Key concepts:** ``BaseVelocityPlugin`` velocity servo, driving a MJCF ``<freejoint>`` body,
+disturbance rejection against reaction forces from a moving mounted joint, floating-base odometry
+(``odom_free_joint_name``).
+
+**Resources:** ``demo_resources/scenes/scene_mobile_base.xml``, ``demo_resources/mobile_base/mobile_base.xml``,
+``demo_resources/mobile_base/mobile_base.urdf``, ``config/mujoco_ros2_control_plugins_base_velocity.yaml``
+
+See :doc:`../../mujoco_ros2_control_plugins/doc/plugins` for the full list of ``BaseVelocityPlugin`` parameters.
+
+
 Combined Demo
 -------------
 
@@ -121,14 +158,17 @@ Package Structure
 
    mujoco_ros2_control_demos/
    ├── launch/
-   │   ├── 01_basic_robot.launch.py      # Tutorial 1
-   │   ├── 02_mjcf_generation.launch.py  # Tutorial 2
-   │   ├── 03_pid_control.launch.py      # Tutorial 3
-   │   ├── 04_transmissions.launch.py    # Tutorial 4
-   │   └── demo.launch.py               # Combined demo
+   │   ├── 01_basic_robot.launch.py         # Tutorial 1
+   │   ├── 02_mjcf_generation.launch.py     # Tutorial 2
+   │   ├── 03_pid_control.launch.py         # Tutorial 3
+   │   ├── 04_transmissions.launch.py       # Tutorial 4
+   │   ├── 05_base_velocity_plugin.launch.py # Tutorial 5
+   │   └── demo.launch.py                  # Combined demo
    ├── config/
-   │   ├── controllers.yaml             # Controller configuration
-   │   └── mujoco_pid.yaml              # PID gains (Tutorial 3)
+   │   ├── controllers.yaml                        # Controller configuration
+   │   ├── mujoco_pid.yaml                         # PID gains (Tutorial 3)
+   │   ├── controllers_base_velocity.yaml          # joint_state_broadcaster + arm_position_controller (Tutorial 5)
+   │   └── mujoco_ros2_control_plugins_base_velocity.yaml  # BaseVelocityPlugin config (Tutorial 5)
    └── demo_resources/
        ├── robot/
        │   ├── test_robot.urdf          # Shared URDF description
@@ -136,8 +176,12 @@ Package Structure
        ├── scenes/
        │   ├── scene.xml                # Basic scene (Tutorial 1, 4)
        │   ├── scene_pid.xml            # PID scene (Tutorial 3)
-       │   └── scene_info.xml           # Scene generation info
+       │   ├── scene_info.xml           # Scene generation info
+       │   └── scene_mobile_base.xml    # Mobile base + wall obstacle (Tutorial 5)
        ├── mjcf_generation/
        │   └── test_inputs.xml          # MJCF conversion inputs (Tutorial 2)
-       └── pid_control/
-           └── test_robot_pid.xml       # Robot with motor actuators
+       ├── pid_control/
+       │   └── test_robot_pid.xml       # Robot with motor actuators
+       └── mobile_base/
+           ├── mobile_base.xml          # MJCF chassis with freejoint (Tutorial 5)
+           └── mobile_base.urdf         # Minimal URDF, no ros2_control joints (Tutorial 5)

--- a/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
+++ b/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
@@ -18,21 +18,10 @@ Tutorial 5: Base Velocity Plugin
 This tutorial demonstrates driving a mobile/floating-base robot with BaseVelocityPlugin.
 The mobile base is a free-floating, wheeled chassis (MJCF <freejoint>) carrying a
 1-DOF arm mounted on top. Propulsion is driven entirely by the plugin's velocity servo
-wrench -- the base itself has no ros2_control joints, only the arm does. The ground and
-wheels have zero friction (see mobile_base.xml / scene_mobile_base.xml), so the ground
-itself can never exert any tangential force on the base: the *only* thing that can
-change its velocity is BaseVelocityPlugin's servo.
-
-Swinging the arm creates a reaction force/torque on the base through the joint,
-unrelated to ground friction, since it acts directly between the two bodies, yet
-BaseVelocityPlugin measures the base's own velocity regardless of what disturbs it, so
-it corrects this the same way it would correct an external push: the base stays close
-to put while the arm moves, and only actually travels once a nonzero velocity is
-commanded on cmd_vel. The arm's joint is range-limited to a back-and-forth sweep rather
-than a continuous spin, since a real arm reaches to poses rather than windmilling, and a
-bounded sweep's disturbance is largely self-cancelling over a full swing. Collisions
-with obstacles (e.g. the wall in the scene) are still handled by the physics engine as
-normal.
+wrench -- the base itself has no ros2_control joints, only the arm does. Ground/wheel
+friction is zero, so the *only* thing that can change the base's velocity is the servo,
+whether the disturbance is an external push or the mounted arm's own reaction forces as
+it swings. See doc/tutorials.rst (Tutorial 5) and mobile_base.xml for the full rationale.
 
 Key concepts:
 - BaseVelocityPlugin: proportional velocity servo applied via data->xfrc_applied

--- a/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
+++ b/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
@@ -1,0 +1,160 @@
+# Copyright 2026 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tutorial 5: Base Velocity Plugin
+
+This tutorial demonstrates driving a mobile/floating-base robot with BaseVelocityPlugin.
+The mobile base is a free-floating, wheeled chassis (MJCF <freejoint>) carrying a
+1-DOF arm mounted on top. Propulsion is driven entirely by the plugin's velocity servo
+wrench -- the base itself has no ros2_control joints, only the arm does. The ground and
+wheels have zero friction (see mobile_base.xml / scene_mobile_base.xml), so the ground
+itself can never exert any tangential force on the base: the *only* thing that can
+change its velocity is BaseVelocityPlugin's servo.
+
+Swinging the arm creates a reaction force/torque on the base through the joint,
+unrelated to ground friction, since it acts directly between the two bodies, yet
+BaseVelocityPlugin measures the base's own velocity regardless of what disturbs it, so
+it corrects this the same way it would correct an external push: the base stays close
+to put while the arm moves, and only actually travels once a nonzero velocity is
+commanded on cmd_vel. The arm's joint is range-limited to a back-and-forth sweep rather
+than a continuous spin, since a real arm reaches to poses rather than windmilling, and a
+bounded sweep's disturbance is largely self-cancelling over a full swing. Collisions
+with obstacles (e.g. the wall in the scene) are still handled by the physics engine as
+normal.
+
+Key concepts:
+- BaseVelocityPlugin: proportional velocity servo applied via data->xfrc_applied
+- Driving a MJCF <freejoint> body from a cmd_vel-style topic
+- Disturbance rejection: the servo actively holds the commanded velocity (zero, by
+  default) against internal reaction forces from a moving mounted joint, rather than
+  relying on friction to damp them out
+- Floating-base odometry publishing (mujoco_ros2_control's odom_free_joint_name)
+
+Resources used:
+- demo_resources/scenes/scene_mobile_base.xml (scene with mobile base + wall obstacle)
+- demo_resources/mobile_base/mobile_base.xml (MJCF chassis+arm with wheels and freejoint)
+- demo_resources/mobile_base/mobile_base.urdf (URDF with the arm's ros2_control joint)
+- config/mujoco_ros2_control_plugins_base_velocity.yaml (BaseVelocityPlugin configuration)
+- config/controllers_base_velocity.yaml (joint_state_broadcaster + arm_position_controller)
+
+Usage:
+    ros2 launch mujoco_ros2_control_demos 05_base_velocity_plugin.launch.py
+    ros2 launch mujoco_ros2_control_demos 05_base_velocity_plugin.launch.py headless:=true
+
+Drive the base:
+    ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.5}, angular: {z: 0.2}}" --rate 10
+
+Swing the arm back and forth (with no cmd_vel active, the base should stay close to put):
+    ros2 topic pub /arm_position_controller/commands std_msgs/msg/Float64MultiArray "data: [0.7]"
+    ros2 topic pub /arm_position_controller/commands std_msgs/msg/Float64MultiArray "data: [-0.7]"
+
+Watch odometry:
+    ros2 topic echo /simulator/floating_base_state
+"""
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, Shutdown
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue, ParameterFile
+from launch_ros.substitutions import FindPackageShare
+
+
+def launch_setup(context, *args, **kwargs):
+    pkg_share = FindPackageShare("mujoco_ros2_control_demos")
+
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution([pkg_share, "demo_resources", "mobile_base", "mobile_base.urdf"]),
+            " headless:=",
+            LaunchConfiguration("headless"),
+        ]
+    )
+
+    robot_description_str = robot_description_content.perform(context)
+    robot_description = {"robot_description": ParameterValue(value=robot_description_str, value_type=str)}
+
+    controllers_file = PathJoinSubstitution([pkg_share, "config", "controllers_base_velocity.yaml"])
+    mujoco_plugins_file = PathJoinSubstitution([pkg_share, "config", "mujoco_ros2_control_plugins_base_velocity.yaml"])
+
+    nodes = []
+
+    # Robot state publisher
+    nodes.append(
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="both",
+            parameters=[robot_description, {"use_sim_time": True}],
+        )
+    )
+
+    # ros2_control node with MuJoCo. The base itself has no ros2_control joints --
+    # BaseVelocityPlugin drives it directly from /cmd_vel -- only the mounted arm does.
+    nodes.append(
+        Node(
+            package="mujoco_ros2_control",
+            executable="ros2_control_node",
+            emulate_tty=True,
+            output="both",
+            parameters=[
+                {"use_sim_time": True},
+                ParameterFile(controllers_file),
+                ParameterFile(mujoco_plugins_file),
+            ],
+            remappings=(
+                [("~/robot_description", "/robot_description")] if os.environ.get("ROS_DISTRO") == "humble" else []
+            ),
+            on_exit=Shutdown(),
+        )
+    )
+
+    # Controller spawners for the arm joint
+    controllers_to_spawn = ["joint_state_broadcaster", "arm_position_controller"]
+    for controller in controllers_to_spawn:
+        nodes.append(
+            Node(
+                package="controller_manager",
+                executable="spawner",
+                arguments=[controller, "--param-file", controllers_file],
+                output="both",
+            )
+        )
+
+    return nodes
+
+
+def generate_launch_description():
+    headless = DeclareLaunchArgument(
+        "headless",
+        default_value="false",
+        description="Run simulation without visualization window",
+    )
+
+    return LaunchDescription(
+        [
+            headless,
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
+++ b/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
@@ -17,18 +17,16 @@ Tutorial 5: Base Velocity Plugin
 
 This tutorial demonstrates driving a mobile/floating-base robot with BaseVelocityPlugin.
 The mobile base is a free-floating, wheeled chassis (MJCF <freejoint>) carrying a
-1-DOF arm mounted on top. Propulsion is driven entirely by the plugin's velocity servo
-wrench -- the base itself has no ros2_control joints, only the arm does. Ground/wheel
-friction is zero, so the *only* thing that can change the base's velocity is the servo,
-whether the disturbance is an external push or the mounted arm's own reaction forces as
-it swings. See doc/tutorials.rst (Tutorial 5) and mobile_base.xml for the full rationale.
+Because the override is kinematic, it outranks the physics engine: the mounted arm's 
+reaction forces as it swings have no effect on the base's velocity, but neither does 
+colliding with the wall in the scene -- see doc/tutorials.rst (Tutorial 5) and 
+mobile_base.xml for the full rationale.
 
 Key concepts:
-- BaseVelocityPlugin: proportional velocity servo applied via data->xfrc_applied
+- BaseVelocityPlugin: hard free-joint velocity override, applied by writing directly into
+  data->qvel during update()
 - Driving a MJCF <freejoint> body from a cmd_vel-style topic
-- Disturbance rejection: the servo actively holds the commanded velocity (zero, by
-  default) against internal reaction forces from a moving mounted joint, rather than
-  relying on friction to damp them out
+- Disturbance immunity: the override holds the commanded velocity (zero, by default)
 - Floating-base odometry publishing (mujoco_ros2_control's odom_free_joint_name)
 
 Resources used:

--- a/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
+++ b/mujoco_ros2_control_demos/launch/05_base_velocity_plugin.launch.py
@@ -17,9 +17,9 @@ Tutorial 5: Base Velocity Plugin
 
 This tutorial demonstrates driving a mobile/floating-base robot with BaseVelocityPlugin.
 The mobile base is a free-floating, wheeled chassis (MJCF <freejoint>) carrying a
-Because the override is kinematic, it outranks the physics engine: the mounted arm's 
-reaction forces as it swings have no effect on the base's velocity, but neither does 
-colliding with the wall in the scene -- see doc/tutorials.rst (Tutorial 5) and 
+Because the override is kinematic, it outranks the physics engine: the mounted arm's
+reaction forces as it swings have no effect on the base's velocity, but neither does
+colliding with the wall in the scene -- see doc/tutorials.rst (Tutorial 5) and
 mobile_base.xml for the full rationale.
 
 Key concepts:

--- a/mujoco_ros2_control_plugins/CMakeLists.txt
+++ b/mujoco_ros2_control_plugins/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(mujoco_ros2_control_plugins INTERFACE
 add_library(mujoco_ros2_control_plugins_impl SHARED
   src/heartbeat_publisher_plugin.cpp
   src/external_wrench_plugin.cpp
+  src/base_velocity_plugin.cpp
   src/free_joint_state_publisher_plugin.cpp
   src/camera_plugin.cpp
   src/mujoco_3d_lidar_plugin.cpp

--- a/mujoco_ros2_control_plugins/CMakeLists.txt
+++ b/mujoco_ros2_control_plugins/CMakeLists.txt
@@ -163,6 +163,22 @@ if(BUILD_TESTING)
     "$<TARGET_LINKER_FILE:tinyxml2::tinyxml2>"
     "LINKER:--pop-state"
   )
+
+  ament_add_gtest(test_base_velocity_plugin
+    test/test_base_velocity_plugin.cpp
+  )
+  target_include_directories(test_base_velocity_plugin PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_base_velocity_plugin
+    mujoco_ros2_control_plugins_impl
+    ${geometry_msgs_TARGETS}
+  )
+  target_link_options(test_base_velocity_plugin PUBLIC
+    "LINKER:--push-state,--no-as-needed"
+    "$<TARGET_LINKER_FILE:tinyxml2::tinyxml2>"
+    "LINKER:--pop-state"
+  )
 endif()
 
 # Install include directory

--- a/mujoco_ros2_control_plugins/README.md
+++ b/mujoco_ros2_control_plugins/README.md
@@ -15,7 +15,7 @@ Full documentation is maintained in RST format:
 | `HeartbeatPublisherPlugin` | Publishes a heartbeat string to `/mujoco_heartbeat` at 1 Hz |
 | `CameraPlugin` | Publishes MuJoCo RGB-D camera color/depth/info to ROS 2 topics |
 | `ExternalWrenchPlugin` | Applies external wrenches to MuJoCo bodies via a ROS 2 service |
-| `BaseVelocityPlugin` | Drives a mobile/floating-base robot from a `cmd_vel`-style topic via a velocity servo, independent of wheel-ground contact |
+| `BaseVelocityPlugin` | Drives a mobile/floating-base robot from a `cmd_vel`-style topic via a direct free-joint velocity override, independent of wheel-ground contact |
 | `FreeJointStatePublisherPlugin` | Publishes the pose/velocity of free-joint bodies to a topic, in a selectable reference frame |
 | `Mujoco3dLidarPlugin` | Republishes MuJoCo lidar-extension sensor data as `LaserScan`/`PointCloud2` messages |
 | `RangefinderLidarPlugin` | **[Deprecated]** Wraps MuJoCo rangefinder sensors as `LaserScan` publishers |

--- a/mujoco_ros2_control_plugins/README.md
+++ b/mujoco_ros2_control_plugins/README.md
@@ -15,6 +15,7 @@ Full documentation is maintained in RST format:
 | `HeartbeatPublisherPlugin` | Publishes a heartbeat string to `/mujoco_heartbeat` at 1 Hz |
 | `CameraPlugin` | Publishes MuJoCo RGB-D camera color/depth/info to ROS 2 topics |
 | `ExternalWrenchPlugin` | Applies external wrenches to MuJoCo bodies via a ROS 2 service |
+| `BaseVelocityPlugin` | Drives a mobile/floating-base robot from a `cmd_vel`-style topic via a velocity servo, independent of wheel-ground contact |
 | `FreeJointStatePublisherPlugin` | Publishes the pose/velocity of free-joint bodies to a topic, in a selectable reference frame |
 | `Mujoco3dLidarPlugin` | Republishes MuJoCo lidar-extension sensor data as `LaserScan`/`PointCloud2` messages |
 | `RangefinderLidarPlugin` | **[Deprecated]** Wraps MuJoCo rangefinder sensors as `LaserScan` publishers |

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -373,11 +373,12 @@ BaseVelocity Parameters
 
 .. note::
 
-   The plugin's own parameters (``body``, ``cmd_vel_topic``, etc.) are declared directly on the
-   underlying ``ros2_control_node`` node, not namespaced under the plugin's instance name --
-   ``rclcpp::Node::create_sub_node()`` only extends the namespace of topics/services/actions, not
-   parameters. Only ``type`` is read from under ``mujoco_plugins.<instance_name>``. Avoid loading
-   two plugin instances that declare the same parameter name at the same time.
+   ``rclcpp::Node::create_sub_node()`` (used to give this plugin its own topic/service
+   namespace) does not namespace *parameters* -- they're always node-level. So the plugin's own
+   parameters are declared under an explicitly-built ``mujoco_plugins.<instance_name>.`` prefix
+   (matching the plugin's actual instance key in your YAML), rather than relying on the
+   sub-node's namespace the way topics/services do. This mirrors the pattern used by
+   ``CameraPlugin``/``RangefinderLidarPlugin``/``Mujoco3dLidarPlugin``.
 
 .. note::
 
@@ -400,12 +401,10 @@ BaseVelocity Parameters
        mujoco_plugins:
          base_velocity:
            type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
-       # BaseVelocityPlugin's own parameters are node-level (see note above), not nested
-       # under the "base_velocity" key.
-       body: base_link
-       cmd_vel_topic: /cmd_vel
-       kv_linear: 200.0
-       kv_yaw: 50.0
+           body: base_link
+           cmd_vel_topic: /cmd_vel
+           kv_linear: 200.0
+           kv_yaw: 50.0
 
 **Example: teleop from the command line**
 

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -359,7 +359,9 @@ BaseVelocity Parameters
      - ``bool``
      - ``false``
      - Subscribe to ``geometry_msgs/TwistStamped`` instead of ``geometry_msgs/Twist`` (e.g. for
-       Nav2, which publishes stamped twists by default in some configurations).
+       Nav2, which publishes stamped twists by default in some configurations). Even when the param
+       is set to ``true``, the header info is internally not used and only the time at which the
+       message received internal to the plugin takes precedence.
    * - ``max_linear_velocity``
      - ``double``
      - ``+inf``

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -285,6 +285,119 @@ ExternalWrench Parameters
            force_arrow_scale: 0.01      # 100 N  → 1 m arrow
            torque_arrow_scale: 0.1      # 10 N·m → 1 m arrow
 
+BaseVelocityPlugin
+~~~~~~~~~~~~~~~~~~
+
+Drives a mobile or floating-base robot from a commanded planar body velocity (``vx``, ``vy``,
+yaw-rate) received on a ``cmd_vel``-style topic, without relying on wheel-ground contact.
+
+Wheel-terrain friction/slip is often unreliable enough to make it a poor foundation for testing
+navigation stacks. This plugin instead runs a proportional velocity servo directly on the base
+body's free joint and applies the result as a world-frame wrench via ``data->xfrc_applied``.
+Because the servo is force-based rather than a kinematic override, the base still collides
+realistically with walls and obstacles — only the *propulsion* bypasses wheel-ground contact, not
+collision response.
+
+Only the planar degrees of freedom are driven: body-frame linear x/y and yaw-rate (about body z).
+Vertical motion and roll/pitch are left entirely to gravity and contacts, so the base settles onto
+the ground normally.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 0
+
+   * - **Topic**
+     - ``cmd_vel`` (``geometry_msgs/msg/Twist``, or ``TwistStamped`` if ``use_stamped_twist`` is
+       set)
+
+Servo Behavior
+^^^^^^^^^^^^^^
+
+The servo error is computed in the body frame from the commanded velocity ``v_cmd``/``w_cmd`` and
+the body's measured velocity ``v_meas``/``w_meas`` (via ``mj_objectVelocity`` in local-frame mode):
+
+.. code-block:: text
+
+   F_body = clamp(kv_linear * (v_cmd - v_meas), ±max_force)   (x, y)
+   T_body = clamp(kv_yaw    * (w_cmd - w_meas), ±max_torque)  (about z)
+
+``F_body``/``T_body`` are then rotated into the world frame using the body's current orientation
+and written into ``data->xfrc_applied`` at the body's slot, applied at its centre of mass.
+A command that hasn't been refreshed within ``cmd_timeout`` seconds is treated as zero (safety
+stop) rather than left to coast on the last known wrench.
+
+BaseVelocity Parameters
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 25 15 15 45
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``body``
+     - ``string``
+     - *(required)*
+     - MJCF body name of the base. Must carry a ``<freejoint/>`` for the servo to have any effect.
+   * - ``cmd_vel_topic``
+     - ``string``
+     - ``cmd_vel``
+     - Command topic name.
+   * - ``use_stamped_twist``
+     - ``bool``
+     - ``false``
+     - Subscribe to ``geometry_msgs/TwistStamped`` instead of ``geometry_msgs/Twist`` (e.g. for
+       Nav2, which publishes stamped twists by default in some configurations).
+   * - ``kv_linear``
+     - ``double``
+     - ``200.0``
+     - Linear servo gain [N per m/s].
+   * - ``kv_yaw``
+     - ``double``
+     - ``50.0``
+     - Yaw servo gain [N·m per rad/s].
+   * - ``max_force``
+     - ``double``
+     - ``1000.0``
+     - Per-axis linear force saturation [N].
+   * - ``max_torque``
+     - ``double``
+     - ``500.0``
+     - Yaw torque saturation [N·m].
+   * - ``cmd_timeout``
+     - ``double``
+     - ``0.5``
+     - Seconds since the last received command after which it is treated as zero.
+
+**Example configuration**
+
+.. code-block:: yaml
+
+   /**:
+     ros__parameters:
+       mujoco_plugins:
+         base_velocity:
+           type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
+           body: base_link
+           cmd_vel_topic: /cmd_vel
+           kv_linear: 200.0
+           kv_yaw: 50.0
+
+**Example: teleop from the command line**
+
+.. code-block:: bash
+
+   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist \
+     "{linear: {x: 0.5}, angular: {z: 0.2}}" --rate 10
+
+.. note::
+
+   Odometry for the floating base is published independently by ``mujoco_ros2_control`` itself
+   (parameter ``odom_free_joint_name``, default topic ``/simulator/floating_base_state``) — this
+   plugin only drives the base, it does not publish odometry.
+
 FreeJointStatePublisherPlugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -371,6 +371,26 @@ BaseVelocity Parameters
      - ``0.5``
      - Seconds since the last received command after which it is treated as zero.
 
+.. note::
+
+   The plugin's own parameters (``body``, ``cmd_vel_topic``, etc.) are declared directly on the
+   underlying ``ros2_control_node`` node, not namespaced under the plugin's instance name --
+   ``rclcpp::Node::create_sub_node()`` only extends the namespace of topics/services/actions, not
+   parameters. Only ``type`` is read from under ``mujoco_plugins.<instance_name>``. Avoid loading
+   two plugin instances that declare the same parameter name at the same time.
+
+.. note::
+
+   ``kv_linear``/``kv_yaw`` are proportional-only gains with no damping term, so each is only
+   stable up to roughly ``2 * I / control_period`` for the body's mass (linear) or rotational
+   inertia about the relevant axis (yaw), where ``control_period`` is ``1 / update_rate`` from
+   ``controller_manager``. Push a gain past that ceiling and the axis diverges into a growing
+   oscillation instead of converging -- this is highly sensitive to the body's actual inertia, so
+   a gain that's stable for one robot can be unstable for another (e.g. adding a rigidly-coupled
+   mounted joint that effectively stiffens the body can lower the ceiling for an axis that was
+   previously stable at the same gain). If a commanded velocity looks shaky or runs away rather
+   than settling, lower the corresponding gain first before assuming it's a modelling bug.
+
 **Example configuration**
 
 .. code-block:: yaml
@@ -380,10 +400,12 @@ BaseVelocity Parameters
        mujoco_plugins:
          base_velocity:
            type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
-           body: base_link
-           cmd_vel_topic: /cmd_vel
-           kv_linear: 200.0
-           kv_yaw: 50.0
+       # BaseVelocityPlugin's own parameters are node-level (see note above), not nested
+       # under the "base_velocity" key.
+       body: base_link
+       cmd_vel_topic: /cmd_vel
+       kv_linear: 200.0
+       kv_yaw: 50.0
 
 **Example: teleop from the command line**
 

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -292,11 +292,20 @@ Drives a mobile or floating-base robot from a commanded planar body velocity (``
 yaw-rate) received on a ``cmd_vel``-style topic, without relying on wheel-ground contact.
 
 Wheel-terrain friction/slip is often unreliable enough to make it a poor foundation for testing
-navigation stacks. This plugin instead runs a proportional velocity servo directly on the base
-body's free joint and applies the result as a world-frame wrench via ``data->xfrc_applied``.
-Because the servo is force-based rather than a kinematic override, the base still collides
-realistically with walls and obstacles — only the *propulsion* bypasses wheel-ground contact, not
-collision response.
+navigation stacks. This plugin instead requests a hard **kinematic override** of the base body's
+free-joint velocity every cycle: the (optionally clamped) commanded planar velocity is written
+directly into the joint's ``qvel``, bypassing force/mass dynamics entirely for the driven DOFs.
+There is no gain to tune and no convergence delay — the measured body velocity on the driven axes
+is exactly the commanded velocity on the very next simulation step.
+
+.. warning::
+
+   Because the override is kinematic, it outranks MuJoCo's contact solver. **Colliding with a
+   wall or obstacle will not slow the base down** on the driven axes — the commanded velocity is
+   reasserted every cycle regardless of what any contact computed in between. If you need
+   physically realistic collision response while driving the base, this plugin is not the right
+   tool; the trade-off it makes is exact, disturbance-immune velocity tracking in exchange for
+   giving up momentum-conserving contacts on the driven DOFs.
 
 Only the planar degrees of freedom are driven: body-frame linear x/y and yaw-rate (about body z).
 Vertical motion and roll/pitch are left entirely to gravity and contacts, so the base settles onto
@@ -310,21 +319,21 @@ the ground normally.
      - ``cmd_vel`` (``geometry_msgs/msg/Twist``, or ``TwistStamped`` if ``use_stamped_twist`` is
        set)
 
-Servo Behavior
-^^^^^^^^^^^^^^
+Velocity Override Behavior
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The servo error is computed in the body frame from the commanded velocity ``v_cmd``/``w_cmd`` and
-the body's measured velocity ``v_meas``/``w_meas`` (via ``mj_objectVelocity`` in local-frame mode):
+Each cycle, the commanded body-frame ``vx``/``vy`` is clamped to ``max_linear_velocity`` (preserving
+direction) and rotated into the world frame using the body's current orientation, since a free
+joint's linear ``qvel`` is expressed in the world frame. The commanded yaw-rate is clamped to
+``max_yaw_rate`` and used as-is, since a free joint's rotational ``qvel`` is already expressed in
+the body-local frame. The result is written directly into ``data->qvel`` during ``update()``:
+the core NaN-fills ``qvel`` before every plugin's ``update()`` runs, so writing a finite value
+into an entry requests a hard velocity override there, applied by the core simulation as a direct
+``qvel`` write immediately before the next physics step (see "Creating Your Own Plugin" below for
+the full mechanism, which is not available through ``xfrc_applied`` alone).
 
-.. code-block:: text
-
-   F_body = clamp(kv_linear * (v_cmd - v_meas), ±max_force)   (x, y)
-   T_body = clamp(kv_yaw    * (w_cmd - w_meas), ±max_torque)  (about z)
-
-``F_body``/``T_body`` are then rotated into the world frame using the body's current orientation
-and written into ``data->xfrc_applied`` at the body's slot, applied at its centre of mass.
 A command that hasn't been refreshed within ``cmd_timeout`` seconds is treated as zero (safety
-stop) rather than left to coast on the last known wrench.
+stop) rather than left to coast on the last commanded velocity.
 
 BaseVelocity Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -340,7 +349,8 @@ BaseVelocity Parameters
    * - ``body``
      - ``string``
      - *(required)*
-     - MJCF body name of the base. Must carry a ``<freejoint/>`` for the servo to have any effect.
+     - MJCF body name of the base. Must carry a ``<freejoint/>`` — ``init()`` fails otherwise,
+       since there is no ``qvel`` to override without one.
    * - ``cmd_vel_topic``
      - ``string``
      - ``cmd_vel``
@@ -350,22 +360,16 @@ BaseVelocity Parameters
      - ``false``
      - Subscribe to ``geometry_msgs/TwistStamped`` instead of ``geometry_msgs/Twist`` (e.g. for
        Nav2, which publishes stamped twists by default in some configurations).
-   * - ``kv_linear``
+   * - ``max_linear_velocity``
      - ``double``
-     - ``200.0``
-     - Linear servo gain [N per m/s].
-   * - ``kv_yaw``
+     - ``+inf``
+     - Clamps the commanded planar speed ``sqrt(vx^2+vy^2)`` [m/s]; unset (the default) passes
+       the command through unclamped.
+   * - ``max_yaw_rate``
      - ``double``
-     - ``50.0``
-     - Yaw servo gain [N·m per rad/s].
-   * - ``max_force``
-     - ``double``
-     - ``1000.0``
-     - Per-axis linear force saturation [N].
-   * - ``max_torque``
-     - ``double``
-     - ``500.0``
-     - Yaw torque saturation [N·m].
+     - ``+inf``
+     - Clamps the commanded yaw-rate [rad/s]; unset (the default) passes the command through
+       unclamped.
    * - ``cmd_timeout``
      - ``double``
      - ``0.5``
@@ -380,18 +384,6 @@ BaseVelocity Parameters
    sub-node's namespace the way topics/services do. This mirrors the pattern used by
    ``CameraPlugin``/``RangefinderLidarPlugin``/``Mujoco3dLidarPlugin``.
 
-.. note::
-
-   ``kv_linear``/``kv_yaw`` are proportional-only gains with no damping term, so each is only
-   stable up to roughly ``2 * I / control_period`` for the body's mass (linear) or rotational
-   inertia about the relevant axis (yaw), where ``control_period`` is ``1 / update_rate`` from
-   ``controller_manager``. Push a gain past that ceiling and the axis diverges into a growing
-   oscillation instead of converging -- this is highly sensitive to the body's actual inertia, so
-   a gain that's stable for one robot can be unstable for another (e.g. adding a rigidly-coupled
-   mounted joint that effectively stiffens the body can lower the ceiling for an axis that was
-   previously stable at the same gain). If a commanded velocity looks shaky or runs away rather
-   than settling, lower the corresponding gain first before assuming it's a modelling bug.
-
 **Example configuration**
 
 .. code-block:: yaml
@@ -399,12 +391,10 @@ BaseVelocity Parameters
    /**:
      ros__parameters:
        mujoco_plugins:
-         base_velocity:
+         base_velocity_plugin:
            type: "mujoco_ros2_control_plugins/BaseVelocityPlugin"
            body: base_link
            cmd_vel_topic: /cmd_vel
-           kv_linear: 200.0
-           kv_yaw: 50.0
 
 **Example: teleop from the command line**
 
@@ -703,6 +693,21 @@ Plugin Lifecycle
    before the controller update and ``write`` loops. Changes to ``mjData`` here are visible to
    controllers and affect the next simulation step. This runs in a real-time thread — avoid
    blocking operations.
+
+   ``data->qvel`` here has one special property: it is **NaN-filled before every plugin's**
+   ``update()`` **runs this cycle**. Most plugins never touch it and can ignore this entirely.
+   A plugin that needs to *dictate* a free joint's velocity exactly (``BaseVelocityPlugin`` is
+   the example in this package) can write a finite value into any ``qvel`` entry to request a
+   hard velocity override there — the core simulation applies every non-NaN entry as a direct
+   ``qvel`` write immediately before the next ``mj_step``, bypassing the normal mass/contact
+   dynamics for that DOF. This exists because plugins only ever see a throwaway copy of
+   ``mjData`` — only ``ctrl``, ``qfrc_applied``, and ``xfrc_applied`` are otherwise copied back
+   into the real simulation state, so this NaN convention is the only way a plugin can
+   influence ``qvel`` at all. Leaving an entry ``NaN`` keeps its normal physics-driven value;
+   because of this, ``data->qvel`` cannot be read here for the body's actual velocity either,
+   since it isn't restored to a real value until after every plugin's ``update()`` has run.
+   See ``MuJoCoROS2ControlPluginBase::update()``'s doc comment in
+   ``mujoco_ros2_control_plugins_base.hpp`` for the authoritative reference.
 3. **Cleanup** (``cleanup``): Called when shutting down. Release any resources acquired in
    ``init``.
 

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -54,6 +54,12 @@ public:
    * affect the next simulation step.
    * @note This method will be called in a real-time thread, so it should avoid blocking operations and should be
    * efficient.
+   * @note data->qvel is NaN-filled before every plugin's update() runs this cycle. Write a finite value into any
+   * entry to request a hard velocity override on that DOF -- it bypasses the normal mass/contact dynamics for that
+   * DOF this step, overwriting mj_data_->qvel directly right before the next mj_step. Leave an entry NaN to keep its
+   * normal physics-driven value untouched. This is the only channel a plugin has to influence qvel: unlike
+   * ctrl/qfrc_applied/xfrc_applied, data->qvel here cannot be read for the body's actual velocity, since it is not
+   * restored to a real value until after every plugin's update() has run this cycle.
    */
   virtual void update(const mjModel* model, mjData* data) = 0;
 

--- a/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins.xml
+++ b/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins.xml
@@ -54,10 +54,10 @@
          base_class_type="mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase">
     <description>
       Drives a mobile/floating-base robot from a commanded planar body velocity (vx, vy,
-      yaw-rate) received on a cmd_vel-style topic, via a proportional velocity servo applied
-      as a world-frame wrench on the base body's free joint (data->xfrc_applied). Propulsion no
-      longer depends on wheel-ground contact/friction, while collisions with obstacles are
-      still governed by the physics engine as normal.
+      yaw-rate) received on a cmd_vel-style topic, via a hard kinematic override of the base
+      body's free-joint velocity applied directly before every physics step. Propulsion no
+      longer depends on wheel-ground contact/friction and the commanded velocity is tracked
+      exactly, but this also means contacts no longer slow the base down on the driven axes.
     </description>
   </class>
   <class name="mujoco_ros2_control_plugins/RangefinderLidarPlugin"

--- a/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins.xml
+++ b/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins.xml
@@ -49,6 +49,17 @@
       will have their data copied and published whenever it becomes available.
     </description>
   </class>
+  <class name="mujoco_ros2_control_plugins/BaseVelocityPlugin"
+         type="mujoco_ros2_control_plugins::BaseVelocityPlugin"
+         base_class_type="mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase">
+    <description>
+      Drives a mobile/floating-base robot from a commanded planar body velocity (vx, vy,
+      yaw-rate) received on a cmd_vel-style topic, via a proportional velocity servo applied
+      as a world-frame wrench on the base body's free joint (data->xfrc_applied). Propulsion no
+      longer depends on wheel-ground contact/friction, while collisions with obstacles are
+      still governed by the physics engine as normal.
+    </description>
+  </class>
   <class name="mujoco_ros2_control_plugins/RangefinderLidarPlugin"
          type="mujoco_ros2_control_plugins::RangefinderLidarPlugin"
          base_class_type="mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase">

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -24,16 +24,23 @@ namespace mujoco_ros2_control_plugins
 
 namespace
 {
+std::string namespacedParamName(const rclcpp::Node::SharedPtr& node, const std::string& name)
+{
+  const std::string sub_ns = node->get_sub_namespace();
+  return sub_ns.empty() ? name : ("mujoco_plugins." + sub_ns + "." + name);
+}
+
 // Declares `name` with `default_value` only if it hasn't already been declared
 // (e.g. by a test fixture), matching the pattern used by ExternalWrenchPlugin.
 template <typename T>
 T declareOrGetParameter(const rclcpp::Node::SharedPtr& node, const std::string& name, const T& default_value)
 {
-  if (!node->has_parameter(name))
+  const std::string full_name = namespacedParamName(node, name);
+  if (!node->has_parameter(full_name))
   {
-    node->declare_parameter(name, default_value);
+    node->declare_parameter(full_name, default_value);
   }
-  return node->get_parameter(name).get_value<T>();
+  return node->get_parameter(full_name).get_value<T>();
 }
 }  // namespace
 

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -14,6 +14,7 @@
 
 #include "base_velocity_plugin.hpp"
 
+#include <cmath>
 #include <mutex>
 #include <string>
 
@@ -65,30 +66,26 @@ bool BaseVelocityPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model
     return false;
   }
 
-  // A free joint is what lets the servo actually move the body; warn (but don't
-  // fail) if the body is welded/fixed, since the wrench would then have no effect.
-  bool has_free_joint = false;
+  // A free joint's qvel is what the velocity override writes into -- without one, there is
+  // nothing for this plugin to drive, so this is a hard failure rather than a warning.
   for (int j = 0; j < model_->njnt; ++j)
   {
     if (model_->jnt_bodyid[j] == body_id_ && model_->jnt_type[j] == mjJNT_FREE)
     {
-      has_free_joint = true;
+      qvel_adr_ = model_->jnt_dofadr[j];
       break;
     }
   }
-  if (!has_free_joint)
+  if (qvel_adr_ < 0)
   {
-    RCLCPP_WARN(logger_,
-                "Body '%s' has no free joint; BaseVelocityPlugin's servo wrench will have no effect on it.",
-                body_name.c_str());
+    RCLCPP_ERROR(logger_, "Body '%s' has no free joint; BaseVelocityPlugin cannot drive it.", body_name.c_str());
+    return false;
   }
 
   const std::string cmd_vel_topic = declareOrGetParameter<std::string>(node_, "cmd_vel_topic", "cmd_vel");
   const bool use_stamped_twist = declareOrGetParameter<bool>(node_, "use_stamped_twist", false);
-  kv_linear_ = declareOrGetParameter<double>(node_, "kv_linear", kv_linear_);
-  kv_yaw_ = declareOrGetParameter<double>(node_, "kv_yaw", kv_yaw_);
-  max_force_ = declareOrGetParameter<double>(node_, "max_force", max_force_);
-  max_torque_ = declareOrGetParameter<double>(node_, "max_torque", max_torque_);
+  max_linear_velocity_ = declareOrGetParameter<double>(node_, "max_linear_velocity", max_linear_velocity_);
+  max_yaw_rate_ = declareOrGetParameter<double>(node_, "max_yaw_rate", max_yaw_rate_);
   const double cmd_timeout_sec = declareOrGetParameter<double>(node_, "cmd_timeout", 0.5);
   cmd_timeout_ = rclcpp::Duration::from_seconds(cmd_timeout_sec);
 
@@ -106,9 +103,9 @@ bool BaseVelocityPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model
 
   RCLCPP_INFO(logger_,
               "BaseVelocityPlugin initialised for body '%s'. Listening for %s on '%s'. "
-              "kv_linear=%.2f kv_yaw=%.2f cmd_timeout=%.2fs",
-              body_name.c_str(), use_stamped_twist ? "TwistStamped" : "Twist", cmd_vel_topic.c_str(), kv_linear_,
-              kv_yaw_, cmd_timeout_sec);
+              "max_linear_velocity=%.2f max_yaw_rate=%.2f cmd_timeout=%.2fs",
+              body_name.c_str(), use_stamped_twist ? "TwistStamped" : "Twist", cmd_vel_topic.c_str(),
+              max_linear_velocity_, max_yaw_rate_, cmd_timeout_sec);
 
   return true;
 }
@@ -131,7 +128,7 @@ void BaseVelocityPlugin::storeCommand(double vx, double vy, double wz)
 
 void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
 {
-  if (body_id_ < 0)
+  if (body_id_ < 0 || qvel_adr_ < 0)
   {
     return;
   }
@@ -146,8 +143,7 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
   }
 
   // Step 2 - a stale (or never-received) command is treated as a zero-velocity
-  // command, i.e. the base is commanded to stop rather than coast under whatever
-  // wrench was last computed.
+  // command, i.e. the base is commanded to stop rather than coast on the last override.
   double vx_cmd = 0.0, vy_cmd = 0.0, wz_cmd = 0.0;
   if (cached_cmd_.valid)
   {
@@ -160,33 +156,22 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
     }
   }
 
-  // Step 3 - measure the body's current velocity in its own (body) frame.
-  mjtNum vel6[6];  // (rot:lin) = [wx, wy, wz, vx, vy, vz]
-  mj_objectVelocity(model_, data, mjOBJ_BODY, body_id_, vel6, /*flg_local=*/1);
-  const double vx_meas = vel6[3];
-  const double vy_meas = vel6[4];
-  const double wz_meas = vel6[2];
-
-  // Step 4 - proportional velocity servo, body frame, saturated.
-  const double f_body_x = mju_clip(kv_linear_ * (vx_cmd - vx_meas), -max_force_, max_force_);
-  const double f_body_y = mju_clip(kv_linear_ * (vy_cmd - vy_meas), -max_force_, max_force_);
-  const double t_body_z = mju_clip(kv_yaw_ * (wz_cmd - wz_meas), -max_torque_, max_torque_);
-
-  // Step 5 - rotate the body-frame force/torque into the world frame. xmat is the
-  // row-major 3x3 body->world rotation. Applying the force at the body's centre of
-  // mass (i.e. no offset application point) means the torque needs no additional
-  // wrench-transport term, unlike ExternalWrenchPlugin's arbitrary application point.
-  const mjtNum* xmat = data->xmat + body_id_ * 9;
-  const mjtNum force_world[3] = { xmat[0] * f_body_x + xmat[1] * f_body_y, xmat[3] * f_body_x + xmat[4] * f_body_y,
-                                  xmat[6] * f_body_x + xmat[7] * f_body_y };
-  const mjtNum torque_world[3] = { xmat[2] * t_body_z, xmat[5] * t_body_z, xmat[8] * t_body_z };
-
-  mjtNum* base = data->xfrc_applied + body_id_ * 6;
-  for (int j = 0; j < 3; ++j)
+  // Step 3 - clamp to the configured limits, preserving direction for the planar speed.
+  const double linear_speed = std::hypot(vx_cmd, vy_cmd);
+  if (linear_speed > max_linear_velocity_)
   {
-    base[j] = force_world[j];
-    base[3 + j] = torque_world[j];
+    const double scale = max_linear_velocity_ / linear_speed;
+    vx_cmd *= scale;
+    vy_cmd *= scale;
   }
+  wz_cmd = mju_clip(wz_cmd, -max_yaw_rate_, max_yaw_rate_);
+
+  // Step 4 - rotate the commanded body-frame linear velocity into the world frame (a free
+  // joint's linear qvel is world-frame)
+  const mjtNum* xmat = data->xmat + body_id_ * 9;
+  data->qvel[qvel_adr_ + 0] = xmat[0] * vx_cmd + xmat[1] * vy_cmd;
+  data->qvel[qvel_adr_ + 1] = xmat[3] * vx_cmd + xmat[4] * vy_cmd;
+  data->qvel[qvel_adr_ + 5] = wz_cmd;
 }
 
 void BaseVelocityPlugin::cleanup()

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -119,29 +119,11 @@ void BaseVelocityPlugin::twistStampedCallback(const geometry_msgs::msg::TwistSta
 void BaseVelocityPlugin::storeCommand(double vx, double vy, double wz)
 {
   std::lock_guard<std::mutex> lock(cmd_mutex_);
-  cmd_vx_ = vx;
-  cmd_vy_ = vy;
-  cmd_wz_ = wz;
-  last_cmd_time_ = node_->get_clock()->now();
-  has_cmd_ = true;
+  latest_cmd_ = { vx, vy, wz, node_->get_clock()->now(), true };
 }
 
 void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
 {
-  // Step 0 - undo the xfrc_applied contribution written in the previous cycle, so a
-  // stale servo force is never left behind (mirrors ExternalWrenchPlugin's pattern).
-  // When the system interface also zeroes xfrc_applied before calling update(), this
-  // is a harmless no-op on already-zero values.
-  if (prev_written_)
-  {
-    mjtNum* base = data->xfrc_applied + body_id_ * 6;
-    for (int j = 0; j < 6; ++j)
-    {
-      base[j] = 0.0;
-    }
-    prev_written_ = false;
-  }
-
   if (body_id_ < 0)
   {
     return;
@@ -152,11 +134,7 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
   // successfully cached values.
   if (cmd_mutex_.try_lock())
   {
-    cached_cmd_vx_ = cmd_vx_;
-    cached_cmd_vy_ = cmd_vy_;
-    cached_cmd_wz_ = cmd_wz_;
-    cached_cmd_time_ = last_cmd_time_;
-    cached_has_cmd_ = has_cmd_;
+    cached_cmd_ = latest_cmd_;
     cmd_mutex_.unlock();
   }
 
@@ -164,14 +142,14 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
   // command, i.e. the base is commanded to stop rather than coast under whatever
   // wrench was last computed.
   double vx_cmd = 0.0, vy_cmd = 0.0, wz_cmd = 0.0;
-  if (cached_has_cmd_)
+  if (cached_cmd_.valid)
   {
-    const rclcpp::Duration age = node_->get_clock()->now() - cached_cmd_time_;
+    const rclcpp::Duration age = node_->get_clock()->now() - cached_cmd_.time;
     if (age <= cmd_timeout_)
     {
-      vx_cmd = cached_cmd_vx_;
-      vy_cmd = cached_cmd_vy_;
-      wz_cmd = cached_cmd_wz_;
+      vx_cmd = cached_cmd_.vx;
+      vy_cmd = cached_cmd_.vy;
+      wz_cmd = cached_cmd_.wz;
     }
   }
 
@@ -202,7 +180,6 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
     base[j] = force_world[j];
     base[3 + j] = torque_world[j];
   }
-  prev_written_ = true;
 }
 
 void BaseVelocityPlugin::cleanup()

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -1,0 +1,220 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base_velocity_plugin.hpp"
+
+#include <mutex>
+#include <string>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace mujoco_ros2_control_plugins
+{
+
+namespace
+{
+// Declares `name` with `default_value` only if it hasn't already been declared
+// (e.g. by a test fixture), matching the pattern used by ExternalWrenchPlugin.
+template <typename T>
+T declareOrGetParameter(const rclcpp::Node::SharedPtr& node, const std::string& name, const T& default_value)
+{
+  if (!node->has_parameter(name))
+  {
+    node->declare_parameter(name, default_value);
+  }
+  return node->get_parameter(name).get_value<T>();
+}
+}  // namespace
+
+bool BaseVelocityPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* /*data*/)
+{
+  node_ = node;
+  logger_ = node_->get_logger().get_child(node->get_sub_namespace());
+  model_ = model;
+
+  // "body" has no sane default -- it must name the base's MJCF body.
+  const std::string body_name = declareOrGetParameter<std::string>(node_, "body", "");
+  if (body_name.empty())
+  {
+    RCLCPP_ERROR(logger_, "BaseVelocityPlugin requires the 'body' parameter (MJCF body name).");
+    return false;
+  }
+
+  body_id_ = mj_name2id(model_, mjOBJ_BODY, body_name.c_str());
+  if (body_id_ < 0)
+  {
+    RCLCPP_ERROR(logger_, "Body '%s' not found in MuJoCo model.", body_name.c_str());
+    return false;
+  }
+
+  // A free joint is what lets the servo actually move the body; warn (but don't
+  // fail) if the body is welded/fixed, since the wrench would then have no effect.
+  bool has_free_joint = false;
+  for (int j = 0; j < model_->njnt; ++j)
+  {
+    if (model_->jnt_bodyid[j] == body_id_ && model_->jnt_type[j] == mjJNT_FREE)
+    {
+      has_free_joint = true;
+      break;
+    }
+  }
+  if (!has_free_joint)
+  {
+    RCLCPP_WARN(logger_,
+                "Body '%s' has no free joint; BaseVelocityPlugin's servo wrench will have no effect on it.",
+                body_name.c_str());
+  }
+
+  const std::string cmd_vel_topic = declareOrGetParameter<std::string>(node_, "cmd_vel_topic", "cmd_vel");
+  const bool use_stamped_twist = declareOrGetParameter<bool>(node_, "use_stamped_twist", false);
+  kv_linear_ = declareOrGetParameter<double>(node_, "kv_linear", kv_linear_);
+  kv_yaw_ = declareOrGetParameter<double>(node_, "kv_yaw", kv_yaw_);
+  max_force_ = declareOrGetParameter<double>(node_, "max_force", max_force_);
+  max_torque_ = declareOrGetParameter<double>(node_, "max_torque", max_torque_);
+  const double cmd_timeout_sec = declareOrGetParameter<double>(node_, "cmd_timeout", 0.5);
+  cmd_timeout_ = rclcpp::Duration::from_seconds(cmd_timeout_sec);
+
+  if (use_stamped_twist)
+  {
+    twist_stamped_sub_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(
+        cmd_vel_topic, rclcpp::SystemDefaultsQoS(),
+        [this](const geometry_msgs::msg::TwistStamped& msg) { twistStampedCallback(msg); });
+  }
+  else
+  {
+    twist_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(
+        cmd_vel_topic, rclcpp::SystemDefaultsQoS(), [this](const geometry_msgs::msg::Twist& msg) { twistCallback(msg); });
+  }
+
+  RCLCPP_INFO(logger_,
+              "BaseVelocityPlugin initialised for body '%s'. Listening for %s on '%s'. "
+              "kv_linear=%.2f kv_yaw=%.2f cmd_timeout=%.2fs",
+              body_name.c_str(), use_stamped_twist ? "TwistStamped" : "Twist", cmd_vel_topic.c_str(), kv_linear_,
+              kv_yaw_, cmd_timeout_sec);
+
+  return true;
+}
+
+void BaseVelocityPlugin::twistCallback(const geometry_msgs::msg::Twist& msg)
+{
+  storeCommand(msg.linear.x, msg.linear.y, msg.angular.z);
+}
+
+void BaseVelocityPlugin::twistStampedCallback(const geometry_msgs::msg::TwistStamped& msg)
+{
+  storeCommand(msg.twist.linear.x, msg.twist.linear.y, msg.twist.angular.z);
+}
+
+void BaseVelocityPlugin::storeCommand(double vx, double vy, double wz)
+{
+  std::lock_guard<std::mutex> lock(cmd_mutex_);
+  cmd_vx_ = vx;
+  cmd_vy_ = vy;
+  cmd_wz_ = wz;
+  last_cmd_time_ = node_->get_clock()->now();
+  has_cmd_ = true;
+}
+
+void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
+{
+  // Step 0 - undo the xfrc_applied contribution written in the previous cycle, so a
+  // stale servo force is never left behind (mirrors ExternalWrenchPlugin's pattern).
+  // When the system interface also zeroes xfrc_applied before calling update(), this
+  // is a harmless no-op on already-zero values.
+  if (prev_written_)
+  {
+    mjtNum* base = data->xfrc_applied + body_id_ * 6;
+    for (int j = 0; j < 6; ++j)
+    {
+      base[j] = 0.0;
+    }
+    prev_written_ = false;
+  }
+
+  if (body_id_ < 0)
+  {
+    return;
+  }
+
+  // Step 1 - refresh the cached command from the subscription callback without
+  // blocking the real-time thread; if the lock is contended, keep using the last
+  // successfully cached values.
+  if (cmd_mutex_.try_lock())
+  {
+    cached_cmd_vx_ = cmd_vx_;
+    cached_cmd_vy_ = cmd_vy_;
+    cached_cmd_wz_ = cmd_wz_;
+    cached_cmd_time_ = last_cmd_time_;
+    cached_has_cmd_ = has_cmd_;
+    cmd_mutex_.unlock();
+  }
+
+  // Step 2 - a stale (or never-received) command is treated as a zero-velocity
+  // command, i.e. the base is commanded to stop rather than coast under whatever
+  // wrench was last computed.
+  double vx_cmd = 0.0, vy_cmd = 0.0, wz_cmd = 0.0;
+  if (cached_has_cmd_)
+  {
+    const rclcpp::Duration age = node_->get_clock()->now() - cached_cmd_time_;
+    if (age <= cmd_timeout_)
+    {
+      vx_cmd = cached_cmd_vx_;
+      vy_cmd = cached_cmd_vy_;
+      wz_cmd = cached_cmd_wz_;
+    }
+  }
+
+  // Step 3 - measure the body's current velocity in its own (body) frame.
+  mjtNum vel6[6];  // (rot:lin) = [wx, wy, wz, vx, vy, vz]
+  mj_objectVelocity(model_, data, mjOBJ_BODY, body_id_, vel6, /*flg_local=*/1);
+  const double vx_meas = vel6[3];
+  const double vy_meas = vel6[4];
+  const double wz_meas = vel6[2];
+
+  // Step 4 - proportional velocity servo, body frame, saturated.
+  const double f_body_x = mju_clip(kv_linear_ * (vx_cmd - vx_meas), -max_force_, max_force_);
+  const double f_body_y = mju_clip(kv_linear_ * (vy_cmd - vy_meas), -max_force_, max_force_);
+  const double t_body_z = mju_clip(kv_yaw_ * (wz_cmd - wz_meas), -max_torque_, max_torque_);
+
+  // Step 5 - rotate the body-frame force/torque into the world frame. xmat is the
+  // row-major 3x3 body->world rotation. Applying the force at the body's centre of
+  // mass (i.e. no offset application point) means the torque needs no additional
+  // wrench-transport term, unlike ExternalWrenchPlugin's arbitrary application point.
+  const mjtNum* xmat = data->xmat + body_id_ * 9;
+  const mjtNum force_world[3] = { xmat[0] * f_body_x + xmat[1] * f_body_y, xmat[3] * f_body_x + xmat[4] * f_body_y,
+                                  xmat[6] * f_body_x + xmat[7] * f_body_y };
+  const mjtNum torque_world[3] = { xmat[2] * t_body_z, xmat[5] * t_body_z, xmat[8] * t_body_z };
+
+  mjtNum* base = data->xfrc_applied + body_id_ * 6;
+  for (int j = 0; j < 3; ++j)
+  {
+    base[j] = force_world[j];
+    base[3 + j] = torque_world[j];
+  }
+  prev_written_ = true;
+}
+
+void BaseVelocityPlugin::cleanup()
+{
+  RCLCPP_INFO(logger_, "BaseVelocityPlugin cleanup.");
+  twist_sub_.reset();
+  twist_stamped_sub_.reset();
+  node_.reset();
+}
+
+}  // namespace mujoco_ros2_control_plugins
+
+// Export the plugin
+PLUGINLIB_EXPORT_CLASS(mujoco_ros2_control_plugins::BaseVelocityPlugin,
+                       mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase)

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -97,8 +97,10 @@ bool BaseVelocityPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model
   }
   else
   {
-    twist_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(
-        cmd_vel_topic, rclcpp::SystemDefaultsQoS(), [this](const geometry_msgs::msg::Twist& msg) { twistCallback(msg); });
+    twist_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(cmd_vel_topic, rclcpp::SystemDefaultsQoS(),
+                                                                       [this](const geometry_msgs::msg::Twist& msg) {
+                                                                         twistCallback(msg);
+                                                                       });
   }
 
   RCLCPP_INFO(logger_,

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -125,16 +125,11 @@ void BaseVelocityPlugin::twistStampedCallback(const geometry_msgs::msg::TwistSta
 void BaseVelocityPlugin::storeCommand(double vx, double vy, double wz)
 {
   std::lock_guard<std::mutex> lock(cmd_mutex_);
-  latest_cmd_ = { vx, vy, wz, node_->get_clock()->now(), true };
+  latest_cmd_ = { vx, vy, wz, node_->get_clock()->now() };
 }
 
 void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
 {
-  if (body_id_ < 0 || qvel_adr_ < 0)
-  {
-    return;
-  }
-
   // Step 1 - refresh the cached command from the subscription callback without
   // blocking the real-time thread; if the lock is contended, keep using the last
   // successfully cached values.
@@ -147,15 +142,12 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
   // Step 2 - a stale (or never-received) command is treated as a zero-velocity
   // command, i.e. the base is commanded to stop rather than coast on the last override.
   double vx_cmd = 0.0, vy_cmd = 0.0, wz_cmd = 0.0;
-  if (cached_cmd_.valid)
+  const rclcpp::Duration age = node_->get_clock()->now() - cached_cmd_.time;
+  if (age <= cmd_timeout_)
   {
-    const rclcpp::Duration age = node_->get_clock()->now() - cached_cmd_.time;
-    if (age <= cmd_timeout_)
-    {
-      vx_cmd = cached_cmd_.vx;
-      vy_cmd = cached_cmd_.vy;
-      wz_cmd = cached_cmd_.wz;
-    }
+    vx_cmd = cached_cmd_.vx;
+    vy_cmd = cached_cmd_.vy;
+    wz_cmd = cached_cmd_.wz;
   }
 
   // Step 3 - clamp to the configured limits, preserving direction for the planar speed.

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -71,11 +71,8 @@ namespace mujoco_ros2_control_plugins
  * body's centre of mass (no offset application point), no wrench-transport term is
  * needed, unlike ExternalWrenchPlugin's arbitrary application point.
  *
- * At the start of every update() the plugin undoes the xfrc_applied contribution it
- * wrote in the previous cycle before writing the new one, mirroring
- * ExternalWrenchPlugin's self-cleanup so the plugin is correct even when called
- * outside of MujocoSystemInterface (which already zeroes xfrc_applied before invoking
- * plugins).
+ * update() unconditionally overwrites all 6 xfrc_applied entries for the body every
+ * cycle, so no stale contribution from a previous cycle is ever left behind.
  */
 class BaseVelocityPlugin : public MuJoCoROS2ControlPluginBase
 {
@@ -109,27 +106,23 @@ private:
   double max_torque_{ 500.0 };
   rclcpp::Duration cmd_timeout_{ 0, 0 };
 
-  // Latest command, written by the subscription callback (ROS executor thread) and
-  // read by update() (real-time thread) under cmd_mutex_.
+  struct CommandState
+  {
+    double vx{ 0.0 };
+    double vy{ 0.0 };
+    double wz{ 0.0 };
+    rclcpp::Time time{ 0, 0, RCL_ROS_TIME };
+    bool valid{ false };
+  };
+
+  // Latest command, written by the subscription callback (ROS executor thread) under
+  // cmd_mutex_. update() (real-time thread) copies it into cached_cmd_ via try_lock, so
+  // it never blocks on the subscription callback.
   std::mutex cmd_mutex_;
-  double cmd_vx_{ 0.0 };
-  double cmd_vy_{ 0.0 };
-  double cmd_wz_{ 0.0 };
-  rclcpp::Time last_cmd_time_{ 0, 0, RCL_ROS_TIME };
-  bool has_cmd_{ false };
+  CommandState latest_cmd_;
 
-  // Local cache of the command, only ever touched from update() (single real-time
-  // thread), so no lock needed here. Used when a try_lock on cmd_mutex_ fails, so
-  // update() never blocks on the subscription callback.
-  double cached_cmd_vx_{ 0.0 };
-  double cached_cmd_vy_{ 0.0 };
-  double cached_cmd_wz_{ 0.0 };
-  rclcpp::Time cached_cmd_time_{ 0, 0, RCL_ROS_TIME };
-  bool cached_has_cmd_{ false };
-
-  // Whether update() wrote a (possibly zero) contribution to xfrc_applied for
-  // body_id_ in the previous cycle, so it can be undone before the next write.
-  bool prev_written_{ false };
+  // Local copy of the command, only ever touched from update() (single real-time thread).
+  CommandState cached_cmd_;
 };
 
 }  // namespace mujoco_ros2_control_plugins

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -103,7 +103,6 @@ private:
     double vy{ 0.0 };
     double wz{ 0.0 };
     rclcpp::Time time{ 0, 0, RCL_ROS_TIME };
-    bool valid{ false };
   };
 
   // Latest command, written by the subscription callback (ROS executor thread) under

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -15,6 +15,7 @@
 #ifndef MUJOCO_ROS2_CONTROL_PLUGINS__BASE_VELOCITY_PLUGIN_HPP_
 #define MUJOCO_ROS2_CONTROL_PLUGINS__BASE_VELOCITY_PLUGIN_HPP_
 
+#include <limits>
 #include <mutex>
 #include <string>
 
@@ -29,50 +30,41 @@ namespace mujoco_ros2_control_plugins
 
 /**
  * @brief Drives a mobile/floating-base robot from a commanded planar body velocity
- *        (vx, vy, yaw-rate), independent of wheel-ground contact.
+ *        (vx, vy, yaw-rate) by writing a hard kinematic override of the base's free-joint
+ *        velocity directly into data->qvel every cycle (see
+ *        MuJoCoROS2ControlPluginBase::update()'s doc comment for the NaN convention this
+ *        relies on).
  *
  * Wheel-terrain friction/slip modelling is often unreliable enough to make it a poor
  * foundation for testing navigation stacks. This plugin instead subscribes to a
- * cmd_vel-style topic and runs a proportional velocity servo directly on the base
- * body's free joint, applying the result as a world-frame wrench via
- * data->xfrc_applied. Because the servo is force-based (not a kinematic override),
- * the base still collides realistically with walls/obstacles -- only the *propulsion*
- * bypasses wheel-ground contact, not collision response.
+ * cmd_vel-style topic and, every cycle, writes the (optionally clamped) commanded planar
+ * velocity directly into the base body's free-joint qvel entries in data. There is no
+ * gain to tune and no convergence delay: the measured body velocity on the driven DOFs is
+ * exactly the commanded velocity on the very next simulation step.
  *
- * Only the planar DOFs are driven: body-frame linear x/y and yaw-rate (about body z).
- * Vertical motion and roll/pitch are left entirely to gravity and contacts, so the
- * base settles onto the ground normally.
+ * The trade-off is that the driven DOFs cannot be influenced by anything else -- not
+ * contacts, not forces from other bodies rigidly mounted on the base (e.g. a swinging
+ * arm). They are simply reasserted every cycle regardless of what the physics engine
+ * computed in between.
+ *
+ * Only the planar DOFs are driven: world-frame linear x/y (converted from the commanded
+ * body-frame vx/vy via the body's current orientation) and body-local yaw-rate about z.
+ * Vertical linear velocity and local roll/pitch are left untouched every cycle, so gravity
+ * and contacts continue to settle the base onto the ground normally.
  *
  * Configuration parameters (declared under "mujoco_plugins.<instance_name>.")
  * -------------------------------------------------------------------------------
- *   body              (string, required) - MJCF body name of the base. Must have a
- *                      <freejoint/> for the servo to have any effect.
- *   cmd_vel_topic      (string, default "cmd_vel")   - command topic name.
- *   use_stamped_twist  (bool,   default false)       - subscribe to
- *                      geometry_msgs/TwistStamped instead of geometry_msgs/Twist.
- *   kv_linear          (double, default 200.0)       - linear servo gain [N per m/s].
- *   kv_yaw             (double, default 50.0)        - yaw servo gain [N.m per rad/s].
- *   max_force          (double, default 1000.0)      - per-axis linear force cap [N].
- *   max_torque         (double, default 500.0)       - yaw torque cap [N.m].
- *   cmd_timeout        (double, default 0.5)         - seconds since the last command
- *                      after which it is treated as zero (safety stop).
- *
- * Implementation notes
- * ---------------------
- * The servo error is computed in the body frame:
- *
- *   F_body = clamp(kv_linear * (v_cmd - v_meas), +-max_force)   (x, y)
- *   T_body = clamp(kv_yaw    * (w_cmd - w_meas), +-max_torque)  (about z)
- *
- * where v_meas/w_meas come from mj_objectVelocity(..., flg_local=1), i.e. the body's
- * own 6D velocity expressed in its own frame. F_body/T_body are then rotated into the
- * world frame via data->xmat (body -> world rotation) before being written into
- * data->xfrc_applied at the body's slot. Because the force/torque are applied at the
- * body's centre of mass (no offset application point), no wrench-transport term is
- * needed, unlike ExternalWrenchPlugin's arbitrary application point.
- *
- * update() unconditionally overwrites all 6 xfrc_applied entries for the body every
- * cycle, so no stale contribution from a previous cycle is ever left behind.
+ *   body                (string, required) - MJCF body name of the base. Must have a
+ *                        <freejoint/>; init() fails otherwise, since there is no qvel to
+ *                        override without one.
+ *   cmd_vel_topic       (string, default "cmd_vel")   - command topic name.
+ *   use_stamped_twist   (bool,   default false)       - subscribe to
+ *                        geometry_msgs/TwistStamped instead of geometry_msgs/Twist.
+ *   max_linear_velocity (double, default +inf) - clamps the commanded planar speed
+ *                        sqrt(vx^2+vy^2) [m/s]; direction is preserved when scaled down.
+ *   max_yaw_rate        (double, default +inf) - clamps the commanded yaw-rate [rad/s].
+ *   cmd_timeout         (double, default 0.5)  - seconds since the last command after
+ *                        which it is treated as zero (safety stop).
  */
 class BaseVelocityPlugin : public MuJoCoROS2ControlPluginBase
 {
@@ -95,15 +87,14 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub_;
 
-  // Model/body lookup
+  // Model/body/joint lookup
   const mjModel* model_{ nullptr };
   int body_id_{ -1 };
+  int qvel_adr_{ -1 };
 
-  // Servo parameters
-  double kv_linear_{ 200.0 };
-  double kv_yaw_{ 50.0 };
-  double max_force_{ 1000.0 };
-  double max_torque_{ 500.0 };
+  // Clamp parameters
+  double max_linear_velocity_{ std::numeric_limits<double>::infinity() };
+  double max_yaw_rate_{ std::numeric_limits<double>::infinity() };
   rclcpp::Duration cmd_timeout_{ 0, 0 };
 
   struct CommandState

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -43,8 +43,8 @@ namespace mujoco_ros2_control_plugins
  * Vertical motion and roll/pitch are left entirely to gravity and contacts, so the
  * base settles onto the ground normally.
  *
- * Configuration parameters (declared on the plugin's sub-node)
- * -------------------------------------------------------------
+ * Configuration parameters (declared under "mujoco_plugins.<instance_name>.")
+ * -------------------------------------------------------------------------------
  *   body              (string, required) - MJCF body name of the base. Must have a
  *                      <freejoint/> for the servo to have any effect.
  *   cmd_vel_topic      (string, default "cmd_vel")   - command topic name.

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -1,0 +1,137 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_ROS2_CONTROL_PLUGINS__BASE_VELOCITY_PLUGIN_HPP_
+#define MUJOCO_ROS2_CONTROL_PLUGINS__BASE_VELOCITY_PLUGIN_HPP_
+
+#include <mutex>
+#include <string>
+
+#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp"
+
+namespace mujoco_ros2_control_plugins
+{
+
+/**
+ * @brief Drives a mobile/floating-base robot from a commanded planar body velocity
+ *        (vx, vy, yaw-rate), independent of wheel-ground contact.
+ *
+ * Wheel-terrain friction/slip modelling is often unreliable enough to make it a poor
+ * foundation for testing navigation stacks. This plugin instead subscribes to a
+ * cmd_vel-style topic and runs a proportional velocity servo directly on the base
+ * body's free joint, applying the result as a world-frame wrench via
+ * data->xfrc_applied. Because the servo is force-based (not a kinematic override),
+ * the base still collides realistically with walls/obstacles -- only the *propulsion*
+ * bypasses wheel-ground contact, not collision response.
+ *
+ * Only the planar DOFs are driven: body-frame linear x/y and yaw-rate (about body z).
+ * Vertical motion and roll/pitch are left entirely to gravity and contacts, so the
+ * base settles onto the ground normally.
+ *
+ * Configuration parameters (declared on the plugin's sub-node)
+ * -------------------------------------------------------------
+ *   body              (string, required) - MJCF body name of the base. Must have a
+ *                      <freejoint/> for the servo to have any effect.
+ *   cmd_vel_topic      (string, default "cmd_vel")   - command topic name.
+ *   use_stamped_twist  (bool,   default false)       - subscribe to
+ *                      geometry_msgs/TwistStamped instead of geometry_msgs/Twist.
+ *   kv_linear          (double, default 200.0)       - linear servo gain [N per m/s].
+ *   kv_yaw             (double, default 50.0)        - yaw servo gain [N.m per rad/s].
+ *   max_force          (double, default 1000.0)      - per-axis linear force cap [N].
+ *   max_torque         (double, default 500.0)       - yaw torque cap [N.m].
+ *   cmd_timeout        (double, default 0.5)         - seconds since the last command
+ *                      after which it is treated as zero (safety stop).
+ *
+ * Implementation notes
+ * ---------------------
+ * The servo error is computed in the body frame:
+ *
+ *   F_body = clamp(kv_linear * (v_cmd - v_meas), +-max_force)   (x, y)
+ *   T_body = clamp(kv_yaw    * (w_cmd - w_meas), +-max_torque)  (about z)
+ *
+ * where v_meas/w_meas come from mj_objectVelocity(..., flg_local=1), i.e. the body's
+ * own 6D velocity expressed in its own frame. F_body/T_body are then rotated into the
+ * world frame via data->xmat (body -> world rotation) before being written into
+ * data->xfrc_applied at the body's slot. Because the force/torque are applied at the
+ * body's centre of mass (no offset application point), no wrench-transport term is
+ * needed, unlike ExternalWrenchPlugin's arbitrary application point.
+ *
+ * At the start of every update() the plugin undoes the xfrc_applied contribution it
+ * wrote in the previous cycle before writing the new one, mirroring
+ * ExternalWrenchPlugin's self-cleanup so the plugin is correct even when called
+ * outside of MujocoSystemInterface (which already zeroes xfrc_applied before invoking
+ * plugins).
+ */
+class BaseVelocityPlugin : public MuJoCoROS2ControlPluginBase
+{
+public:
+  BaseVelocityPlugin() = default;
+  ~BaseVelocityPlugin() override = default;
+
+  bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
+  void update(const mjModel* model, mjData* data) override;
+  void cleanup() override;
+
+private:
+  void twistCallback(const geometry_msgs::msg::Twist& msg);
+  void twistStampedCallback(const geometry_msgs::msg::TwistStamped& msg);
+  void storeCommand(double vx, double vy, double wz);
+
+  // ROS interfaces
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Logger logger_{ rclcpp::get_logger("BaseVelocityPlugin") };
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub_;
+
+  // Model/body lookup
+  const mjModel* model_{ nullptr };
+  int body_id_{ -1 };
+
+  // Servo parameters
+  double kv_linear_{ 200.0 };
+  double kv_yaw_{ 50.0 };
+  double max_force_{ 1000.0 };
+  double max_torque_{ 500.0 };
+  rclcpp::Duration cmd_timeout_{ 0, 0 };
+
+  // Latest command, written by the subscription callback (ROS executor thread) and
+  // read by update() (real-time thread) under cmd_mutex_.
+  std::mutex cmd_mutex_;
+  double cmd_vx_{ 0.0 };
+  double cmd_vy_{ 0.0 };
+  double cmd_wz_{ 0.0 };
+  rclcpp::Time last_cmd_time_{ 0, 0, RCL_ROS_TIME };
+  bool has_cmd_{ false };
+
+  // Local cache of the command, only ever touched from update() (single real-time
+  // thread), so no lock needed here. Used when a try_lock on cmd_mutex_ fails, so
+  // update() never blocks on the subscription callback.
+  double cached_cmd_vx_{ 0.0 };
+  double cached_cmd_vy_{ 0.0 };
+  double cached_cmd_wz_{ 0.0 };
+  rclcpp::Time cached_cmd_time_{ 0, 0, RCL_ROS_TIME };
+  bool cached_has_cmd_{ false };
+
+  // Whether update() wrote a (possibly zero) contribution to xfrc_applied for
+  // body_id_ in the previous cycle, so it can be undone before the next write.
+  bool prev_written_{ false };
+};
+
+}  // namespace mujoco_ros2_control_plugins
+
+#endif  // MUJOCO_ROS2_CONTROL_PLUGINS__BASE_VELOCITY_PLUGIN_HPP_

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -1,0 +1,278 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <mujoco/mujoco.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "base_velocity_plugin.hpp"
+
+namespace
+{
+// A free-floating sphere (nv = 6: 3 translational + 3 rotational DOFs), no gravity so the
+// body only moves under the servo forces the plugin applies. Identity orientation means
+// body-frame and world-frame vectors coincide at t=0, which keeps the arithmetic in the
+// tests simple to reason about.
+constexpr const char* kMjcf = R"(
+<mujoco model="base_velocity_test">
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="base_link" pos="0 0 1">
+      <freejoint/>
+      <inertial mass="1.0" pos="0 0 0" diaginertia="0.1 0.1 0.1"/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+}  // namespace
+
+class BaseVelocityPluginTest : public ::testing::Test
+{
+protected:
+  using Twist = geometry_msgs::msg::Twist;
+
+  static void SetUpTestCase()
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  static void TearDownTestCase()
+  {
+    if (rclcpp::ok())
+    {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override
+  {
+    node_ = std::make_shared<rclcpp::Node>("base_velocity_test_node");
+    plugin_node_ = node_->create_sub_node("base_velocity_plugin");
+
+    executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(rclcpp::ExecutorOptions{}, 2);
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+
+    char error[1024] = { 0 };
+    mjSpec* spec = mj_parseXMLString(kMjcf, nullptr, error, sizeof(error));
+    ASSERT_NE(spec, nullptr) << error;
+
+    model_ = mj_compile(spec, nullptr);
+    if (model_ == nullptr)
+    {
+      const char* ce = mjs_getError(spec);
+      mj_deleteSpec(spec);
+      FAIL() << (ce ? ce : "mj_compile failed");
+    }
+    mj_deleteSpec(spec);
+
+    data_ = mj_makeData(model_);
+    ASSERT_NE(data_, nullptr);
+    mj_forward(model_, data_);
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable())
+    {
+      spin_thread_.join();
+    }
+    executor_.reset();
+    plugin_node_.reset();
+    node_.reset();
+    mj_deleteData(data_);
+    data_ = nullptr;
+    mj_deleteModel(model_);
+    model_ = nullptr;
+  }
+
+  /// Publishes a Twist on the plugin's cmd_vel topic and waits briefly for delivery.
+  void publishTwist(const std::string& topic, double vx, double vy, double wz)
+  {
+    auto pub = plugin_node_->create_publisher<Twist>(topic, rclcpp::SystemDefaultsQoS());
+    Twist msg;
+    msg.linear.x = vx;
+    msg.linear.y = vy;
+    msg.angular.z = wz;
+    // Give the subscription time to match before publishing (intra-process/local discovery).
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    pub->publish(msg);
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  }
+
+  mjModel* model_{ nullptr };
+  mjData* data_{ nullptr };
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr plugin_node_;
+
+private:
+  std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+TEST_F(BaseVelocityPluginTest, InitFailsForUnknownBody)
+{
+  plugin_node_->declare_parameter("body", std::string("does_not_exist"));
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  EXPECT_FALSE(plugin.init(plugin_node_, model_, data_));
+  plugin.cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, InitSucceedsForFreeJointBody)
+{
+  plugin_node_->declare_parameter("body", std::string("base_link"));
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
+  plugin.cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, ZeroCommandProducesNoForce)
+{
+  plugin_node_->declare_parameter("body", std::string("base_link"));
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  plugin.update(model_, data_);
+
+  for (int i = 0; i < model_->nbody * 6; ++i)
+  {
+    EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0);
+  }
+
+  plugin.cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, CommandAppliesForceTowardTarget)
+{
+  plugin_node_->declare_parameter("body", std::string("base_link"));
+  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
+
+  plugin.update(model_, data_);
+
+  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
+  ASSERT_GE(base_id, 0);
+
+  // Body starts at rest, commanded +X velocity => positive world-X force at identity
+  // orientation, and no spurious force/torque on the other axes.
+  EXPECT_GT(data_->xfrc_applied[base_id * 6 + 0], 0.0);
+  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 1], 0.0, 1e-9);
+  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 2], 0.0, 1e-9);
+  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 3], 0.0, 1e-9);
+  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 4], 0.0, 1e-9);
+  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 5], 0.0, 1e-9);
+
+  plugin.cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
+{
+  plugin_node_->declare_parameter("body", std::string("base_link"));
+  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
+  plugin_node_->declare_parameter("kv_linear", 50.0);
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  publishTwist("cmd_vel", /*vx=*/0.5, /*vy=*/0.0, /*wz=*/0.0);
+
+  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
+  ASSERT_GE(base_id, 0);
+
+  // Drive the servo + physics forward for a few hundred steps and check that the
+  // measured body-frame x velocity converges to the 0.5 m/s command.
+  for (int i = 0; i < 500; ++i)
+  {
+    plugin.update(model_, data_);
+    mj_step(model_, data_);
+  }
+
+  mjtNum vel6[6];
+  mj_objectVelocity(model_, data_, mjOBJ_BODY, base_id, vel6, /*flg_local=*/1);
+  // vel6 layout is (rot:lin): [wx,wy,wz, vx,vy,vz]
+  EXPECT_NEAR(vel6[3], 0.5, 0.05);
+  EXPECT_NEAR(vel6[4], 0.0, 0.05);
+}
+
+TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
+{
+  plugin_node_->declare_parameter("body", std::string("base_link"));
+  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
+  plugin_node_->declare_parameter("kv_yaw", 10.0);
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/1.0);
+
+  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
+  ASSERT_GE(base_id, 0);
+
+  for (int i = 0; i < 500; ++i)
+  {
+    plugin.update(model_, data_);
+    mj_step(model_, data_);
+  }
+
+  mjtNum vel6[6];
+  mj_objectVelocity(model_, data_, mjOBJ_BODY, base_id, vel6, /*flg_local=*/1);
+  EXPECT_NEAR(vel6[2], 1.0, 0.1);
+}
+
+TEST_F(BaseVelocityPluginTest, StaleCommandDecaysToZeroForce)
+{
+  plugin_node_->declare_parameter("body", std::string("base_link"));
+  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
+  plugin_node_->declare_parameter("cmd_timeout", 0.2);
+
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
+
+  plugin.update(model_, data_);
+  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
+  ASSERT_GE(base_id, 0);
+  ASSERT_GT(data_->xfrc_applied[base_id * 6 + 0], 0.0) << "sanity: force applied while command is fresh";
+
+  // Wait past the timeout without publishing again.
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  plugin.update(model_, data_);
+
+  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 0], 0.0, 1e-9)
+      << "stale command should be treated as zero, producing no force";
+
+  plugin.cleanup();
+}

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -21,9 +21,9 @@
 #include <string>
 #include <thread>
 
+#include <mujoco/mujoco.h>
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
-#include <mujoco/mujoco.h>
 #include <rclcpp/rclcpp.hpp>
 
 #include "base_velocity_plugin.hpp"
@@ -140,8 +140,14 @@ protected:
   }
 
   /// Index of the (only) joint's first qvel/qpos entry in this single-free-joint test model.
-  int dofAdr() const { return model_->jnt_dofadr[0]; }
-  int qposAdr() const { return model_->jnt_qposadr[0]; }
+  int dofAdr() const
+  {
+    return model_->jnt_dofadr[0];
+  }
+  int qposAdr() const
+  {
+    return model_->jnt_qposadr[0];
+  }
 
   /// NaN-fills this body's 6 qvel entries, mirroring the real system's per-cycle pre-fill
   /// (MujocoSystemInterface::write()) so tests can verify which entries the plugin leaves

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -111,6 +111,19 @@ protected:
     model_ = nullptr;
   }
 
+  /// Declares "body" (defaulting to "base_link") and initializes a plugin instance with it.
+  std::unique_ptr<mujoco_ros2_control_plugins::BaseVelocityPlugin>
+  makeInitializedPlugin(const std::string& body_name = "base_link")
+  {
+    if (!plugin_node_->has_parameter("body"))
+    {
+      plugin_node_->declare_parameter("body", body_name);
+    }
+    auto plugin = std::make_unique<mujoco_ros2_control_plugins::BaseVelocityPlugin>();
+    EXPECT_TRUE(plugin->init(plugin_node_, model_, data_));
+    return plugin;
+  }
+
   /// Publishes a Twist on the plugin's cmd_vel topic and waits briefly for delivery.
   void publishTwist(const std::string& topic, double vx, double vy, double wz)
   {
@@ -146,41 +159,31 @@ TEST_F(BaseVelocityPluginTest, InitFailsForUnknownBody)
 
 TEST_F(BaseVelocityPluginTest, InitSucceedsForFreeJointBody)
 {
-  plugin_node_->declare_parameter("body", std::string("base_link"));
-
-  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
-  plugin.cleanup();
+  auto plugin = makeInitializedPlugin();
+  plugin->cleanup();
 }
 
 TEST_F(BaseVelocityPluginTest, ZeroCommandProducesNoForce)
 {
-  plugin_node_->declare_parameter("body", std::string("base_link"));
+  auto plugin = makeInitializedPlugin();
 
-  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
-
-  plugin.update(model_, data_);
+  plugin->update(model_, data_);
 
   for (int i = 0; i < model_->nbody * 6; ++i)
   {
     EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0);
   }
 
-  plugin.cleanup();
+  plugin->cleanup();
 }
 
 TEST_F(BaseVelocityPluginTest, CommandAppliesForceTowardTarget)
 {
-  plugin_node_->declare_parameter("body", std::string("base_link"));
-  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
-
-  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
 
-  plugin.update(model_, data_);
+  plugin->update(model_, data_);
 
   const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
   ASSERT_GE(base_id, 0);
@@ -194,17 +197,13 @@ TEST_F(BaseVelocityPluginTest, CommandAppliesForceTowardTarget)
   EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 4], 0.0, 1e-9);
   EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 5], 0.0, 1e-9);
 
-  plugin.cleanup();
+  plugin->cleanup();
 }
 
 TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
 {
-  plugin_node_->declare_parameter("body", std::string("base_link"));
-  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
   plugin_node_->declare_parameter("kv_linear", 50.0);
-
-  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/0.5, /*vy=*/0.0, /*wz=*/0.0);
 
@@ -215,7 +214,7 @@ TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
   // measured body-frame x velocity converges to the 0.5 m/s command.
   for (int i = 0; i < 500; ++i)
   {
-    plugin.update(model_, data_);
+    plugin->update(model_, data_);
     mj_step(model_, data_);
   }
 
@@ -228,12 +227,8 @@ TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
 
 TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
 {
-  plugin_node_->declare_parameter("body", std::string("base_link"));
-  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
   plugin_node_->declare_parameter("kv_yaw", 10.0);
-
-  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/1.0);
 
@@ -242,7 +237,7 @@ TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
 
   for (int i = 0; i < 500; ++i)
   {
-    plugin.update(model_, data_);
+    plugin->update(model_, data_);
     mj_step(model_, data_);
   }
 
@@ -253,26 +248,22 @@ TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
 
 TEST_F(BaseVelocityPluginTest, StaleCommandDecaysToZeroForce)
 {
-  plugin_node_->declare_parameter("body", std::string("base_link"));
-  plugin_node_->declare_parameter("cmd_vel_topic", std::string("cmd_vel"));
   plugin_node_->declare_parameter("cmd_timeout", 0.2);
-
-  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
 
-  plugin.update(model_, data_);
+  plugin->update(model_, data_);
   const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
   ASSERT_GE(base_id, 0);
   ASSERT_GT(data_->xfrc_applied[base_id * 6 + 0], 0.0) << "sanity: force applied while command is fresh";
 
   // Wait past the timeout without publishing again.
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
-  plugin.update(model_, data_);
+  plugin->update(model_, data_);
 
   EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 0], 0.0, 1e-9)
       << "stale command should be treated as zero, producing no force";
 
-  plugin.cleanup();
+  plugin->cleanup();
 }

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -111,13 +111,18 @@ protected:
     model_ = nullptr;
   }
 
+  std::string paramName(const std::string& name)
+  {
+    return "mujoco_plugins." + plugin_node_->get_sub_namespace() + "." + name;
+  }
+
   /// Declares "body" (defaulting to "base_link") and initializes a plugin instance with it.
   std::unique_ptr<mujoco_ros2_control_plugins::BaseVelocityPlugin>
   makeInitializedPlugin(const std::string& body_name = "base_link")
   {
-    if (!plugin_node_->has_parameter("body"))
+    if (!plugin_node_->has_parameter(paramName("body")))
     {
-      plugin_node_->declare_parameter("body", body_name);
+      plugin_node_->declare_parameter(paramName("body"), body_name);
     }
     auto plugin = std::make_unique<mujoco_ros2_control_plugins::BaseVelocityPlugin>();
     EXPECT_TRUE(plugin->init(plugin_node_, model_, data_));
@@ -150,7 +155,7 @@ private:
 
 TEST_F(BaseVelocityPluginTest, InitFailsForUnknownBody)
 {
-  plugin_node_->declare_parameter("body", std::string("does_not_exist"));
+  plugin_node_->declare_parameter(paramName("body"), std::string("does_not_exist"));
 
   mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
   EXPECT_FALSE(plugin.init(plugin_node_, model_, data_));
@@ -202,7 +207,7 @@ TEST_F(BaseVelocityPluginTest, CommandAppliesForceTowardTarget)
 
 TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
 {
-  plugin_node_->declare_parameter("kv_linear", 50.0);
+  plugin_node_->declare_parameter(paramName("kv_linear"), 50.0);
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/0.5, /*vy=*/0.0, /*wz=*/0.0);
@@ -227,7 +232,7 @@ TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
 
 TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
 {
-  plugin_node_->declare_parameter("kv_yaw", 10.0);
+  plugin_node_->declare_parameter(paramName("kv_yaw"), 10.0);
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/1.0);
@@ -248,7 +253,7 @@ TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
 
 TEST_F(BaseVelocityPluginTest, StaleCommandDecaysToZeroForce)
 {
-  plugin_node_->declare_parameter("cmd_timeout", 0.2);
+  plugin_node_->declare_parameter(paramName("cmd_timeout"), 0.2);
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <string>
 #include <thread>
@@ -30,9 +31,9 @@
 namespace
 {
 // A free-floating sphere (nv = 6: 3 translational + 3 rotational DOFs), no gravity so the
-// body only moves under the servo forces the plugin applies. Identity orientation means
-// body-frame and world-frame vectors coincide at t=0, which keeps the arithmetic in the
-// tests simple to reason about.
+// body only moves if the plugin's velocity override writes into qvel. Identity orientation
+// means body-frame and world-frame vectors coincide at t=0, which keeps the arithmetic in
+// most tests simple to reason about.
 constexpr const char* kMjcf = R"(
 <mujoco model="base_velocity_test">
   <option gravity="0 0 0"/>
@@ -45,6 +46,38 @@ constexpr const char* kMjcf = R"(
   </worldbody>
 </mujoco>
 )";
+
+// Same body, but welded to the world (no <freejoint/>) -- used to verify that init() now
+// fails outright, since a velocity override has nowhere to write without a free joint.
+constexpr const char* kMjcfNoFreeJoint = R"(
+<mujoco model="base_velocity_test_no_free">
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="base_link" pos="0 0 1">
+      <inertial mass="1.0" pos="0 0 0" diaginertia="0.1 0.1 0.1"/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+mjModel* compileModel(const char* xml)
+{
+  char error[1024] = { 0 };
+  mjSpec* spec = mj_parseXMLString(xml, nullptr, error, sizeof(error));
+  if (spec == nullptr)
+  {
+    ADD_FAILURE() << error;
+    return nullptr;
+  }
+  mjModel* model = mj_compile(spec, nullptr);
+  if (model == nullptr)
+  {
+    ADD_FAILURE() << (mjs_getError(spec) ? mjs_getError(spec) : "mj_compile failed");
+  }
+  mj_deleteSpec(spec);
+  return model;
+}
 }  // namespace
 
 class BaseVelocityPluginTest : public ::testing::Test
@@ -77,18 +110,8 @@ protected:
     executor_->add_node(node_);
     spin_thread_ = std::thread([this]() { executor_->spin(); });
 
-    char error[1024] = { 0 };
-    mjSpec* spec = mj_parseXMLString(kMjcf, nullptr, error, sizeof(error));
-    ASSERT_NE(spec, nullptr) << error;
-
-    model_ = mj_compile(spec, nullptr);
-    if (model_ == nullptr)
-    {
-      const char* ce = mjs_getError(spec);
-      mj_deleteSpec(spec);
-      FAIL() << (ce ? ce : "mj_compile failed");
-    }
-    mj_deleteSpec(spec);
+    model_ = compileModel(kMjcf);
+    ASSERT_NE(model_, nullptr);
 
     data_ = mj_makeData(model_);
     ASSERT_NE(data_, nullptr);
@@ -114,6 +137,22 @@ protected:
   std::string paramName(const std::string& name)
   {
     return "mujoco_plugins." + plugin_node_->get_sub_namespace() + "." + name;
+  }
+
+  /// Index of the (only) joint's first qvel/qpos entry in this single-free-joint test model.
+  int dofAdr() const { return model_->jnt_dofadr[0]; }
+  int qposAdr() const { return model_->jnt_qposadr[0]; }
+
+  /// NaN-fills this body's 6 qvel entries, mirroring the real system's per-cycle pre-fill
+  /// (MujocoSystemInterface::write()) so tests can verify which entries the plugin leaves
+  /// untouched versus which it overrides.
+  void fillQvelNaN()
+  {
+    const int adr = dofAdr();
+    for (int i = 0; i < 6; ++i)
+    {
+      data_->qvel[adr + i] = std::numeric_limits<double>::quiet_NaN();
+    }
   }
 
   /// Declares "body" (defaulting to "base_link") and initializes a plugin instance with it.
@@ -168,90 +207,69 @@ TEST_F(BaseVelocityPluginTest, InitSucceedsForFreeJointBody)
   plugin->cleanup();
 }
 
-TEST_F(BaseVelocityPluginTest, ZeroCommandProducesNoForce)
+TEST_F(BaseVelocityPluginTest, InitFailsForBodyWithoutFreeJoint)
+{
+  mjModel* welded_model = compileModel(kMjcfNoFreeJoint);
+  ASSERT_NE(welded_model, nullptr);
+  mjData* welded_data = mj_makeData(welded_model);
+  ASSERT_NE(welded_data, nullptr);
+  mj_forward(welded_model, welded_data);
+
+  plugin_node_->declare_parameter(paramName("body"), std::string("base_link"));
+  mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
+  // A velocity override has nowhere to write without a free joint, so init() must fail
+  // outright rather than merely warn as the old force-servo design did.
+  EXPECT_FALSE(plugin.init(plugin_node_, welded_model, welded_data));
+  plugin.cleanup();
+
+  mj_deleteData(welded_data);
+  mj_deleteModel(welded_model);
+}
+
+TEST_F(BaseVelocityPluginTest, NoCommandRequestsZeroVelocity)
 {
   auto plugin = makeInitializedPlugin();
+  fillQvelNaN();
 
   plugin->update(model_, data_);
 
-  for (int i = 0; i < model_->nbody * 6; ++i)
-  {
-    EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0);
-  }
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  EXPECT_DOUBLE_EQ(qvel[0], 0.0);
+  EXPECT_DOUBLE_EQ(qvel[1], 0.0);
+  EXPECT_DOUBLE_EQ(qvel[5], 0.0);
+
+  // Vertical linear velocity and roll/pitch are left to gravity/contacts, never driven --
+  // the real system's NaN pre-fill (mirrored here) must survive untouched.
+  EXPECT_TRUE(std::isnan(qvel[2]));
+  EXPECT_TRUE(std::isnan(qvel[3]));
+  EXPECT_TRUE(std::isnan(qvel[4]));
 
   plugin->cleanup();
 }
 
-TEST_F(BaseVelocityPluginTest, CommandAppliesForceTowardTarget)
+TEST_F(BaseVelocityPluginTest, CommandIsReportedAsOverride)
 {
   auto plugin = makeInitializedPlugin();
+  fillQvelNaN();
 
-  publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
-
+  publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.3);
   plugin->update(model_, data_);
 
-  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
-  ASSERT_GE(base_id, 0);
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  // Identity orientation => body-x == world-x. This is a direct assignment, not a servo,
+  // so the commanded value is reached immediately -- no convergence tolerance needed.
+  EXPECT_NEAR(qvel[0], 1.0, 1e-9);
+  EXPECT_NEAR(qvel[1], 0.0, 1e-9);
+  EXPECT_NEAR(qvel[5], 0.3, 1e-9);
 
-  // Body starts at rest, commanded +X velocity => positive world-X force at identity
-  // orientation, and no spurious force/torque on the other axes.
-  EXPECT_GT(data_->xfrc_applied[base_id * 6 + 0], 0.0);
-  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 1], 0.0, 1e-9);
-  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 2], 0.0, 1e-9);
-  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 3], 0.0, 1e-9);
-  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 4], 0.0, 1e-9);
-  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 5], 0.0, 1e-9);
+  EXPECT_TRUE(std::isnan(qvel[2]));
+  EXPECT_TRUE(std::isnan(qvel[3]));
+  EXPECT_TRUE(std::isnan(qvel[4]));
 
   plugin->cleanup();
 }
 
-TEST_F(BaseVelocityPluginTest, ServoConvergesLinearVelocityToCommand)
-{
-  plugin_node_->declare_parameter(paramName("kv_linear"), 50.0);
-  auto plugin = makeInitializedPlugin();
-
-  publishTwist("cmd_vel", /*vx=*/0.5, /*vy=*/0.0, /*wz=*/0.0);
-
-  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
-  ASSERT_GE(base_id, 0);
-
-  // Drive the servo + physics forward for a few hundred steps and check that the
-  // measured body-frame x velocity converges to the 0.5 m/s command.
-  for (int i = 0; i < 500; ++i)
-  {
-    plugin->update(model_, data_);
-    mj_step(model_, data_);
-  }
-
-  mjtNum vel6[6];
-  mj_objectVelocity(model_, data_, mjOBJ_BODY, base_id, vel6, /*flg_local=*/1);
-  // vel6 layout is (rot:lin): [wx,wy,wz, vx,vy,vz]
-  EXPECT_NEAR(vel6[3], 0.5, 0.05);
-  EXPECT_NEAR(vel6[4], 0.0, 0.05);
-}
-
-TEST_F(BaseVelocityPluginTest, ServoConvergesYawRateToCommand)
-{
-  plugin_node_->declare_parameter(paramName("kv_yaw"), 10.0);
-  auto plugin = makeInitializedPlugin();
-
-  publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/1.0);
-
-  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
-  ASSERT_GE(base_id, 0);
-
-  for (int i = 0; i < 500; ++i)
-  {
-    plugin->update(model_, data_);
-    mj_step(model_, data_);
-  }
-
-  mjtNum vel6[6];
-  mj_objectVelocity(model_, data_, mjOBJ_BODY, base_id, vel6, /*flg_local=*/1);
-  EXPECT_NEAR(vel6[2], 1.0, 0.1);
-}
-
-TEST_F(BaseVelocityPluginTest, StaleCommandDecaysToZeroForce)
+TEST_F(BaseVelocityPluginTest, StaleCommandRequestsZeroVelocity)
 {
   plugin_node_->declare_parameter(paramName("cmd_timeout"), 0.2);
   auto plugin = makeInitializedPlugin();
@@ -259,16 +277,83 @@ TEST_F(BaseVelocityPluginTest, StaleCommandDecaysToZeroForce)
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
 
   plugin->update(model_, data_);
-  const int base_id = mj_name2id(model_, mjOBJ_BODY, "base_link");
-  ASSERT_GE(base_id, 0);
-  ASSERT_GT(data_->xfrc_applied[base_id * 6 + 0], 0.0) << "sanity: force applied while command is fresh";
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  ASSERT_GT(qvel[0], 0.0) << "sanity: velocity requested while command is fresh";
 
   // Wait past the timeout without publishing again.
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
   plugin->update(model_, data_);
 
-  EXPECT_NEAR(data_->xfrc_applied[base_id * 6 + 0], 0.0, 1e-9)
-      << "stale command should be treated as zero, producing no force";
+  EXPECT_NEAR(qvel[0], 0.0, 1e-9) << "stale command should be treated as zero";
+
+  plugin->cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, LinearCommandIsClampedToMaxLinearVelocity)
+{
+  plugin_node_->declare_parameter(paramName("max_linear_velocity"), 0.2);
+  auto plugin = makeInitializedPlugin();
+
+  publishTwist("cmd_vel", /*vx=*/5.0, /*vy=*/0.0, /*wz=*/0.0);
+  plugin->update(model_, data_);
+
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  EXPECT_NEAR(qvel[0], 0.2, 1e-9);
+
+  plugin->cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, YawCommandIsClampedToMaxYawRate)
+{
+  plugin_node_->declare_parameter(paramName("max_yaw_rate"), 0.3);
+  auto plugin = makeInitializedPlugin();
+
+  publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/5.0);
+  plugin->update(model_, data_);
+
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  EXPECT_NEAR(qvel[5], 0.3, 1e-9);
+
+  plugin->cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, UnsetLimitsDoNotClamp)
+{
+  // Neither max_linear_velocity nor max_yaw_rate is declared -- both default to +inf, so
+  // even a very large command must pass through unclamped.
+  auto plugin = makeInitializedPlugin();
+
+  publishTwist("cmd_vel", /*vx=*/1000.0, /*vy=*/0.0, /*wz=*/1000.0);
+  plugin->update(model_, data_);
+
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  EXPECT_NEAR(qvel[0], 1000.0, 1e-6);
+  EXPECT_NEAR(qvel[5], 1000.0, 1e-6);
+
+  plugin->cleanup();
+}
+
+TEST_F(BaseVelocityPluginTest, BodyFrameCommandIsRotatedIntoFreeJointFrame)
+{
+  auto plugin = makeInitializedPlugin();
+
+  // Yaw the body 90 degrees about world z before commanding, so body-frame +x now points
+  // along world +y. A free joint's linear qvel is world-frame; if the plugin forgot to
+  // rotate the commanded body-frame velocity by the body's orientation, this test would
+  // see the command land on the wrong world axis.
+  const int qpos_adr = qposAdr();
+  data_->qpos[qpos_adr + 3] = std::cos(M_PI / 4.0);  // qw
+  data_->qpos[qpos_adr + 4] = 0.0;                   // qx
+  data_->qpos[qpos_adr + 5] = 0.0;                   // qy
+  data_->qpos[qpos_adr + 6] = std::sin(M_PI / 4.0);  // qz
+  mj_forward(model_, data_);
+
+  publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
+  plugin->update(model_, data_);
+
+  const mjtNum* qvel = data_->qvel + dofAdr();
+  EXPECT_NEAR(qvel[0], 0.0, 1e-6) << "world-x should be ~0 after a 90 deg yaw";
+  EXPECT_NEAR(qvel[1], 1.0, 1e-6) << "commanded body-x should land on world-y";
 
   plugin->cleanup();
 }


### PR DESCRIPTION
## Description

This PR adds a new plugin that can control the base of the robot by commanding directly the floating joint it is connected to directly; it resembles the ROS planar move plugin that Gazebo offers. This is very reliable as the users doesn't have to spend time modeling their wheels and contact friction etc, and this basically helps to fast prototype

### Is this user-facing behavior change?
NO

### Did you use Generative AI?
Claude

### Additional Information

[TIAGo Pro with Mobile base twist plugin](https://github.com/user-attachments/assets/6acd0ffc-5278-48f0-a8c1-a224ca464926)
