### PR TITLE
Support joint overrides in reset world service

### DIFF
--- a/mujoco_ros2_control/docs/hardware_interface.rst
+++ b/mujoco_ros2_control/docs/hardware_interface.rst
@@ -299,10 +299,21 @@ Services
       ros2 service call /ros2_control_node/set_pause mujoco_ros2_control_msgs/srv/SetPause "{paused: false}"
 
 ``~/reset_world`` (``mujoco_ros2_control_msgs/srv/ResetWorld``)
-   Resets the simulation state.
+   Resets the simulation state, optionally applying per-joint state overrides on top of the restored state.
 
    - If the optional ``keyframe`` string field is empty, the simulation is restored to the state captured at startup (initial joint positions, velocities, and control values).
    - If a ``keyframe`` name is provided, that named keyframe from the MJCF is applied instead.
+   - ``joint_state_overrides`` (``sensor_msgs/JointState``): optional overrides for single-DOF
+     (hinge/slide) joints, keyed by MuJoCo joint name — e.g. opening a door or posing an
+     uncontrolled mechanism as part of the reset. ``position`` and ``velocity`` must each be
+     empty or the same length as ``name``; an empty array leaves that field at its reset value.
+     ``effort`` is not supported and must be empty.
+   - ``free_joint_state_overrides`` (``mujoco_ros2_control_msgs/FreeJointState[]``): optional
+     overrides for free-joint objects, keyed by the name of the body each free joint drives.
+     Entries behave exactly like the ``~/set_free_joint_state`` service (see below), except that
+     any ``pose``/``twist`` ``frame_id`` is resolved against body poses *after* the reset is
+     applied — so an object can be placed relative to where another body ends up, not where it
+     was before the reset.
    - Returns ``success`` and a human-readable ``message``.
 
    .. code-block:: bash
@@ -313,10 +324,21 @@ Services
       # Reset to a named MJCF keyframe
       ros2 service call /ros2_control_node/reset_world mujoco_ros2_control_msgs/srv/ResetWorld "{keyframe: 'home'}"
 
+      # Reset to a keyframe, but with the cabinet door open and "box_1" placed on the table
+      ros2 service call /ros2_control_node/reset_world mujoco_ros2_control_msgs/srv/ResetWorld \
+        "{keyframe: 'home',
+          joint_state_overrides: {name: ['door_hinge'], position: [1.57]},
+          free_joint_state_overrides: [
+            {name: 'box_1', pose: {header: {frame_id: 'table'}, pose: {position: {z: 0.4}}}}
+          ]}"
+
    .. important::
 
       If controllers are active during the service call, the robot may reset to the initial state and then immediately
       snap back to its previous commanded position. Deactivate any active joint controllers before calling this service.
+      This applies equally to ``joint_state_overrides`` targeting controlled joints: the hardware interface re-syncs its
+      command interfaces to the overridden positions as part of the reset, but an active controller may still command
+      the joints elsewhere on its next update.
 
 ``~/step_simulation`` (``mujoco_ros2_control_msgs/srv/StepSimulation``)
    Advances the paused simulation by an exact number of physics steps and blocks until all steps have completed.

--- a/mujoco_ros2_control/docs/hardware_interface.rst
+++ b/mujoco_ros2_control/docs/hardware_interface.rst
@@ -303,17 +303,13 @@ Services
 
    - If the optional ``keyframe`` string field is empty, the simulation is restored to the state captured at startup (initial joint positions, velocities, and control values).
    - If a ``keyframe`` name is provided, that named keyframe from the MJCF is applied instead.
-   - ``joint_state_overrides`` (``sensor_msgs/JointState``): optional overrides for single-DOF
-     (hinge/slide) joints, keyed by MuJoCo joint name — e.g. opening a door or posing an
-     uncontrolled mechanism as part of the reset. ``position`` and ``velocity`` must each be
-     empty or the same length as ``name``; an empty array leaves that field at its reset value.
+   - ``state_overrides`` (``mujoco_ros2_control_msgs/SimulationState``): optional overrides for single-DOF
+     (hinge/slide) and free joint names, keyed by MuJoCo joint name.
+   - For single-DOF joint states: ``position`` and ``velocity`` must each be empty or the same length as ``name``; an empty array leaves that field at its reset value.
      ``effort`` is not supported and must be empty.
-   - ``free_joint_state_overrides`` (``mujoco_ros2_control_msgs/FreeJointState[]``): optional
-     overrides for free-joint objects, keyed by the name of the body each free joint drives.
-     Entries behave exactly like the ``~/set_free_joint_state`` service (see below), except that
-     any ``pose``/``twist`` ``frame_id`` is resolved against body poses *after* the reset is
-     applied — so an object can be placed relative to where another body ends up, not where it
-     was before the reset.
+   - For free joint states, entries behave exactly like the ``~/set_free_joint_state`` service (see below).
+     However, except that any ``pose``/``twist`` ``frame_id`` is resolved against body poses *after* the reset is applied.
+     As such, an object can be placed relative to where another body ends up, not where it was before the reset.
    - Returns ``success`` and a human-readable ``message``.
 
    .. code-block:: bash
@@ -327,18 +323,21 @@ Services
       # Reset to a keyframe, but with the cabinet door open and "box_1" placed on the table
       ros2 service call /ros2_control_node/reset_world mujoco_ros2_control_msgs/srv/ResetWorld \
         "{keyframe: 'home',
-          joint_state_overrides: {name: ['door_hinge'], position: [1.57]},
-          free_joint_state_overrides: [
-            {name: 'box_1', pose: {header: {frame_id: 'table'}, pose: {position: {z: 0.4}}}}
-          ]}"
+          state_overrides: {
+            joint_states: {name: ['door_hinge'], position: [1.57]},
+            free_joint_states: [
+              {name: 'box_1', pose: {header: {frame_id: 'table'}, pose: {position: {z: 0.4}}}}
+            ]
+          }
+        }"
 
    .. important::
 
       If controllers are active during the service call, the robot may reset to the initial state and then immediately
       snap back to its previous commanded position. Deactivate any active joint controllers before calling this service.
-      This applies equally to ``joint_state_overrides`` targeting controlled joints: the hardware interface re-syncs its
-      command interfaces to the overridden positions as part of the reset, but an active controller may still command
-      the joints elsewhere on its next update.
+      This applies equally to ``overrides.joint_states`` targeting controlled joints: the hardware interface re-syncs
+      its command interfaces to the overridden positions as part of the reset, but an active controller may still
+      command the joints elsewhere on its next update.
 
 ``~/step_simulation`` (``mujoco_ros2_control_msgs/srv/StepSimulation``)
    Advances the paused simulation by an exact number of physics steps and blocks until all steps have completed.

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -45,6 +45,7 @@
 #include <mujoco_ros2_control_msgs/srv/set_pause.hpp>
 #include <mujoco_ros2_control_msgs/srv/step_simulation.hpp>
 #include <mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 
 namespace mujoco_ros2_control
 {
@@ -178,10 +179,17 @@ public:
   }
 
   /**
-   * @brief Reset simulation state (qpos/qvel/ctrl/sensors/forces) to the captured initial state.
+   * @brief Reset simulation state (qpos/qvel/ctrl/sensors/forces) to the captured initial state,
+   * optionally applying joint state overrides on top of the restored state.
+   *
+   * Overrides are assumed to have been validated by the caller, so they cannot fail here
+   * (see `resolve_joint_state_writes` / `resolve_free_joint_writes`).
+   *
    * @note Caller must hold the sim mutex.
    */
-  void reset_world_state(bool fill_initial_state);
+  void
+  reset_world_state(bool fill_initial_state, const sensor_msgs::msg::JointState& joint_state_overrides = {},
+                    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joint_state_overrides = {});
 
   /**
    * @brief Sets the pose and velocity of one or more free-joint objects, identified by body name.
@@ -360,18 +368,61 @@ private:
                         std::string& error_message);
 
   /**
-   * @brief Resolves a `FreeJointState` entry into a `FreeJointWrite`, without touching
+   * @brief Resolves a list of `FreeJointState` entries into `FreeJointWrite`s, without touching
    * `mj_data_`.
    *
-   * `pose` and `twist` resolve their own `header.frame_id` independently -- they may reference
-   * different bodies, or one may stay in the world frame while the other is relative.
+   * Each entry's `pose` and `twist` resolve their own `header.frame_id` independently -- they
+   * may reference different bodies, or vary between world vs. relative frame to another body.
    *
    * @note Caller must hold the sim mutex.
-   * @return true if the body, its free joint, and both frame_ids were resolved; false
+   * @return true if every entry's body, free joint, and both frame_ids were resolved; false
    * otherwise, with `error_message` set.
    */
-  bool resolve_free_joint_write(const mujoco_ros2_control_msgs::msg::FreeJointState& state, FreeJointWrite& out,
-                                std::string& error_message);
+  bool resolve_free_joint_writes(const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints,
+                                 std::vector<FreeJointWrite>& writes, std::string& error_message);
+
+  /**
+   * @brief Writes resolved free-joint states into `mj_data_->qpos`/`qvel`.
+   * Does not refresh snapshots or run forward dynamics; the caller is responsible for both.
+   *
+   * @note Caller must hold the sim mutex.
+   */
+  void apply_free_joint_writes(const std::vector<FreeJointWrite>& writes);
+
+  /**
+   * @brief A single-DOF joint state override resolved to qpos/qvel addresses, ready to write.
+   */
+  struct SingleDofJointWrite
+  {
+    int qpos_adr{ -1 };
+    int qvel_adr{ -1 };
+    bool has_position{ false };
+    bool has_velocity{ false };
+    mjtNum position{ 0.0 };
+    mjtNum velocity{ 0.0 };
+  };
+
+  /**
+   * @brief Resolves a `JointState` message into `SingleDofJointWrite`s, without touching
+   * `mj_data_`.
+   *
+   * Every named joint must be a single-DOF (hinge or slide) MuJoCo joint, and `position` /
+   * `velocity` must each be empty or the same length as `name`. `effort` is not supported and
+   * must be empty.
+   *
+   * @note Caller must hold the sim mutex.
+   * @return true if every entry was resolved; false otherwise, with `error_message` set.
+   */
+  bool resolve_joint_state_writes(const sensor_msgs::msg::JointState& joint_state,
+                                  std::vector<SingleDofJointWrite>& writes, std::string& error_message);
+
+  /**
+   * @brief Writes resolved single-DOF joint states into `mj_data_->qpos`/`qvel`.
+   * Does not refresh snapshots or run forward dynamics; the caller is responsible for both.
+   *
+   * @note Caller must hold the sim mutex.
+   */
+  void apply_joint_state_writes(const std::vector<SingleDofJointWrite>& writes);
 
   // Service callbacks
   void reset_world_callback(const std::shared_ptr<mujoco_ros2_control_msgs::srv::ResetWorld::Request> request,

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -40,6 +40,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <mujoco_ros2_control_msgs/msg/free_joint_state.hpp>
+#include <mujoco_ros2_control_msgs/msg/simulation_state.hpp>
 #include <mujoco_ros2_control_msgs/srv/reset_world.hpp>
 #include <mujoco_ros2_control_msgs/srv/set_free_joint_state.hpp>
 #include <mujoco_ros2_control_msgs/srv/set_pause.hpp>
@@ -187,9 +188,7 @@ public:
    *
    * @note Caller must hold the sim mutex.
    */
-  void
-  reset_world_state(bool fill_initial_state, const sensor_msgs::msg::JointState& joint_state_overrides = {},
-                    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joint_state_overrides = {});
+  void reset_world_state(bool fill_initial_state, const mujoco_ros2_control_msgs::msg::SimulationState& state_overrides);
 
   /**
    * @brief Sets the pose and velocity of one or more free-joint objects, identified by body name.

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -184,7 +184,7 @@ public:
    * optionally applying joint state overrides on top of the restored state.
    *
    * Overrides are assumed to have been validated by the caller, so they cannot fail here
-   * (see `resolve_joint_state_writes` / `resolve_free_joint_writes`).
+   * (see `validate_joint_state_overrides` / `validate_free_joint_states`).
    *
    * @note Caller must hold the sim mutex.
    */
@@ -193,7 +193,7 @@ public:
   /**
    * @brief Sets the pose and velocity of one or more free-joint objects, identified by body name.
    *
-   * Applied atomically: every entry is resolved before anything is written, so a single invalid
+   * Applied atomically: every entry is validated before anything is written, so a single invalid
    * entry leaves the sim state unchanged. Duplicate body names are applied in order, so the last
    * one wins. See `FreeJointState.msg` for per-entry fields.
    *
@@ -344,19 +344,6 @@ private:
   void update_sim_display();
 
   /**
-   * @brief A `FreeJointState` entry fully resolved to world-frame values, ready to write.
-   */
-  struct FreeJointWrite
-  {
-    int qpos_adr{ -1 };
-    int qvel_adr{ -1 };
-    mjtNum world_pos[3];
-    mjtNum world_quat[4];
-    mjtNum world_linvel[3];
-    mjtNum world_angvel[3];
-  };
-
-  /**
    * @brief Resolves `frame_id` to a body id: empty means the world frame (`body_id = -1`),
    * otherwise it must name a known MuJoCo body.
    *
@@ -367,61 +354,50 @@ private:
                         std::string& error_message);
 
   /**
-   * @brief Resolves a list of `FreeJointState` entries into `FreeJointWrite`s, without touching
-   * `mj_data_`.
-   *
-   * Each entry's `pose` and `twist` resolve their own `header.frame_id` independently -- they
-   * may reference different bodies, or vary between world vs. relative frame to another body.
-   *
-   * @note Caller must hold the sim mutex.
-   * @return true if every entry's body, free joint, and both frame_ids were resolved; false
-   * otherwise, with `error_message` set.
+   * @brief Returns the id of the free joint driving `body_id`, or -1 if there is none.
    */
-  bool resolve_free_joint_writes(const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints,
-                                 std::vector<FreeJointWrite>& writes, std::string& error_message);
+  int find_free_joint_id(int body_id) const;
 
   /**
-   * @brief Writes resolved free-joint states into `mj_data_->qpos`/`qvel`.
+   * @brief Validates a list of `FreeJointState` entries against the model, without touching
+   * `mj_data_`: every entry must name a body driven by a free joint, and both `header.frame_id`s
+   * must be empty (world frame) or name a known body.
+   *
+   * @note Caller must hold the sim mutex.
+   * @return true if every entry is valid; false otherwise, with `error_message` set.
+   */
+  bool validate_free_joint_states(const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints,
+                                  std::string& error_message);
+
+  /**
+   * @brief Writes free-joint states into `mj_data_->qpos`/`qvel`, resolving each entry's `pose`
+   * and `twist` against their own `header.frame_id` -- they may reference different bodies, or
+   * vary between world vs. relative frame to another body.
    * Does not refresh snapshots or run forward dynamics; the caller is responsible for both.
    *
-   * @note Caller must hold the sim mutex.
+   * @note Caller must hold the sim mutex and have validated `free_joints` first.
    */
-  void apply_free_joint_writes(const std::vector<FreeJointWrite>& writes);
+  void apply_free_joint_states(const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints);
 
   /**
-   * @brief A single-DOF joint state override resolved to qpos/qvel addresses, ready to write.
-   */
-  struct SingleDofJointWrite
-  {
-    int qpos_adr{ -1 };
-    int qvel_adr{ -1 };
-    bool has_position{ false };
-    bool has_velocity{ false };
-    mjtNum position{ 0.0 };
-    mjtNum velocity{ 0.0 };
-  };
-
-  /**
-   * @brief Resolves a `JointState` message into `SingleDofJointWrite`s, without touching
-   * `mj_data_`.
+   * @brief Validates a `JointState` message against the model, without touching `mj_data_`.
    *
    * Every named joint must be a single-DOF (hinge or slide) MuJoCo joint, and `position` /
    * `velocity` must each be empty or the same length as `name`. `effort` is not supported and
    * must be empty.
    *
    * @note Caller must hold the sim mutex.
-   * @return true if every entry was resolved; false otherwise, with `error_message` set.
+   * @return true if the message is valid; false otherwise, with `error_message` set.
    */
-  bool resolve_joint_state_writes(const sensor_msgs::msg::JointState& joint_state,
-                                  std::vector<SingleDofJointWrite>& writes, std::string& error_message);
+  bool validate_joint_state_overrides(const sensor_msgs::msg::JointState& joint_state, std::string& error_message);
 
   /**
-   * @brief Writes resolved single-DOF joint states into `mj_data_->qpos`/`qvel`.
+   * @brief Writes single-DOF joint states into `mj_data_->qpos`/`qvel`.
    * Does not refresh snapshots or run forward dynamics; the caller is responsible for both.
    *
-   * @note Caller must hold the sim mutex.
+   * @note Caller must hold the sim mutex and have validated `joint_state` first.
    */
-  void apply_joint_state_writes(const std::vector<SingleDofJointWrite>& writes);
+  void apply_joint_state_overrides(const sensor_msgs::msg::JointState& joint_state);
 
   // Service callbacks
   void reset_world_callback(const std::shared_ptr<mujoco_ros2_control_msgs::srv::ResetWorld::Request> request,

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -821,9 +821,8 @@ void MujocoSimulation::shutdown()
   }
 }
 
-void MujocoSimulation::reset_world_state(
-    bool fill_initial_state, const sensor_msgs::msg::JointState& joint_state_overrides,
-    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joint_state_overrides)
+void MujocoSimulation::reset_world_state(bool fill_initial_state,
+                                         const mujoco_ros2_control_msgs::msg::SimulationState& state_overrides)
 {
   /// @note This method assumes sim_mutex_ is already held by the caller
 
@@ -871,10 +870,10 @@ void MujocoSimulation::reset_world_state(
 
   // Apply single-DOF joint overrides on top of the restored state.
   std::string error_message;
-  if (!joint_state_overrides.name.empty())
+  if (!state_overrides.joint_states.name.empty())
   {
     std::vector<SingleDofJointWrite> joint_writes;
-    if (resolve_joint_state_writes(joint_state_overrides, joint_writes, error_message))
+    if (resolve_joint_state_writes(state_overrides.joint_states, joint_writes, error_message))
     {
       apply_joint_state_writes(joint_writes);
     }
@@ -886,11 +885,11 @@ void MujocoSimulation::reset_world_state(
 
   // Apply free-joint overrides. Their frame_ids resolve against post-reset body poses
   // (including the single-DOF overrides above), so refresh kinematics before resolving.
-  if (!free_joint_state_overrides.empty())
+  if (!state_overrides.free_joint_states.empty())
   {
     mj_kinematics(mj_model_, mj_data_);
     std::vector<FreeJointWrite> free_joint_writes;
-    if (resolve_free_joint_writes(free_joint_state_overrides, free_joint_writes, error_message))
+    if (resolve_free_joint_writes(state_overrides.free_joint_states, free_joint_writes, error_message))
     {
       apply_free_joint_writes(free_joint_writes);
     }
@@ -931,8 +930,8 @@ void MujocoSimulation::reset_world_callback(
     std::vector<SingleDofJointWrite> joint_writes;
     std::vector<FreeJointWrite> free_joint_writes;
     std::string error_message;
-    if (!resolve_joint_state_writes(request->joint_state_overrides, joint_writes, error_message) ||
-        !resolve_free_joint_writes(request->free_joint_state_overrides, free_joint_writes, error_message))
+    if (!resolve_joint_state_writes(request->state_overrides.joint_states, joint_writes, error_message) ||
+        !resolve_free_joint_writes(request->state_overrides.free_joint_states, free_joint_writes, error_message))
     {
       response->message = error_message + " Not resetting world.";
       RCLCPP_ERROR(get_logger(), "%s", response->message.c_str());
@@ -953,11 +952,12 @@ void MujocoSimulation::reset_world_callback(
     }
   }
 
-  reset_world_state(fill_initial_state, request->joint_state_overrides, request->free_joint_state_overrides);
+  reset_world_state(fill_initial_state, request->state_overrides);
   response->success = true;
   const std::string keyframe_str = fill_initial_state ? "initial" : ("'" + request->keyframe + "'");
   response->message = "Successfully reset the MuJoCo world to the " + keyframe_str + " state.";
-  const size_t num_overrides = request->joint_state_overrides.name.size() + request->free_joint_state_overrides.size();
+  const size_t num_overrides =
+      request->state_overrides.joint_states.name.size() + request->state_overrides.free_joint_states.size();
   if (num_overrides > 0)
   {
     response->message +=
@@ -1234,7 +1234,7 @@ bool MujocoSimulation::resolve_joint_state_writes(const sensor_msgs::msg::JointS
       error_message = entry_prefix + "Not a single-DOF (hinge or slide) joint.";
       if (joint_type == mjJNT_FREE)
       {
-        error_message += " Free joints are set through 'free_joint_state_overrides' by body name.";
+        error_message += " Free joints are set through 'state_overrides.free_joint_states' by body name.";
       }
       return false;
     }
@@ -1468,8 +1468,8 @@ void MujocoSimulation::physics_loop()
         // Restore simulation time before reset_world_state saves it
         mj_data_->time = prevSimTime;
 
-        // Apply initial state using common method
-        reset_world_state(true);
+        // Apply initial state with no joint state overrides.
+        reset_world_state(true, mujoco_ros2_control_msgs::msg::SimulationState{});
 
         // Force speed_changed to re-sync timing
         sim_->speed_changed = true;

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -869,34 +869,14 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
   mj_data_->time = saved_time;
 
   // Apply single-DOF joint overrides on top of the restored state.
-  std::string error_message;
-  if (!state_overrides.joint_states.name.empty())
-  {
-    std::vector<SingleDofJointWrite> joint_writes;
-    if (resolve_joint_state_writes(state_overrides.joint_states, joint_writes, error_message))
-    {
-      apply_joint_state_writes(joint_writes);
-    }
-    else
-    {
-      RCLCPP_ERROR(get_logger(), "Skipping unvalidated joint state overrides: %s", error_message.c_str());
-    }
-  }
+  apply_joint_state_overrides(state_overrides.joint_states);
 
   // Apply free-joint overrides. Their frame_ids resolve against post-reset body poses
-  // (including the single-DOF overrides above), so refresh kinematics before resolving.
+  // (including the single-DOF overrides above), so refresh kinematics before applying.
   if (!state_overrides.free_joint_states.empty())
   {
     mj_kinematics(mj_model_, mj_data_);
-    std::vector<FreeJointWrite> free_joint_writes;
-    if (resolve_free_joint_writes(state_overrides.free_joint_states, free_joint_writes, error_message))
-    {
-      apply_free_joint_writes(free_joint_writes);
-    }
-    else
-    {
-      RCLCPP_ERROR(get_logger(), "Skipping unvalidated free joint overrides: %s", error_message.c_str());
-    }
+    apply_free_joint_states(state_overrides.free_joint_states);
   }
 
   // Run forward dynamics to update derived quantities
@@ -924,20 +904,16 @@ void MujocoSimulation::reset_world_callback(
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
 
   // Validate every override before touching any state, so an invalid entry leaves the world
-  // un-reset. The resolved writes are discarded: free-joint frame_ids must be re-resolved
-  // against post-reset body poses, which reset_world_state does after applying the reset.
+  // un-reset. Validation only checks names and shapes against the model; free-joint frame_ids
+  // resolve against post-reset body poses when reset_world_state applies the overrides.
+  std::string error_message;
+  if (!validate_joint_state_overrides(request->state_overrides.joint_states, error_message) ||
+      !validate_free_joint_states(request->state_overrides.free_joint_states, error_message))
   {
-    std::vector<SingleDofJointWrite> joint_writes;
-    std::vector<FreeJointWrite> free_joint_writes;
-    std::string error_message;
-    if (!resolve_joint_state_writes(request->state_overrides.joint_states, joint_writes, error_message) ||
-        !resolve_free_joint_writes(request->state_overrides.free_joint_states, free_joint_writes, error_message))
-    {
-      response->message = error_message + " Not resetting world.";
-      RCLCPP_ERROR(get_logger(), "%s", response->message.c_str());
-      response->success = false;
-      return;
-    }
+    response->message = error_message + " Not resetting world.";
+    RCLCPP_ERROR(get_logger(), "%s", response->message.c_str());
+    response->success = false;
+    return;
   }
 
   bool fill_initial_state = request->keyframe.empty();
@@ -1084,11 +1060,22 @@ bool MujocoSimulation::resolve_frame_id(const std::string& frame_id, const std::
   return true;
 }
 
-bool MujocoSimulation::resolve_free_joint_writes(
-    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints, std::vector<FreeJointWrite>& writes,
-    std::string& error_message)
+int MujocoSimulation::find_free_joint_id(int body_id) const
 {
-  writes.reserve(writes.size() + free_joints.size());
+  // A body has at most one free joint.
+  for (int j = 0; j < mj_model_->njnt; ++j)
+  {
+    if (mj_model_->jnt_bodyid[j] == body_id && mj_model_->jnt_type[j] == mjJNT_FREE)
+    {
+      return j;
+    }
+  }
+  return -1;
+}
+
+bool MujocoSimulation::validate_free_joint_states(
+    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints, std::string& error_message)
+{
   for (size_t i = 0; i < free_joints.size(); ++i)
   {
     const mujoco_ros2_control_msgs::msg::FreeJointState& state = free_joints[i];
@@ -1101,23 +1088,35 @@ bool MujocoSimulation::resolve_free_joint_writes(
       return false;
     }
 
-    // A body has at most one free joint.
-    FreeJointWrite write;
-    for (int j = 0; j < mj_model_->njnt; ++j)
-    {
-      if (mj_model_->jnt_bodyid[j] == body_id && mj_model_->jnt_type[j] == mjJNT_FREE)
-      {
-        write.qpos_adr = mj_model_->jnt_qposadr[j];
-        write.qvel_adr = mj_model_->jnt_dofadr[j];
-        break;
-      }
-    }
-
-    if (write.qpos_adr == -1)
+    if (find_free_joint_id(body_id) == -1)
     {
       error_message = entry_prefix + "Body is not driven by a free joint.";
       return false;
     }
+
+    std::string frame_error;
+    int frame_body_id = -1;
+    if (!resolve_frame_id(state.pose.header.frame_id, "pose", frame_body_id, frame_error) ||
+        !resolve_frame_id(state.twist.header.frame_id, "twist", frame_body_id, frame_error))
+    {
+      error_message = entry_prefix + frame_error;
+      return false;
+    }
+  }
+  return true;
+}
+
+void MujocoSimulation::apply_free_joint_states(
+    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints)
+{
+  for (const mujoco_ros2_control_msgs::msg::FreeJointState& state : free_joints)
+  {
+    const int body_id = mj_name2id(mj_model_, mjOBJ_BODY, state.name.c_str());
+    const int joint_id = find_free_joint_id(body_id);
+    // qpos layout is position then orientation in (w, x, y, z), MuJoCo's convention; qvel is
+    // linear then angular velocity.
+    mjtNum* qpos = mj_data_->qpos + mj_model_->jnt_qposadr[joint_id];
+    mjtNum* qvel = mj_data_->qvel + mj_model_->jnt_dofadr[joint_id];
 
     const mjtNum rel_pos[3] = { state.pose.pose.position.x, state.pose.pose.position.y, state.pose.pose.position.z };
     const mjtNum rel_quat[4] = { state.pose.pose.orientation.w, state.pose.pose.orientation.x,
@@ -1126,76 +1125,40 @@ bool MujocoSimulation::resolve_free_joint_writes(
     const mjtNum rel_angvel[3] = { state.twist.twist.angular.x, state.twist.twist.angular.y,
                                    state.twist.twist.angular.z };
 
-    std::string frame_error;
-    int pose_frame_body_id = -1;
-    if (!resolve_frame_id(state.pose.header.frame_id, "pose", pose_frame_body_id, frame_error))
-    {
-      error_message = entry_prefix + frame_error;
-      return false;
-    }
-
+    // Frame poses come from xpos/xquat, which only change when kinematics runs, so earlier
+    // entries' qpos/qvel writes cannot affect later entries' frame resolution.
+    const std::string& pose_frame = state.pose.header.frame_id;
+    const int pose_frame_body_id = pose_frame.empty() ? -1 : mj_name2id(mj_model_, mjOBJ_BODY, pose_frame.c_str());
     if (pose_frame_body_id == -1)
     {
-      mju_copy3(write.world_pos, rel_pos);
-      mju_copy4(write.world_quat, rel_quat);
+      mju_copy3(qpos, rel_pos);
+      mju_copy4(qpos + 3, rel_quat);
     }
     else
     {
-      mju_mulPose(write.world_pos, write.world_quat, mj_data_->xpos + 3 * pose_frame_body_id,
-                  mj_data_->xquat + 4 * pose_frame_body_id, rel_pos, rel_quat);
+      mju_mulPose(qpos, qpos + 3, mj_data_->xpos + 3 * pose_frame_body_id, mj_data_->xquat + 4 * pose_frame_body_id,
+                  rel_pos, rel_quat);
     }
 
-    int twist_frame_body_id = -1;
-    if (!resolve_frame_id(state.twist.header.frame_id, "twist", twist_frame_body_id, frame_error))
-    {
-      error_message = entry_prefix + frame_error;
-      return false;
-    }
-
+    const std::string& twist_frame = state.twist.header.frame_id;
+    const int twist_frame_body_id = twist_frame.empty() ? -1 : mj_name2id(mj_model_, mjOBJ_BODY, twist_frame.c_str());
     if (twist_frame_body_id == -1)
     {
-      mju_copy3(write.world_linvel, rel_linvel);
-      mju_copy3(write.world_angvel, rel_angvel);
+      mju_copy3(qvel, rel_linvel);
+      mju_copy3(qvel + 3, rel_angvel);
     }
     else
     {
       // The reference body's own velocity is not added, only its orientation.
       const mjtNum* twist_frame_quat = mj_data_->xquat + 4 * twist_frame_body_id;
-      mju_rotVecQuat(write.world_linvel, rel_linvel, twist_frame_quat);
-      mju_rotVecQuat(write.world_angvel, rel_angvel, twist_frame_quat);
+      mju_rotVecQuat(qvel, rel_linvel, twist_frame_quat);
+      mju_rotVecQuat(qvel + 3, rel_angvel, twist_frame_quat);
     }
-
-    writes.push_back(write);
-  }
-  return true;
-}
-
-void MujocoSimulation::apply_free_joint_writes(const std::vector<FreeJointWrite>& writes)
-{
-  for (const FreeJointWrite& write : writes)
-  {
-    mj_data_->qpos[write.qpos_adr + 0] = write.world_pos[0];
-    mj_data_->qpos[write.qpos_adr + 1] = write.world_pos[1];
-    mj_data_->qpos[write.qpos_adr + 2] = write.world_pos[2];
-
-    // qpos orientation is (w, x, y, z), MuJoCo's convention.
-    mj_data_->qpos[write.qpos_adr + 3] = write.world_quat[0];
-    mj_data_->qpos[write.qpos_adr + 4] = write.world_quat[1];
-    mj_data_->qpos[write.qpos_adr + 5] = write.world_quat[2];
-    mj_data_->qpos[write.qpos_adr + 6] = write.world_quat[3];
-
-    mj_data_->qvel[write.qvel_adr + 0] = write.world_linvel[0];
-    mj_data_->qvel[write.qvel_adr + 1] = write.world_linvel[1];
-    mj_data_->qvel[write.qvel_adr + 2] = write.world_linvel[2];
-
-    mj_data_->qvel[write.qvel_adr + 3] = write.world_angvel[0];
-    mj_data_->qvel[write.qvel_adr + 4] = write.world_angvel[1];
-    mj_data_->qvel[write.qvel_adr + 5] = write.world_angvel[2];
   }
 }
 
-bool MujocoSimulation::resolve_joint_state_writes(const sensor_msgs::msg::JointState& joint_state,
-                                                  std::vector<SingleDofJointWrite>& writes, std::string& error_message)
+bool MujocoSimulation::validate_joint_state_overrides(const sensor_msgs::msg::JointState& joint_state,
+                                                      std::string& error_message)
 {
   const size_t num_joints = joint_state.name.size();
   if (!joint_state.effort.empty())
@@ -1216,7 +1179,6 @@ bool MujocoSimulation::resolve_joint_state_writes(const sensor_msgs::msg::JointS
     return false;
   }
 
-  writes.reserve(writes.size() + num_joints);
   for (size_t i = 0; i < num_joints; ++i)
   {
     const std::string& name = joint_state.name[i];
@@ -1238,36 +1200,22 @@ bool MujocoSimulation::resolve_joint_state_writes(const sensor_msgs::msg::JointS
       }
       return false;
     }
-
-    SingleDofJointWrite write;
-    write.qpos_adr = mj_model_->jnt_qposadr[joint_id];
-    write.qvel_adr = mj_model_->jnt_dofadr[joint_id];
-    if (!joint_state.position.empty())
-    {
-      write.has_position = true;
-      write.position = joint_state.position[i];
-    }
-    if (!joint_state.velocity.empty())
-    {
-      write.has_velocity = true;
-      write.velocity = joint_state.velocity[i];
-    }
-    writes.push_back(write);
   }
   return true;
 }
 
-void MujocoSimulation::apply_joint_state_writes(const std::vector<SingleDofJointWrite>& writes)
+void MujocoSimulation::apply_joint_state_overrides(const sensor_msgs::msg::JointState& joint_state)
 {
-  for (const SingleDofJointWrite& write : writes)
+  for (size_t i = 0; i < joint_state.name.size(); ++i)
   {
-    if (write.has_position)
+    const int joint_id = mj_name2id(mj_model_, mjOBJ_JOINT, joint_state.name[i].c_str());
+    if (!joint_state.position.empty())
     {
-      mj_data_->qpos[write.qpos_adr] = write.position;
+      mj_data_->qpos[mj_model_->jnt_qposadr[joint_id]] = joint_state.position[i];
     }
-    if (write.has_velocity)
+    if (!joint_state.velocity.empty())
     {
-      mj_data_->qvel[write.qvel_adr] = write.velocity;
+      mj_data_->qvel[mj_model_->jnt_dofadr[joint_id]] = joint_state.velocity[i];
     }
   }
 }
@@ -1277,21 +1225,20 @@ bool MujocoSimulation::set_free_joint_states(
 {
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
 
-  // Resolve everything before writing anything, so a single invalid entry leaves mj_data_
+  // Validate everything before writing anything, so a single invalid entry leaves mj_data_
   // untouched.
-  std::vector<FreeJointWrite> writes;
-  if (!resolve_free_joint_writes(free_joints, writes, error_message))
+  if (!validate_free_joint_states(free_joints, error_message))
   {
     RCLCPP_WARN(get_logger(), "%s", error_message.c_str());
     return false;
   }
 
-  if (writes.empty())
+  if (free_joints.empty())
   {
     return true;
   }
 
-  apply_free_joint_writes(writes);
+  apply_free_joint_states(free_joints);
 
   refresh_data_snapshot();
   publish_control_state();

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -821,7 +821,9 @@ void MujocoSimulation::shutdown()
   }
 }
 
-void MujocoSimulation::reset_world_state(bool fill_initial_state)
+void MujocoSimulation::reset_world_state(
+    bool fill_initial_state, const sensor_msgs::msg::JointState& joint_state_overrides,
+    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joint_state_overrides)
 {
   /// @note This method assumes sim_mutex_ is already held by the caller
 
@@ -867,6 +869,37 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state)
   // Restore simulation time to preserve ROS clock continuity
   mj_data_->time = saved_time;
 
+  // Apply single-DOF joint overrides on top of the restored state.
+  std::string error_message;
+  if (!joint_state_overrides.name.empty())
+  {
+    std::vector<SingleDofJointWrite> joint_writes;
+    if (resolve_joint_state_writes(joint_state_overrides, joint_writes, error_message))
+    {
+      apply_joint_state_writes(joint_writes);
+    }
+    else
+    {
+      RCLCPP_ERROR(get_logger(), "Skipping unvalidated joint state overrides: %s", error_message.c_str());
+    }
+  }
+
+  // Apply free-joint overrides. Their frame_ids resolve against post-reset body poses
+  // (including the single-DOF overrides above), so refresh kinematics before resolving.
+  if (!free_joint_state_overrides.empty())
+  {
+    mj_kinematics(mj_model_, mj_data_);
+    std::vector<FreeJointWrite> free_joint_writes;
+    if (resolve_free_joint_writes(free_joint_state_overrides, free_joint_writes, error_message))
+    {
+      apply_free_joint_writes(free_joint_writes);
+    }
+    else
+    {
+      RCLCPP_ERROR(get_logger(), "Skipping unvalidated free joint overrides: %s", error_message.c_str());
+    }
+  }
+
   // Run forward dynamics to update derived quantities
   mj_forward(mj_model_, mj_data_);
 
@@ -891,6 +924,23 @@ void MujocoSimulation::reset_world_callback(
                          "Reset world service called. Resetting to initial keyframe...");
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
 
+  // Validate every override before touching any state, so an invalid entry leaves the world
+  // un-reset. The resolved writes are discarded: free-joint frame_ids must be re-resolved
+  // against post-reset body poses, which reset_world_state does after applying the reset.
+  {
+    std::vector<SingleDofJointWrite> joint_writes;
+    std::vector<FreeJointWrite> free_joint_writes;
+    std::string error_message;
+    if (!resolve_joint_state_writes(request->joint_state_overrides, joint_writes, error_message) ||
+        !resolve_free_joint_writes(request->free_joint_state_overrides, free_joint_writes, error_message))
+    {
+      response->message = error_message + " Not resetting world.";
+      RCLCPP_ERROR(get_logger(), "%s", response->message.c_str());
+      response->success = false;
+      return;
+    }
+  }
+
   bool fill_initial_state = request->keyframe.empty();
   if (!fill_initial_state)
   {
@@ -903,10 +953,16 @@ void MujocoSimulation::reset_world_callback(
     }
   }
 
-  reset_world_state(fill_initial_state);
+  reset_world_state(fill_initial_state, request->joint_state_overrides, request->free_joint_state_overrides);
   response->success = true;
   const std::string keyframe_str = fill_initial_state ? "initial" : ("'" + request->keyframe + "'");
   response->message = "Successfully reset the MuJoCo world to the " + keyframe_str + " state.";
+  const size_t num_overrides = request->joint_state_overrides.name.size() + request->free_joint_state_overrides.size();
+  if (num_overrides > 0)
+  {
+    response->message +=
+        " Applied " + std::to_string(num_overrides) + " joint state override" + (num_overrides == 1 ? "" : "s") + ".";
+  }
 
   RCLCPP_INFO(get_logger(), "%s", response->message.c_str());
 }
@@ -1028,120 +1084,94 @@ bool MujocoSimulation::resolve_frame_id(const std::string& frame_id, const std::
   return true;
 }
 
-bool MujocoSimulation::resolve_free_joint_write(const mujoco_ros2_control_msgs::msg::FreeJointState& state,
-                                                FreeJointWrite& out, std::string& error_message)
+bool MujocoSimulation::resolve_free_joint_writes(
+    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints, std::vector<FreeJointWrite>& writes,
+    std::string& error_message)
 {
-  const int body_id = mj_name2id(mj_model_, mjOBJ_BODY, state.name.c_str());
-  if (body_id == -1)
+  writes.reserve(writes.size() + free_joints.size());
+  for (size_t i = 0; i < free_joints.size(); ++i)
   {
-    error_message = "Unknown body name: '" + state.name + "'.";
-    return false;
-  }
+    const mujoco_ros2_control_msgs::msg::FreeJointState& state = free_joints[i];
+    const std::string entry_prefix = "Entry " + std::to_string(i) + " ('" + state.name + "'): ";
 
-  // A body has at most one free joint.
-  int qpos_adr = -1;
-  int qvel_adr = -1;
-  for (int i = 0; i < mj_model_->njnt; ++i)
-  {
-    if (mj_model_->jnt_bodyid[i] == body_id && mj_model_->jnt_type[i] == mjJNT_FREE)
+    const int body_id = mj_name2id(mj_model_, mjOBJ_BODY, state.name.c_str());
+    if (body_id == -1)
     {
-      qpos_adr = mj_model_->jnt_qposadr[i];
-      qvel_adr = mj_model_->jnt_dofadr[i];
-      break;
+      error_message = entry_prefix + "Unknown body name.";
+      return false;
     }
+
+    // A body has at most one free joint.
+    FreeJointWrite write;
+    for (int j = 0; j < mj_model_->njnt; ++j)
+    {
+      if (mj_model_->jnt_bodyid[j] == body_id && mj_model_->jnt_type[j] == mjJNT_FREE)
+      {
+        write.qpos_adr = mj_model_->jnt_qposadr[j];
+        write.qvel_adr = mj_model_->jnt_dofadr[j];
+        break;
+      }
+    }
+
+    if (write.qpos_adr == -1)
+    {
+      error_message = entry_prefix + "Body is not driven by a free joint.";
+      return false;
+    }
+
+    const mjtNum rel_pos[3] = { state.pose.pose.position.x, state.pose.pose.position.y, state.pose.pose.position.z };
+    const mjtNum rel_quat[4] = { state.pose.pose.orientation.w, state.pose.pose.orientation.x,
+                                 state.pose.pose.orientation.y, state.pose.pose.orientation.z };
+    const mjtNum rel_linvel[3] = { state.twist.twist.linear.x, state.twist.twist.linear.y, state.twist.twist.linear.z };
+    const mjtNum rel_angvel[3] = { state.twist.twist.angular.x, state.twist.twist.angular.y,
+                                   state.twist.twist.angular.z };
+
+    std::string frame_error;
+    int pose_frame_body_id = -1;
+    if (!resolve_frame_id(state.pose.header.frame_id, "pose", pose_frame_body_id, frame_error))
+    {
+      error_message = entry_prefix + frame_error;
+      return false;
+    }
+
+    if (pose_frame_body_id == -1)
+    {
+      mju_copy3(write.world_pos, rel_pos);
+      mju_copy4(write.world_quat, rel_quat);
+    }
+    else
+    {
+      mju_mulPose(write.world_pos, write.world_quat, mj_data_->xpos + 3 * pose_frame_body_id,
+                  mj_data_->xquat + 4 * pose_frame_body_id, rel_pos, rel_quat);
+    }
+
+    int twist_frame_body_id = -1;
+    if (!resolve_frame_id(state.twist.header.frame_id, "twist", twist_frame_body_id, frame_error))
+    {
+      error_message = entry_prefix + frame_error;
+      return false;
+    }
+
+    if (twist_frame_body_id == -1)
+    {
+      mju_copy3(write.world_linvel, rel_linvel);
+      mju_copy3(write.world_angvel, rel_angvel);
+    }
+    else
+    {
+      // The reference body's own velocity is not added, only its orientation.
+      const mjtNum* twist_frame_quat = mj_data_->xquat + 4 * twist_frame_body_id;
+      mju_rotVecQuat(write.world_linvel, rel_linvel, twist_frame_quat);
+      mju_rotVecQuat(write.world_angvel, rel_angvel, twist_frame_quat);
+    }
+
+    writes.push_back(write);
   }
-
-  if (qpos_adr == -1)
-  {
-    error_message = "Body '" + state.name + "' is not driven by a free joint.";
-    return false;
-  }
-
-  const mjtNum rel_pos[3] = { state.pose.pose.position.x, state.pose.pose.position.y, state.pose.pose.position.z };
-  const mjtNum rel_quat[4] = { state.pose.pose.orientation.w, state.pose.pose.orientation.x,
-                               state.pose.pose.orientation.y, state.pose.pose.orientation.z };
-  const mjtNum rel_linvel[3] = { state.twist.twist.linear.x, state.twist.twist.linear.y, state.twist.twist.linear.z };
-  const mjtNum rel_angvel[3] = { state.twist.twist.angular.x, state.twist.twist.angular.y, state.twist.twist.angular.z };
-
-  mjtNum world_pos[3];
-  mjtNum world_quat[4];
-
-  int pose_frame_body_id = -1;
-  if (!resolve_frame_id(state.pose.header.frame_id, "pose", pose_frame_body_id, error_message))
-  {
-    return false;
-  }
-
-  if (pose_frame_body_id == -1)
-  {
-    mju_copy3(world_pos, rel_pos);
-    mju_copy4(world_quat, rel_quat);
-  }
-  else
-  {
-    mju_mulPose(world_pos, world_quat, mj_data_->xpos + 3 * pose_frame_body_id,
-                mj_data_->xquat + 4 * pose_frame_body_id, rel_pos, rel_quat);
-  }
-
-  mjtNum world_linvel[3];
-  mjtNum world_angvel[3];
-
-  int twist_frame_body_id = -1;
-  if (!resolve_frame_id(state.twist.header.frame_id, "twist", twist_frame_body_id, error_message))
-  {
-    return false;
-  }
-
-  if (twist_frame_body_id == -1)
-  {
-    mju_copy3(world_linvel, rel_linvel);
-    mju_copy3(world_angvel, rel_angvel);
-  }
-  else
-  {
-    // The reference body's own velocity is not added, only its orientation.
-    const mjtNum* twist_frame_quat = mj_data_->xquat + 4 * twist_frame_body_id;
-    mju_rotVecQuat(world_linvel, rel_linvel, twist_frame_quat);
-    mju_rotVecQuat(world_angvel, rel_angvel, twist_frame_quat);
-  }
-
-  out.qpos_adr = qpos_adr;
-  out.qvel_adr = qvel_adr;
-  mju_copy3(out.world_pos, world_pos);
-  mju_copy4(out.world_quat, world_quat);
-  mju_copy3(out.world_linvel, world_linvel);
-  mju_copy3(out.world_angvel, world_angvel);
-
   return true;
 }
 
-bool MujocoSimulation::set_free_joint_states(
-    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints, std::string& error_message)
+void MujocoSimulation::apply_free_joint_writes(const std::vector<FreeJointWrite>& writes)
 {
-  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
-
-  // Resolve everything before writing anything, so a single invalid entry leaves mj_data_
-  // untouched.
-  std::vector<FreeJointWrite> writes;
-  writes.reserve(free_joints.size());
-  for (size_t i = 0; i < free_joints.size(); ++i)
-  {
-    FreeJointWrite write;
-    std::string entry_error;
-    if (!resolve_free_joint_write(free_joints[i], write, entry_error))
-    {
-      error_message = "Entry " + std::to_string(i) + " ('" + free_joints[i].name + "'): " + entry_error;
-      RCLCPP_WARN(get_logger(), "%s", error_message.c_str());
-      return false;
-    }
-    writes.push_back(write);
-  }
-
-  if (writes.empty())
-  {
-    return true;
-  }
-
   for (const FreeJointWrite& write : writes)
   {
     mj_data_->qpos[write.qpos_adr + 0] = write.world_pos[0];
@@ -1162,6 +1192,106 @@ bool MujocoSimulation::set_free_joint_states(
     mj_data_->qvel[write.qvel_adr + 4] = write.world_angvel[1];
     mj_data_->qvel[write.qvel_adr + 5] = write.world_angvel[2];
   }
+}
+
+bool MujocoSimulation::resolve_joint_state_writes(const sensor_msgs::msg::JointState& joint_state,
+                                                  std::vector<SingleDofJointWrite>& writes, std::string& error_message)
+{
+  const size_t num_joints = joint_state.name.size();
+  if (!joint_state.effort.empty())
+  {
+    error_message = "Joint state effort is not supported; leave 'effort' empty.";
+    return false;
+  }
+  if (!joint_state.position.empty() && joint_state.position.size() != num_joints)
+  {
+    error_message = "Joint state 'position' has " + std::to_string(joint_state.position.size()) +
+                    " entries but 'name' has " + std::to_string(num_joints) + "; it must be empty or the same length.";
+    return false;
+  }
+  if (!joint_state.velocity.empty() && joint_state.velocity.size() != num_joints)
+  {
+    error_message = "Joint state 'velocity' has " + std::to_string(joint_state.velocity.size()) +
+                    " entries but 'name' has " + std::to_string(num_joints) + "; it must be empty or the same length.";
+    return false;
+  }
+
+  writes.reserve(writes.size() + num_joints);
+  for (size_t i = 0; i < num_joints; ++i)
+  {
+    const std::string& name = joint_state.name[i];
+    const std::string entry_prefix = "Entry " + std::to_string(i) + " ('" + name + "'): ";
+
+    const int joint_id = mj_name2id(mj_model_, mjOBJ_JOINT, name.c_str());
+    if (joint_id == -1)
+    {
+      error_message = entry_prefix + "Unknown joint name.";
+      return false;
+    }
+    const int joint_type = mj_model_->jnt_type[joint_id];
+    if (joint_type != mjJNT_HINGE && joint_type != mjJNT_SLIDE)
+    {
+      error_message = entry_prefix + "Not a single-DOF (hinge or slide) joint.";
+      if (joint_type == mjJNT_FREE)
+      {
+        error_message += " Free joints are set through 'free_joint_state_overrides' by body name.";
+      }
+      return false;
+    }
+
+    SingleDofJointWrite write;
+    write.qpos_adr = mj_model_->jnt_qposadr[joint_id];
+    write.qvel_adr = mj_model_->jnt_dofadr[joint_id];
+    if (!joint_state.position.empty())
+    {
+      write.has_position = true;
+      write.position = joint_state.position[i];
+    }
+    if (!joint_state.velocity.empty())
+    {
+      write.has_velocity = true;
+      write.velocity = joint_state.velocity[i];
+    }
+    writes.push_back(write);
+  }
+  return true;
+}
+
+void MujocoSimulation::apply_joint_state_writes(const std::vector<SingleDofJointWrite>& writes)
+{
+  for (const SingleDofJointWrite& write : writes)
+  {
+    if (write.has_position)
+    {
+      mj_data_->qpos[write.qpos_adr] = write.position;
+    }
+    if (write.has_velocity)
+    {
+      mj_data_->qvel[write.qvel_adr] = write.velocity;
+    }
+  }
+}
+
+bool MujocoSimulation::set_free_joint_states(
+    const std::vector<mujoco_ros2_control_msgs::msg::FreeJointState>& free_joints, std::string& error_message)
+{
+  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+
+  // Resolve everything before writing anything, so a single invalid entry leaves mj_data_
+  // untouched.
+  std::vector<FreeJointWrite> writes;
+  if (!resolve_free_joint_writes(free_joints, writes, error_message))
+  {
+    RCLCPP_WARN(get_logger(), "%s", error_message.c_str());
+    return false;
+  }
+
+  if (writes.empty())
+  {
+    return true;
+  }
+
+  apply_free_joint_writes(writes);
 
   refresh_data_snapshot();
   publish_control_state();

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -30,6 +30,7 @@
 
 #include <mujoco_ros2_control/mujoco_simulation.hpp>
 #include <mujoco_ros2_control_msgs/msg/free_joint_state.hpp>
+#include <mujoco_ros2_control_msgs/srv/reset_world.hpp>
 #include <mujoco_ros2_control_msgs/srv/set_free_joint_state.hpp>
 
 namespace
@@ -382,6 +383,183 @@ TEST_F(MujocoSimulationTest, ResetWorldTest)
   const double time_after_reset = sim_->data()->time;
   ASSERT_TRUE(wait_until([&]() { return sim_->data()->time > time_after_reset; }))
       << "Time should advance after unpausing post-reset";
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldJointStateOverrides)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  // Capture a known initial state, then drift away from it.
+  sim_->data()->qpos[0] = 0.0;
+  sim_->data()->qvel[0] = 0.0;
+  sim_->capture_initial_state();
+  sim_->data()->qpos[0] = 0.3;
+  sim_->data()->qvel[0] = 2.0;
+
+  const std::string ns = std::string(node_->get_fully_qualified_name());
+  auto client = node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>(ns + "/reset_world");
+  ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
+
+  auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->joint_state_overrides.name = { "hinge" };
+  req->joint_state_overrides.position = { 0.7 };
+  req->joint_state_overrides.velocity = { 0.25 };
+
+  auto future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto resp = future.get();
+  ASSERT_TRUE(resp->success) << resp->message;
+
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[0], 0.7) << "Override should win over the restored initial position";
+  EXPECT_DOUBLE_EQ(sim_->data()->qvel[0], 0.25) << "Override should win over the restored initial velocity";
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldKeyframeAndOverrides)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  const std::string ns = std::string(node_->get_fully_qualified_name());
+  auto client = node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>(ns + "/reset_world");
+  ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
+
+  mujoco_ros2_control_msgs::msg::FreeJointState free_override;
+  free_override.name = "free_object_2";
+  free_override.pose.pose.position.x = 5.0;
+  free_override.pose.pose.position.y = 6.0;
+  free_override.pose.pose.position.z = 7.0;
+  free_override.pose.pose.orientation.w = 1.0;
+
+  auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->keyframe = "home";  // hinge=0.5, free_object at (1,0,1), free_object_2 at (2,0,1)
+  req->joint_state_overrides.name = { "hinge" };
+  req->joint_state_overrides.position = { 0.25 };
+  req->free_joint_state_overrides.push_back(free_override);
+
+  auto future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto resp = future.get();
+  ASSERT_TRUE(resp->success) << resp->message;
+
+  // Overridden entries take their override values, everything else keeps the keyframe values.
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[0], 0.25);
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[1], 1.0);
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[2], 0.0);
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[3], 1.0);
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[8], 5.0);
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[9], 6.0);
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[10], 7.0);
+  // Unset twist in the free-joint override comes to rest, like set_free_joint_state.
+  for (int i = 7; i < 13; ++i)
+  {
+    EXPECT_DOUBLE_EQ(sim_->data()->qvel[i], 0.0) << "qvel[" << i << "] should be zero";
+  }
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldOverridesResolveFramesAfterReset)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  // Move "free_object" away from its keyframe pose so pre-reset and post-reset frame
+  // resolution give different answers.
+  sim_->data()->qpos[1] = 10.0;
+  mj_forward(sim_->model(), sim_->data());
+
+  const std::string ns = std::string(node_->get_fully_qualified_name());
+  auto client = node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>(ns + "/reset_world");
+  ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
+
+  mujoco_ros2_control_msgs::msg::FreeJointState free_override;
+  free_override.name = "free_object_2";
+  free_override.pose.header.frame_id = "free_object";
+  free_override.pose.pose.position.x = 0.5;
+  free_override.pose.pose.orientation.w = 1.0;
+
+  auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->keyframe = "home";  // puts free_object at (1,0,1)
+  req->free_joint_state_overrides.push_back(free_override);
+
+  auto future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto resp = future.get();
+  ASSERT_TRUE(resp->success) << resp->message;
+
+  // Resolved against free_object's post-reset pose (1,0,1), not its pre-reset pose (10,0,1).
+  EXPECT_NEAR(sim_->data()->qpos[8], 1.5, TEST_TOLERANCE);
+  EXPECT_NEAR(sim_->data()->qpos[9], 0.0, TEST_TOLERANCE);
+  EXPECT_NEAR(sim_->data()->qpos[10], 1.0, TEST_TOLERANCE);
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldInvalidOverrides)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  sim_->data()->qpos[0] = 0.0;
+  sim_->capture_initial_state();
+  sim_->data()->qpos[0] = 0.3;
+
+  const std::string ns = std::string(node_->get_fully_qualified_name());
+  auto client = node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>(ns + "/reset_world");
+  ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
+
+  auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->joint_state_overrides.name = { "hinge", "nonexistent_joint" };
+  req->joint_state_overrides.position = { 0.7, 0.1 };
+
+  auto future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto resp = future.get();
+  EXPECT_FALSE(resp->success);
+  EXPECT_FALSE(resp->message.empty());
+  EXPECT_DOUBLE_EQ(sim_->data()->qpos[0], 0.3) << "An invalid override must leave the world un-reset";
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldMalformedOverrides)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  const std::string ns = std::string(node_->get_fully_qualified_name());
+  auto client = node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>(ns + "/reset_world");
+  ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
+
+  // Mismatched position length.
+  auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->joint_state_overrides.name = { "hinge" };
+  req->joint_state_overrides.position = { 0.1, 0.2 };
+  auto future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto resp = future.get();
+  EXPECT_FALSE(resp->success);
+  EXPECT_FALSE(resp->message.empty());
+
+  // Effort overrides are not supported.
+  req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->joint_state_overrides.name = { "hinge" };
+  req->joint_state_overrides.effort = { 1.0 };
+  future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  resp = future.get();
+  EXPECT_FALSE(resp->success);
+  EXPECT_FALSE(resp->message.empty());
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldFreeJointInJointState)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  const std::string ns = std::string(node_->get_fully_qualified_name());
+  auto client = node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>(ns + "/reset_world");
+  ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
+
+  auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
+  req->joint_state_overrides.name = { "free_object_joint" };
+  req->joint_state_overrides.position = { 1.0 };
+
+  auto future = client->async_send_request(req);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto resp = future.get();
+  EXPECT_FALSE(resp->success);
+  EXPECT_NE(resp->message.find("free_joint_state_overrides"), std::string::npos)
+      << "Message should point free joints at the free_joint_state_overrides field, got: " << resp->message;
 }
 
 TEST_F(MujocoSimulationTest, SetFreeJointStateSetsPoseAndVelocity)

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -401,9 +401,9 @@ TEST_F(MujocoSimulationTest, ResetWorldJointStateOverrides)
   ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
 
   auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
-  req->joint_state_overrides.name = { "hinge" };
-  req->joint_state_overrides.position = { 0.7 };
-  req->joint_state_overrides.velocity = { 0.25 };
+  req->state_overrides.joint_states.name = { "hinge" };
+  req->state_overrides.joint_states.position = { 0.7 };
+  req->state_overrides.joint_states.velocity = { 0.25 };
 
   auto future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
@@ -431,9 +431,9 @@ TEST_F(MujocoSimulationTest, ResetWorldKeyframeAndOverrides)
 
   auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
   req->keyframe = "home";  // hinge=0.5, free_object at (1,0,1), free_object_2 at (2,0,1)
-  req->joint_state_overrides.name = { "hinge" };
-  req->joint_state_overrides.position = { 0.25 };
-  req->free_joint_state_overrides.push_back(free_override);
+  req->state_overrides.joint_states.name = { "hinge" };
+  req->state_overrides.joint_states.position = { 0.25 };
+  req->state_overrides.free_joint_states.push_back(free_override);
 
   auto future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
@@ -476,7 +476,7 @@ TEST_F(MujocoSimulationTest, ResetWorldOverridesResolveFramesAfterReset)
 
   auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
   req->keyframe = "home";  // puts free_object at (1,0,1)
-  req->free_joint_state_overrides.push_back(free_override);
+  req->state_overrides.free_joint_states.push_back(free_override);
 
   auto future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
@@ -502,8 +502,8 @@ TEST_F(MujocoSimulationTest, ResetWorldInvalidOverrides)
   ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
 
   auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
-  req->joint_state_overrides.name = { "hinge", "nonexistent_joint" };
-  req->joint_state_overrides.position = { 0.7, 0.1 };
+  req->state_overrides.joint_states.name = { "hinge", "nonexistent_joint" };
+  req->state_overrides.joint_states.position = { 0.7, 0.1 };
 
   auto future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
@@ -523,8 +523,8 @@ TEST_F(MujocoSimulationTest, ResetWorldMalformedOverrides)
 
   // Mismatched position length.
   auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
-  req->joint_state_overrides.name = { "hinge" };
-  req->joint_state_overrides.position = { 0.1, 0.2 };
+  req->state_overrides.joint_states.name = { "hinge" };
+  req->state_overrides.joint_states.position = { 0.1, 0.2 };
   auto future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   auto resp = future.get();
@@ -533,8 +533,8 @@ TEST_F(MujocoSimulationTest, ResetWorldMalformedOverrides)
 
   // Effort overrides are not supported.
   req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
-  req->joint_state_overrides.name = { "hinge" };
-  req->joint_state_overrides.effort = { 1.0 };
+  req->state_overrides.joint_states.name = { "hinge" };
+  req->state_overrides.joint_states.effort = { 1.0 };
   future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   resp = future.get();
@@ -551,15 +551,15 @@ TEST_F(MujocoSimulationTest, ResetWorldFreeJointInJointState)
   ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(5)));
 
   auto req = std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>();
-  req->joint_state_overrides.name = { "free_object_joint" };
-  req->joint_state_overrides.position = { 1.0 };
+  req->state_overrides.joint_states.name = { "free_object_joint" };
+  req->state_overrides.joint_states.position = { 1.0 };
 
   auto future = client->async_send_request(req);
   ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   auto resp = future.get();
   EXPECT_FALSE(resp->success);
-  EXPECT_NE(resp->message.find("free_joint_state_overrides"), std::string::npos)
-      << "Message should point free joints at the free_joint_state_overrides field, got: " << resp->message;
+  EXPECT_NE(resp->message.find("state_overrides.free_joint_states"), std::string::npos)
+      << "Message should point free joints at the state_overrides.free_joint_states field, got: " << resp->message;
 }
 
 TEST_F(MujocoSimulationTest, SetFreeJointStateSetsPoseAndVelocity)

--- a/mujoco_ros2_control_msgs/CMakeLists.txt
+++ b/mujoco_ros2_control_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ set(msg_files
   msg/ExternalWrenchArray.msg
   msg/FreeJointState.msg
   msg/FreeJointStateArray.msg
+  msg/SimulationState.msg
 )
 
 set(srv_files

--- a/mujoco_ros2_control_msgs/CMakeLists.txt
+++ b/mujoco_ros2_control_msgs/CMakeLists.txt
@@ -5,6 +5,7 @@ project(mujoco_ros2_control_msgs)
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
@@ -31,6 +32,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES
     builtin_interfaces
     geometry_msgs
+    sensor_msgs
     std_msgs
 )
 ament_export_dependencies(rosidl_default_runtime)

--- a/mujoco_ros2_control_msgs/msg/SimulationState.msg
+++ b/mujoco_ros2_control_msgs/msg/SimulationState.msg
@@ -1,0 +1,7 @@
+# Expresses a complete MuJoCo simulation state.
+
+# List of single-DOF joint states (e.g., hinges/slides).
+sensor_msgs/JointState joint_states
+
+# List of free joint states.
+FreeJointState[] free_joint_states

--- a/mujoco_ros2_control_msgs/package.xml
+++ b/mujoco_ros2_control_msgs/package.xml
@@ -22,6 +22,7 @@
 
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/mujoco_ros2_control_msgs/srv/ResetWorld.srv
+++ b/mujoco_ros2_control_msgs/srv/ResetWorld.srv
@@ -4,17 +4,14 @@
 # Name of the MJCF keyframe to reset to. Empty resets to the initial state captured at startup.
 string keyframe
 
-# Optional overrides for single-DOF (hinge/slide) joints, applied on top of the reset state and
-# keyed by MuJoCo joint name. Follows sensor_msgs/JointState conventions: `position` and
-# `velocity` must each be empty or the same length as `name`; an empty array leaves that field
-# at its reset value. `effort` is not supported and must be empty. `header` is not used.
-sensor_msgs/JointState joint_state_overrides
-
-# Optional overrides for free joints, applied on top of the reset state and keyed by the name
-# of the body each free joint drives. See FreeJointState.msg for per-entry fields; any
-# `pose`/`twist` frame_id is resolved against body poses *after* the reset is applied, before
-# any overrides are written.
-FreeJointState[] free_joint_state_overrides
+# Optional overrides for single-DOF (hinge/slide) and free joints, applied on top of the
+# reset state and keyed by MuJoCo joint name.
+# For the single-DOF joint states: `position` and `velocity` must each be empty or the
+# same length as `name`; an empty array leaves that field at its reset value.
+# `effort` is not supported and must be empty. `header` is not used.
+# For the free joint states, any `pose`/`twist` frame_id is resolved against body poses
+# *after* the reset is applied, before any overrides are written.
+SimulationState state_overrides
 
 ---
 

--- a/mujoco_ros2_control_msgs/srv/ResetWorld.srv
+++ b/mujoco_ros2_control_msgs/srv/ResetWorld.srv
@@ -1,4 +1,25 @@
+# Reset the simulation to the initial state captured at startup, or to a named MJCF keyframe,
+# optionally applying per-joint state overrides on top of the restored state.
+
+# Name of the MJCF keyframe to reset to. Empty resets to the initial state captured at startup.
 string keyframe
+
+# Optional overrides for single-DOF (hinge/slide) joints, applied on top of the reset state and
+# keyed by MuJoCo joint name. Follows sensor_msgs/JointState conventions: `position` and
+# `velocity` must each be empty or the same length as `name`; an empty array leaves that field
+# at its reset value. `effort` is not supported and must be empty. `header` is not used.
+sensor_msgs/JointState joint_state_overrides
+
+# Optional overrides for free joints, applied on top of the reset state and keyed by the name
+# of the body each free joint drives. See FreeJointState.msg for per-entry fields; any
+# `pose`/`twist` frame_id is resolved against body poses *after* the reset is applied, before
+# any overrides are written.
+FreeJointState[] free_joint_state_overrides
+
 ---
+
+# True if the reset was applied.
 bool success
+
+# Human-readable status / error description.
 string message


### PR DESCRIPTION
## Description

This PR extends the `~/reset_world` service to also apply joint (both single-dof hinge/slide and free joint) overrides.

This stacks on top of keyframes, you can effectively reset world to a known state and then apply extra changes like moving individual free objects or sliding joints like doors/drawers/etc.

A lot of the existing code used by #233 was reusable, so the bulk of the changes in this PR are shuffling things around to be maximally reusable in the world reset context. The diffs are at times a little tough to read because of this.

Tested on our internal NASA simulation and :+1: 

Fixes https://github.com/ros-controls/mujoco_ros2_control/issues/255

### Is this user-facing behavior change?

Yes, it adds a feature and changes a ROS service + message definition.

### Did you use Generative AI?

Yes, Claudio Fabula 5

... it went pretty extensive on the test coverage, so happy to trim down the tests which add a lot to this PR if desired. Basically half the PR is tests lol.