### PR TITLE
[Fix] Don't overwrite transmission-driven joint states in the direct-copy fallback

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include <hardware_interface/version.h>
@@ -331,6 +332,9 @@ private:
   // Transmission instances
   std::unique_ptr<pluginlib::ClassLoader<transmission_interface::TransmissionLoader>> transmission_loader_ = nullptr;
   std::vector<std::shared_ptr<transmission_interface::Transmission>> transmission_instances_;
+  // Names of the URDF joints whose state/command is produced by a transmission. Those joints must never be
+  // overwritten by the name-matching direct-copy fallback, even if a MuJoCo joint happens to share their name.
+  std::unordered_set<std::string> transmission_joint_names_;
 
   // Plugin loader and instances
   std::unique_ptr<pluginlib::ClassLoader<mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase>> plugin_loader_ =

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -22,7 +22,6 @@
 #include <memory>
 #include <string>
 #include <thread>
-#include <unordered_set>
 #include <vector>
 
 #include <hardware_interface/version.h>
@@ -332,9 +331,6 @@ private:
   // Transmission instances
   std::unique_ptr<pluginlib::ClassLoader<transmission_interface::TransmissionLoader>> transmission_loader_ = nullptr;
   std::vector<std::shared_ptr<transmission_interface::Transmission>> transmission_instances_;
-  // Names of the URDF joints whose state/command is produced by a transmission. Those joints must never be
-  // overwritten by the name-matching direct-copy fallback, even if a MuJoCo joint happens to share their name.
-  std::unordered_set<std::string> transmission_joint_names_;
 
   // Plugin loader and instances
   std::unique_ptr<pluginlib::ClassLoader<mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase>> plugin_loader_ =

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1077,6 +1077,21 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
 
 void MujocoSystemInterface::actuator_state_to_joint_state()
 {
+  
+  // Copy state for every joint that does not have a transmission
+  for (auto& joint : urdf_joint_data_)
+  {
+    std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(), [&](auto& actuator_interface) {
+      if (actuator_interface.joint_name == joint.name)
+      {
+        joint.position_interface.transmission_passthrough_ = actuator_interface.position_interface.state_;
+        joint.velocity_interface.transmission_passthrough_ = actuator_interface.velocity_interface.state_;
+        joint.effort_interface.transmission_passthrough_ = actuator_interface.effort_interface.state_;
+      }
+    });
+  }
+
+  // Use transmission to get joint state from actuator
   // actuator: MuJoCo -> transmission
   std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(),
                 [](auto& actuator_interface) { actuator_interface.copy_state_to_transmission(); });
@@ -1088,20 +1103,6 @@ void MujocoSystemInterface::actuator_state_to_joint_state()
   // joint: transmission -> state
   std::for_each(urdf_joint_data_.begin(), urdf_joint_data_.end(),
                 [](auto& joint_interface) { joint_interface.copy_state_from_transmission(); });
-
-  // If the actuator name and joint name is same (which is the case for non transmission joints), we need to copy
-  // the state from actuator to joint here as there is no transmission instance to do that.
-  for (auto& joint : urdf_joint_data_)
-  {
-    std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(), [&](auto& actuator_interface) {
-      if (actuator_interface.joint_name == joint.name)
-      {
-        joint.position_interface.state_ = actuator_interface.position_interface.state_;
-        joint.velocity_interface.state_ = actuator_interface.velocity_interface.state_;
-        joint.effort_interface.state_ = actuator_interface.effort_interface.state_;
-      }
-    });
-  }
 }
 
 void MujocoSystemInterface::joint_command_to_actuator_command()

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1077,7 +1077,6 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
 
 void MujocoSystemInterface::actuator_state_to_joint_state()
 {
-  
   // Copy state for every joint that does not have a transmission
   for (auto& joint : urdf_joint_data_)
   {

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1060,8 +1060,15 @@ void MujocoSystemInterface::actuator_state_to_joint_state()
 
   // If the actuator name and joint name is same (which is the case for non transmission joints), we need to copy
   // the state from actuator to joint here as there is no transmission instance to do that.
+  // Joints that are driven by a transmission are skipped: their state was just produced by actuator_to_joint() and
+  // must not be clobbered by a same-named MuJoCo joint (which is registered as a PASSIVE actuator when it has no
+  // MuJoCo actuator of its own, and whose raw qpos is in the MuJoCo convention, not the transmission's).
   for (auto& joint : urdf_joint_data_)
   {
+    if (transmission_joint_names_.count(joint.name) != 0)
+    {
+      continue;
+    }
     std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(), [&](auto& actuator_interface) {
       if (actuator_interface.joint_name == joint.name)
       {
@@ -1091,6 +1098,10 @@ void MujocoSystemInterface::joint_command_to_actuator_command()
   // the command from joint to actuator here as there is no transmission instance to do that.
   for (auto& joint : urdf_joint_data_)
   {
+    if (transmission_joint_names_.count(joint.name) != 0)
+    {
+      continue;
+    }
     std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(), [&](auto& actuator_interface) {
       if (actuator_interface.joint_name == joint.name && actuator_interface.actuator_type != ActuatorType::PASSIVE)
       {
@@ -1619,6 +1630,7 @@ void MujocoSystemInterface::register_urdf_joints(const hardware_interface::Hardw
 bool MujocoSystemInterface::register_transmissions(const hardware_interface::HardwareInfo& hardware_info)
 {
   transmission_instances_.clear();
+  transmission_joint_names_.clear();
   auto hardware_transmissions = hardware_info.transmissions;
   transmission_loader_ = std::make_unique<pluginlib::ClassLoader<transmission_interface::TransmissionLoader>>(
       "transmission_interface", "transmission_interface::TransmissionLoader");
@@ -1795,6 +1807,10 @@ bool MujocoSystemInterface::register_transmissions(const hardware_interface::Har
     }
 
     transmission_instances_.push_back(transmission);
+    for (const auto& joint_info : t_info.joints)
+    {
+      transmission_joint_names_.insert(joint_info.name);
+    }
   }
   RCLCPP_INFO_EXPRESSION(get_logger(), !transmission_instances_.empty(), "Registered %zu transmissions",
                          transmission_instances_.size());

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1091,15 +1091,8 @@ void MujocoSystemInterface::actuator_state_to_joint_state()
 
   // If the actuator name and joint name is same (which is the case for non transmission joints), we need to copy
   // the state from actuator to joint here as there is no transmission instance to do that.
-  // Joints that are driven by a transmission are skipped: their state was just produced by actuator_to_joint() and
-  // must not be clobbered by a same-named MuJoCo joint (which is registered as a PASSIVE actuator when it has no
-  // MuJoCo actuator of its own, and whose raw qpos is in the MuJoCo convention, not the transmission's).
   for (auto& joint : urdf_joint_data_)
   {
-    if (transmission_joint_names_.count(joint.name) != 0)
-    {
-      continue;
-    }
     std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(), [&](auto& actuator_interface) {
       if (actuator_interface.joint_name == joint.name)
       {
@@ -1657,7 +1650,6 @@ void MujocoSystemInterface::register_urdf_joints(const hardware_interface::Hardw
 bool MujocoSystemInterface::register_transmissions(const hardware_interface::HardwareInfo& hardware_info)
 {
   transmission_instances_.clear();
-  transmission_joint_names_.clear();
   auto hardware_transmissions = hardware_info.transmissions;
   transmission_loader_ = std::make_unique<pluginlib::ClassLoader<transmission_interface::TransmissionLoader>>(
       "transmission_interface", "transmission_interface::TransmissionLoader");
@@ -1834,10 +1826,6 @@ bool MujocoSystemInterface::register_transmissions(const hardware_interface::Har
     }
 
     transmission_instances_.push_back(transmission);
-    for (const auto& joint_info : t_info.joints)
-    {
-      transmission_joint_names_.insert(joint_info.name);
-    }
   }
   RCLCPP_INFO_EXPRESSION(get_logger(), !transmission_instances_.empty(), "Registered %zu transmissions",
                          transmission_instances_.size());

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -1098,10 +1098,6 @@ void MujocoSystemInterface::joint_command_to_actuator_command()
   // the command from joint to actuator here as there is no transmission instance to do that.
   for (auto& joint : urdf_joint_data_)
   {
-    if (transmission_joint_names_.count(joint.name) != 0)
-    {
-      continue;
-    }
     std::for_each(mujoco_actuator_data_.begin(), mujoco_actuator_data_.end(), [&](auto& actuator_interface) {
       if (actuator_interface.joint_name == joint.name && actuator_interface.actuator_type != ActuatorType::PASSIVE)
       {


### PR DESCRIPTION
## Description

The direct-copy fallback at the end of `actuator_state_to_joint_state()` copies actuator state into
joint state whenever the names match. It exists for joints that are *not* part of a transmission —
the comment above it says exactly that — but it only checks the name, and it runs *after* the
transmissions have written their output. So a `<ros2_control>` joint that happens to share a name
with a MuJoCo joint silently loses its transmission result.

This is easy to hit, because `register_mujoco_actuators()` registers every unactuated,
non-free, non-ball MuJoCo joint as a `PASSIVE` actuator whose `joint_name` is the joint's own name.
Any such joint that is also driven by a transmission gets clobbered.

The command direction does not have the bug — `joint_command_to_actuator_command()` already guards
with `actuator_type != ActuatorType::PASSIVE`. Only the state is affected, which is what makes it
easy to miss: the actuators are commanded correctly and only the reported state lies.

**Fix:** `register_transmissions()` records which joints belong to a transmission, and both
direct-copy fallbacks skip those joints.

Adding a `!= PASSIVE` check to the state loop, mirroring the command loop, would have been the
smaller diff but the wrong fix: passive joints legitimately depend on that copy to get any state at
all, so mimic and closed-loop state-only joints would have been left at NaN.

Cost is one hash lookup per joint per `read()`/`write()`.

**How we ran into it:** on a biped with parallel telescopic legs, the ankle pitch/roll joints are
driven by a custom transmission that re-references the ankle angles to the leg-length direction, and
they *also* exist in the MJCF as real unactuated revolute joints (the ankle is a closed-loop
mechanism, so those DoFs have to be in the model). They were the only joints in the robot where both
were true. The published ankle state was therefore the raw MuJoCo angle measured against the tibia
rather than the transmission's output: commanding an 8 cm leg-length motion while holding the ankle
still swung the reported pitch by 0.14 rad, and `/joint_states` matched the raw `qpos` to five
decimals at every sample. With the patch the same motion moves the reported pitch by 0.003 rad while
the raw MuJoCo joint moves 0.16 rad — the two are now correctly different quantities.

No separate issue was opened; happy to file one if you'd prefer the discussion to start there.

### Is this user-facing behavior change?

Yes, but only for models that currently hit the bug. If a transmission-driven `<ros2_control>` joint
shares its name with a MuJoCo joint, its published state changes from the raw MuJoCo `qpos` to the
transmission's output — which is the documented intent of configuring a transmission. Any model
without such a name collision is bit-for-bit unaffected.

### Did you use Generative AI?

Yes. Claude Opus 5, via Claude Code, was used for the whole change: locating the root cause, the
20-line patch, the commit message and this PR description. I reviewed the diff and the reasoning, and
I ran the verification described below on my own robot before submitting. The commit carries a
`Co-Authored-By` trailer for the model.

### Additional Information

**Verification.** Reproduced and A/B tested on a full-model MuJoCo sim of a biped (~90 passive
actuators, 4 custom transmission types, 24 `<equality><connect>` constraints) at
`controller_manager.update_rate=2000`: the same commanded leg-length trajectory was run with and
without the patch, comparing `/joint_states` against the raw actuator values on
`/mujoco_actuators_states`. Numbers above.

**No test added, and I'd like guidance on this.** Nothing in `mujoco_ros2_control_tests` currently
exercises the collision, because no test model has a transmission-driven joint sharing a name with a
MuJoCo joint — which is exactly why the bug survived. A regression test would mean adding an
unactuated joint named `joint1` to the transmissions test MJCF and asserting that
`/joint_states` reports the transmission's value (`joint1 = actuator1 / 2.0`) rather than that raw
joint's `qpos`. Happy to add that to this PR if you want it here rather than as a follow-up — say
which and I'll push it.

**Distros.** The change uses no version-gated API (a `std::unordered_set` member and a lookup), so it
should apply to `humble-devel` unchanged, but I have not built or tested it there.

## TODOs

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. (2 files, +20/-0, no reformatting)
- [x] `pre-commit`-relevant checks pass locally: `clang-format` v19.1.1 with the repo `.clang-format`
      reports no changes on both touched files; no trailing whitespace; `codespell` clean.
      I did not run the full `colcon test` suite against `main` — see the note on tests above.
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in
      the conversation.
