### PR TITLE
support merging multiple sets of state interfaces from multiple sensor tags

### DIFF
--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.16)
 
 project(mujoco_ros2_control)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(ros2_control_cmake REQUIRED)
 
 # find dependencies

--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(mujoco_ros2_control)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(ros2_control_cmake REQUIRED)
 
 # find dependencies

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -312,7 +312,7 @@ private:
 
   // Data containers for the HW interface
   std::unordered_map<std::string, hardware_interface::ComponentInfo> joint_hw_info_;
-  std::unordered_map<std::string, hardware_interface::ComponentInfo> sensors_hw_info_;
+  std::unordered_map<std::string, std::vector<hardware_interface::ComponentInfo>> sensors_hw_info_;
 
   // Container for interacting with the underlying physics sim's data.
   // Handed to plugins during `write` and used to stage control inputs.

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -64,6 +64,20 @@ constexpr char HW_IF_FORCE[] = "force";
 
 namespace mujoco_ros2_control
 {
+/// ros2_control `<sensor>` parameter key selecting which MuJoCo sensor mapping to build.
+constexpr char MUJOCO_TYPE_PARAM[] = "mujoco_type";
+/// Optional `<sensor>` parameter key overriding the MJCF sensor name; defaults to the sensor's own name.
+constexpr char MUJOCO_SENSOR_NAME_PARAM[] = "mujoco_sensor_name";
+
+/// Force/torque sensor: reads a paired MJCF `force` + `torque` sensor.
+constexpr char MUJOCO_TYPE_FTS[] = "fts";
+/// IMU: reads a paired MJCF `framequat` + `gyro` + `accelerometer` sensor.
+constexpr char MUJOCO_TYPE_IMU[] = "imu";
+/// Site pose: reads a paired MJCF `framepos` + `framequat` sensor.
+constexpr char MUJOCO_TYPE_POSE[] = "pose";
+/// Magnetometer: reads a single MJCF `magnetometer` sensor.
+constexpr char MUJOCO_TYPE_MAGNETOMETER[] = "magnetometer";
+
 class MujocoSystemInterface : public hardware_interface::SystemInterface
 {
 public:

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -526,7 +526,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for fts sensors
   for (auto& sensor : ft_sensor_data_)
   {
-    for (const hardware_interface::ComponentInfo& ci : sensors_hw_info_[sensor.name])
+    for (const auto& ci : sensors_hw_info_[sensor.name])
     {
       for (const auto& state_if : ci.state_interfaces)
       {
@@ -561,7 +561,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for IMU sensors
   for (auto& sensor : imu_sensor_data_)
   {
-    for (const hardware_interface::ComponentInfo& ci : sensors_hw_info_[sensor.name])
+    for (const auto& ci : sensors_hw_info_[sensor.name])
     {
       for (const auto& state_if : ci.state_interfaces)
       {
@@ -641,7 +641,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for pose sensors
   for (auto& sensor : pose_sensor_data_)
   {
-    for (const hardware_interface::ComponentInfo& ci : sensors_hw_info_[sensor.name])
+    for (const auto& ci : sensors_hw_info_[sensor.name])
     {
       for (const auto& state_if : ci.state_interfaces)
       {

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -526,9 +526,9 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for fts sensors
   for (auto& sensor : ft_sensor_data_)
   {
-    if (auto it = sensors_hw_info_.find(sensor.name); it != sensors_hw_info_.end())
+    for (const hardware_interface::ComponentInfo& ci : sensors_hw_info_[sensor.name])
     {
-      for (const auto& state_if : it->second.state_interfaces)
+      for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "force.x")
         {
@@ -561,9 +561,9 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for IMU sensors
   for (auto& sensor : imu_sensor_data_)
   {
-    if (auto it = sensors_hw_info_.find(sensor.name); it != sensors_hw_info_.end())
+    for (const hardware_interface::ComponentInfo& ci : sensors_hw_info_[sensor.name])
     {
-      for (const auto& state_if : it->second.state_interfaces)
+      for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "orientation.x")
         {
@@ -641,9 +641,9 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for pose sensors
   for (auto& sensor : pose_sensor_data_)
   {
-    if (auto it = sensors_hw_info_.find(sensor.name); it != sensors_hw_info_.end())
+    for (const hardware_interface::ComponentInfo& ci : sensors_hw_info_[sensor.name])
     {
-      for (const auto& state_if : it->second.state_interfaces)
+      for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "position.x")
         {
@@ -1871,7 +1871,7 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
                 sensor_name.c_str(), mujoco_type.c_str(), mujoco_sensor_name.c_str());
 
     // Add to the sensor hw information map
-    sensors_hw_info_.insert(std::make_pair(sensor_name, sensor));
+    sensors_hw_info_[sensor_name].push_back(sensor);
 
     if (mujoco_type == "fts")
     {

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -680,9 +680,9 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   // Add state interfaces for magnetometer sensors
   for (auto& sensor : magnetometer_sensor_data_)
   {
-    if (sensors_hw_info_.count(sensor.name) > 0)
+    for (const auto& ci : sensors_hw_info_[sensor.name])
     {
-      for (const auto& state_if : sensors_hw_info_.at(sensor.name).state_interfaces)
+      for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "magnetic_field.x")
         {

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -528,7 +528,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
-      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "fts")
+      if (ci.parameters.count(MUJOCO_TYPE_PARAM) > 0 && ci.parameters.at(MUJOCO_TYPE_PARAM) != MUJOCO_TYPE_FTS)
       {
         continue;
       }
@@ -567,7 +567,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
-      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "imu")
+      if (ci.parameters.count(MUJOCO_TYPE_PARAM) > 0 && ci.parameters.at(MUJOCO_TYPE_PARAM) != MUJOCO_TYPE_IMU)
       {
         continue;
       }
@@ -651,7 +651,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
-      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "pose")
+      if (ci.parameters.count(MUJOCO_TYPE_PARAM) > 0 && ci.parameters.at(MUJOCO_TYPE_PARAM) != MUJOCO_TYPE_POSE)
       {
         continue;
       }
@@ -694,7 +694,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
-      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "magnetometer")
+      if (ci.parameters.count(MUJOCO_TYPE_PARAM) > 0 && ci.parameters.at(MUJOCO_TYPE_PARAM) != MUJOCO_TYPE_MAGNETOMETER)
       {
         continue;
       }
@@ -1894,24 +1894,24 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
     auto sensor = hardware_info.sensors.at(sensor_index);
     const std::string sensor_name = sensor.name;
 
-    if (sensor.parameters.count("mujoco_type") == 0)
+    if (sensor.parameters.count(MUJOCO_TYPE_PARAM) == 0)
     {
       RCLCPP_INFO(get_logger(), "Not adding hardware interface for sensor in ros2_control xacro: '%s'",
                   sensor_name.c_str());
       continue;
     }
-    const auto mujoco_type = sensor.parameters.at("mujoco_type");
+    const auto mujoco_type = sensor.parameters.at(MUJOCO_TYPE_PARAM);
 
     // If there is a specific sensor name provided we use that, otherwise we assume the MuJoCo model's
     // sensor is named identically to the ros2_control hardware interface's.
     std::string mujoco_sensor_name;
-    if (sensor.parameters.count("mujoco_sensor_name") == 0)
+    if (sensor.parameters.count(MUJOCO_SENSOR_NAME_PARAM) == 0)
     {
       mujoco_sensor_name = sensor_name;
     }
     else
     {
-      mujoco_sensor_name = sensor.parameters.at("mujoco_sensor_name");
+      mujoco_sensor_name = sensor.parameters.at(MUJOCO_SENSOR_NAME_PARAM);
     }
 
     RCLCPP_INFO(get_logger(), "Adding sensor named: '%s', of type: '%s', mapping to the MJCF sensor: '%s'",
@@ -1920,7 +1920,7 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
     // Add to the sensor hw information map
     sensors_hw_info_[sensor_name].push_back(sensor);
 
-    if (mujoco_type == "fts")
+    if (mujoco_type == MUJOCO_TYPE_FTS)
     {
       FTSensorData sensor_data;
       sensor_data.name = sensor_name;
@@ -1944,7 +1944,7 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
 
       ft_sensor_data_.push_back(sensor_data);
     }
-    else if (mujoco_type == "imu")
+    else if (mujoco_type == MUJOCO_TYPE_IMU)
     {
       IMUSensorData sensor_data;
       sensor_data.name = sensor_name;
@@ -1985,7 +1985,7 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
 
       imu_sensor_data_.push_back(sensor_data);
     }
-    else if (mujoco_type == "pose")
+    else if (mujoco_type == MUJOCO_TYPE_POSE)
     {
       SitePoseData sensor_data;
       sensor_data.name = sensor_name;
@@ -2016,7 +2016,7 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
 
       pose_sensor_data_.push_back(sensor_data);
     }
-    else if (mujoco_type == "magnetometer")
+    else if (mujoco_type == MUJOCO_TYPE_MAGNETOMETER)
     {
       MagnetometerSensorData sensor_data;
       sensor_data.name = sensor_name;

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -528,6 +528,10 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
+      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "fts")
+      {
+        continue;
+      }
       for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "force.x")
@@ -563,6 +567,10 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
+      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "imu")
+      {
+        continue;
+      }
       for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "orientation.x")
@@ -643,6 +651,10 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
+      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "pose")
+      {
+        continue;
+      }
       for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "position.x")
@@ -682,6 +694,10 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
   {
     for (const auto& ci : sensors_hw_info_[sensor.name])
     {
+      if (ci.parameters.count("mujoco_type") > 0 && ci.parameters["mujoco_type"] != "magnetometer")
+      {
+        continue;
+      }
       for (const auto& state_if : ci.state_interfaces)
       {
         if (state_if.name == "magnetic_field.x")

--- a/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
@@ -160,7 +160,7 @@ TEST_F(MujocoSystemInterfaceTest, PoseSensorStateInterfacesRead)
   auto hardware_info = create_hardware_info();
   hardware_interface::ComponentInfo sensor_info;
   sensor_info.name = "pose_sensor";
-  sensor_info.parameters["mujoco_type"] = "pose";
+  sensor_info.parameters[mujoco_ros2_control::MUJOCO_TYPE_PARAM] = mujoco_ros2_control::MUJOCO_TYPE_POSE;
   for (const auto* interface_name :
        { "position.x", "position.y", "position.z", "orientation.x", "orientation.y", "orientation.z", "orientation.w" })
   {
@@ -224,7 +224,7 @@ TEST_F(MujocoSystemInterfaceTest, MagnetometerSensorStateInterfacesRead)
   auto hardware_info = create_hardware_info();
   hardware_interface::ComponentInfo sensor_info;
   sensor_info.name = "magnetometer_sensor";
-  sensor_info.parameters["mujoco_type"] = "magnetometer";
+  sensor_info.parameters[mujoco_ros2_control::MUJOCO_TYPE_PARAM] = mujoco_ros2_control::MUJOCO_TYPE_MAGNETOMETER;
   for (const auto* interface_name : { "magnetic_field.x", "magnetic_field.y", "magnetic_field.z" })
   {
     hardware_interface::InterfaceInfo interface_info;


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

At the moment, the `MujocoSystemInterface` does not support multiple `sensor` tags with the same name.

For example, the `sensor`:
```XML
    <sensor name="base_imu">
      <param name="mujoco_type">imu</param>
      <param name="mujoco_sensor_name">body</param>

      <state_interface name="orientation.x" />
      <state_interface name="orientation.y" />
      <state_interface name="orientation.z" />
      <state_interface name="orientation.w" />
      <state_interface name="angular_velocity.x" />
      <state_interface name="angular_velocity.y" />
      <state_interface name="angular_velocity.z" />
      <state_interface name="linear_acceleration.x" />
      <state_interface name="linear_acceleration.y" />
      <state_interface name="linear_acceleration.z" />
    </sensor>
```
will create interfaces in the `base_imu` namespace, e.g. `base_imu/angular_velocity.x`.

It is not possible to add a second set of state interfaces to the same namespace, and something like:
```XML
    <sensor name="base_imu">
      <param name="mujoco_type">magnetometer</param>
      <param name="mujoco_sensor_name">body_magnetometer</param>

      <state_interface name="magnetic_field.x"/>
      <state_interface name="magnetic_field.y"/>
      <state_interface name="magnetic_field.z"/>
    </sensor>
```
will be ignored.

This PR enables mapping multiple sensors to the same namespace, such that modular sensors can place state interfaces into the same namespace, in the same way this can be done with multiple `<ros2_control type="sensor">` for a modular real hardware system.

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes. It allows adding multiple sets of state interfaces to the same namespace.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [ ] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
