### PR TITLE
Simplify mujoco_ros2_control_plugins integration

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -297,6 +297,16 @@ public:
   void register_plugins(std::vector<std::shared_ptr<mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase>> plugins);
 
   /**
+   * @brief Stops driving the registered plugins.
+   *
+   * Once this returns, no plugin `update()` is in flight and none will be started, so the owner can
+   * safely tear the plugins down. Plugins cache the live model and data pointers, so the required
+   * teardown order is: `detach_plugins()`, then each plugin's `cleanup()`, then destroying this
+   * simulation. Idempotent.
+   */
+  void detach_plugins();
+
+  /**
    * @brief Accessor for the mutex which locks access to the data and model.
    */
   std::recursive_mutex& mutex() const
@@ -325,10 +335,25 @@ private:
    */
   void apply_staged_control_inputs();
 
+  /// One commandable field: where plugins write it, where it lands, and how many entries it has.
+  struct CommandableField
+  {
+    mjtNum* commanded;
+    mjtNum* live;
+    int count;
+  };
+
+  /**
+   * @brief The fields plugins may command, as the single list used to both unset and merge them.
+   *
+   * @note Assumes the sim mutex is held and `control_data_` is allocated.
+   */
+  std::vector<CommandableField> commandable_fields();
+
   /**
    * @brief Runs every registered plugin's `update()` and merges what they commanded.
    *
-   * Fills the commandable fields of `control_data_` with NaN, calls each plugin in registration
+   * Presents the commandable fields of `control_data_` as unset, calls each plugin in registration
    * order, then copies back only the entries the plugins actually wrote. Plugins read live state
    * directly, so no scene-sized copy is involved.
    *
@@ -471,9 +496,10 @@ private:
   // directly unless you are sure of what you are doing.
   mjData* mj_data_{ nullptr };
 
-  // Write-only command buffer handed to plugins in run_plugin_updates(). Its commandable fields
-  // are NaN-filled before every plugin pass, and only the non-NaN entries are merged back into
+  // Write-only command buffer handed to plugins in run_plugin_updates(). Its commandable fields are
+  // marked unset before every plugin pass, and only the commanded entries are merged back into
   // mj_data_. Nothing else in this container is meaningful.
+  // Allocated lazily by register_plugins(), so a run without plugins does not pay for a full mjData.
   mjData* control_data_{ nullptr };
 
   // MuJoCo plugins driven by the physics loop. Borrowed; owned by the hardware interface.

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -76,22 +76,20 @@ namespace mujoco_ros2_control
  * loop can hold the sim mutex for a large fraction of a display refresh while it batches
  * steps, this can block the caller and should not be used from latency-sensitive threads.
  *
- * `acquire_data_snapshot()` instead borrows the most recent completed post-step snapshot of
- * `mj_data_`, produced by the physics loop into a separate buffer. Acquiring is a pointer
- * swap under a mutex that is never held for longer than a swap, so the caller performs no
- * scene-sized copy and never waits on physics stepping or refresh. The returned data may
- * lag `mj_data_` by a few timesteps. This is what the hardware interface uses in `write()`.
+ * `copy_control_state(...)` copies the small per-step `ControlState` (positions, velocities,
+ * sensor data, ...) that the hardware interface needs every cycle. It is far cheaper than a
+ * full mjData copy regardless of scene complexity, and is what the hardware interface uses in
+ * `read()`.
  *
- * `apply_control_data(...)` will copy control inputs from the provided mjData into staging
- * buffers that the physics loop applies to `mj_data_` immediately before each step.
- * Specifically, it stages `ctrl`, `qfrc_applied`, and `xfrc_applied`. Cartesian forces from
- * `xfrc_applied` compete with inputs from Simulate's drag function, so they are resolved
- * separately. This only takes the control staging mutex and never blocks on physics stepping.
- * It also stages `qvel`: the system interface NaN-fills `qvel` before every plugin's
- * `update()` runs, so any DOF a plugin leaves untouched is NaN here and any DOF it writes a
- * finite value into is a requested hard velocity override (see
- * `MuJoCoROS2ControlPluginBase::update()`'s doc comment). Non-NaN entries are applied as a
- * direct `qvel` write, bypassing the normal dynamics for that DOF.
+ * `stage_actuator_commands(...)` copies actuator commands into a staging buffer that the physics
+ * loop merges into `mj_data_->ctrl` immediately before each step. Entries that are NaN mean
+ * "leave unchanged", so the caller only has to fill the actuators it actually commands. This
+ * only takes the control staging mutex and never blocks on physics stepping.
+ *
+ * `register_plugins(...)` hands over the MuJoCo plugins to be driven by the physics loop. Each
+ * plugin is updated once per loop iteration, with the sim mutex held, immediately before the
+ * step batch: it reads live state directly and writes commands into a NaN-filled `control_data`
+ * buffer, of which only the non-NaN entries are merged into `mj_data_`.
  *
  * `overwrite_physics_data(...)` will completely replace the data for the sim. Should be used
  * with extreme caution.
@@ -177,7 +175,8 @@ public:
    *
    * Users should generally not interact with the physics sim data excepting during setup and
    * other special circumstances. For "normal" processing it is recommended to use
-   * `control_data` or other containers populated by `copy_mj_data`.
+   * `copy_control_state` (reads) and `stage_actuator_commands` (writes), both of which are safe
+   * to call from a control loop.
    */
   mjData* data()
   {
@@ -223,29 +222,10 @@ public:
    * @brief Copies `mj_data_` into the provided container in a thread safe way.
    *
    * This locks the sim mutex and will pause the physics loop, so should be used sparingly.
-   * Latency-sensitive callers should use `acquire_data_snapshot` or `copy_control_state` instead.
+   * Latency-sensitive callers should use `copy_control_state` instead.
    * @note: If the destination is null it will be created.
    */
   void copy_physics_data(mjData*& destination);
-
-  /**
-   * @brief Borrows the latest completed post-step snapshot of `mj_data_` (producer-pays copying).
-   *
-   * The physics loop fills snapshot buffers on its own thread; this call only swaps pointers
-   * to take ownership of the most recent completed one, so the caller never performs a scene-sized
-   * copy and never waits for a stepping batch,or in-process refresh. If no new snapshot has
-   * completed since the last call, the same buffer is returned again.
-   * Also requests a fresh snapshot for the next call.
-   *
-   * Ownership contract: there is a single borrower slot. The returned buffer remains valid and
-   * is never touched by the physics loop until the next `acquire_data_snapshot()` call, at
-   * which point the previous buffer is recycled back to the producer. The borrower may freely
-   * write to the buffer (e.g., plugins composing control inputs); all such writes are discarded
-   * when the buffer is recycled and refilled. Only one consumer may use this API — concurrent
-   * callers would swap each other's buffer out from underneath them.
-   * Cold-path consumers that need their own copy should use `copy_physics_data` instead.
-   */
-  mjData* acquire_data_snapshot();
 
   /**
    * @brief Small snapshot of the state the hardware interface needs every control cycle.
@@ -276,18 +256,45 @@ public:
   void copy_control_state(ControlState& destination);
 
   /**
-   * @brief Stages control fields from `control_data` for the physics loop in a thread safe way.
+   * @brief Republishes the per-step control state from the current `mj_data_`.
    *
-   * Specifically, copies `control_data->ctrl` and `control_data->qfrc_applied` into staging
-   * buffers which the physics loop copies into `mj_data_` immediately before each step.
-   * `control_data->xfrc_applied` is copied into `xfrc_plugin_desired_` to avoid conflicts
-   * from the simulate app. `control_data->qvel` is copied into `qvel_override_staged_`;
-   * entries that are not NaN are plugin-requested velocity overrides (see
-   * `MuJoCoROS2ControlPluginBase::update()`'s doc comment for the NaN convention this
-   * relies on) and are applied as direct `qvel` writes before the next `mj_step`. This does
-   * not lock the sim mutex and never waits on stepping.
+   * The physics loop does this after every step, so this is only needed when a caller has
+   * manipulated `mj_data_` directly (e.g. applying initial positions during setup) and wants the
+   * next `copy_control_state` to reflect it without waiting for a step to happen.
+   *
+   * Takes the sim mutex, so it should not be called from a latency-sensitive thread.
    */
-  void apply_control_data(mjData* control_data);
+  void refresh_control_state();
+
+  /**
+   * @brief Stages actuator commands for the physics loop in a thread safe way.
+   *
+   * The physics loop merges these into `mj_data_->ctrl` immediately before each step. Entries
+   * that are NaN are skipped, meaning "leave this actuator unchanged" -- so a caller only fills
+   * the actuators it commands, and passive or uncommanded actuators keep whatever the simulation
+   * (or a plugin, or a reset) last set. This does not lock the sim mutex and never waits on
+   * stepping.
+   *
+   * @param ctrl_commands Per-actuator commands, sized `model()->nu`. Shorter or longer vectors
+   * are rejected with a warning rather than staged partially.
+   */
+  void stage_actuator_commands(const std::vector<mjtNum>& ctrl_commands);
+
+  /**
+   * @brief Hands the MuJoCo plugins to the physics loop, which drives their `update()`.
+   *
+   * Each registered plugin is updated once per physics-loop iteration, with the sim mutex held,
+   * immediately before the step batch. Plugins read live state through
+   * `MuJoCoROS2ControlPluginBase::get_sim_data()` and write commands into a NaN-filled
+   * `control_data` buffer; only the non-NaN entries are merged into `mj_data_`.
+   *
+   * Ownership stays with the caller; this class only borrows the shared pointers. Replaces any
+   * previously registered plugins.
+   *
+   * @note Takes the sim mutex, since plugins may be registered after the physics loop has
+   * already started.
+   */
+  void register_plugins(std::vector<std::shared_ptr<mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase>> plugins);
 
   /**
    * @brief Accessor for the mutex which locks access to the data and model.
@@ -310,11 +317,27 @@ public:
 
 private:
   /**
-   * @brief Helper function to compose hw interface and simulation provided Cartesian forces.
+   * @brief Merges the actuator commands staged by `stage_actuator_commands` into `mj_data_->ctrl`.
    *
-   * This should be called before stepping the simulation. Assumes the sim mutex is held.
+   * NaN entries are skipped, so uncommanded actuators keep their current value. This should be
+   * called before stepping the simulation. Assumes the sim mutex is held; takes the control
+   * staging mutex.
    */
   void apply_staged_control_inputs();
+
+  /**
+   * @brief Runs every registered plugin's `update()` and merges what they commanded.
+   *
+   * Fills the commandable fields of `control_data_` with NaN, calls each plugin in registration
+   * order, then copies back only the entries the plugins actually wrote. Plugins read live state
+   * directly, so no scene-sized copy is involved.
+   *
+   * Called once per physics-loop iteration -- not once per `mj_step` -- so that plugins keep
+   * running at roughly the outer loop rate even when a single iteration batches many steps.
+   *
+   * @note Assumes the sim mutex is held. Plugin code therefore runs under that mutex.
+   */
+  void run_plugin_updates();
 
   /**
    * @brief Publishes the per-step control state from `mj_data_`.
@@ -323,15 +346,6 @@ private:
    * Assumes the sim mutex is held; takes the control state mutex.
    */
   void publish_control_state();
-
-  /**
-   * @brief Refreshes the consumer-facing snapshot from `mj_data_`.
-   *
-   * Reclaims the producer-side buffer (clearing snapshot_ready_ if a previous fill was never
-   * consumed), fills it outside any shared lock (the sim mutex serializes writers), then
-   * raises snapshot_ready_ for the consumer. Assumes the sim mutex is held.
-   */
-  void refresh_data_snapshot();
 
   /**
    * @brief Loops the physics simulation until asked to terminate.
@@ -397,7 +411,7 @@ private:
    * @brief Writes free-joint states into `mj_data_->qpos`/`qvel`, resolving each entry's `pose`
    * and `twist` against their own `header.frame_id` -- they may reference different bodies, or
    * vary between world vs. relative frame to another body.
-   * Does not refresh snapshots or run forward dynamics; the caller is responsible for both.
+   * Does not republish the control state or run forward dynamics; the caller is responsible for both.
    *
    * @note Caller must hold the sim mutex and have validated `free_joints` first.
    */
@@ -417,7 +431,7 @@ private:
 
   /**
    * @brief Writes single-DOF joint states into `mj_data_->qpos`/`qvel`.
-   * Does not refresh snapshots or run forward dynamics; the caller is responsible for both.
+   * Does not republish the control state or run forward dynamics; the caller is responsible for both.
    *
    * @note Caller must hold the sim mutex and have validated `joint_state` first.
    */
@@ -457,55 +471,28 @@ private:
   // directly unless you are sure of what you are doing.
   mjData* mj_data_{ nullptr };
 
-  // Double-buffered snapshot of mj_data_: the physics loop pays for all scene-sized copies,
-  // the consumer borrows the result via acquire_data_snapshot() and performs no copy at all.
-  // The producer (any writer holding the sim mutex) fills snapshot_write_ outside any shared
-  // lock and raises snapshot_ready_; the consumer, when the flag is up, swaps the two pointers
-  // under data_exchange_mutex_ and reads snapshot_read_ in place.
-  mjData* snapshot_write_{ nullptr };
-  mjData* snapshot_read_{ nullptr };
-  bool snapshot_ready_{ false };
+  // Write-only command buffer handed to plugins in run_plugin_updates(). Its commandable fields
+  // are NaN-filled before every plugin pass, and only the non-NaN entries are merged back into
+  // mj_data_. Nothing else in this container is meaningful.
+  mjData* control_data_{ nullptr };
 
-  // Control inputs staged by apply_control_data, applied to mj_data_ before each step.
+  // MuJoCo plugins driven by the physics loop. Borrowed; owned by the hardware interface.
+  std::vector<std::shared_ptr<mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase>> plugins_;
+
+  // Actuator commands staged by stage_actuator_commands, merged into mj_data_->ctrl before each
+  // step. NaN entries mean "leave unchanged", which is what keeps initial / reset / plugin-set
+  // ctrl values from being clobbered by actuators the hardware interface does not command.
   std::vector<mjtNum> ctrl_staged_;
-  std::vector<mjtNum> qfrc_applied_staged_;
 
-  // False until apply_control_data is first called (and cleared on reset), so that initial /
-  // reset ctrl values in mj_data_ are not clobbered by stale staging buffers.
-  bool control_inputs_staged_{ false };
-
-  // Buffers to track actively applied Cartesian forces from both the plugins and the Simulate /
-  // viewer-only drag forces.
-  std::vector<mjtNum> xfrc_plugin_desired_;  // Tracks forces from plugins
-  std::vector<mjtNum> xfrc_viewer_capture_;  // Tracks forces from the viewer
-  std::vector<mjtNum> xfrc_last_written_;    // tracks the last value written to xfrc_applied
-
-  // qvel as staged by apply_control_data: sized nv, NaN by default. A plugin requests a
-  // velocity override on a DOF by writing a finite value into control_data->qvel during its
-  // update()
-  std::vector<mjtNum> qvel_override_staged_;
-
-  // Guards only the snapshot pointer swap and snapshot_ready_ flag.
-  // Lock order: sim_mutex_ (if needed) is always taken before this one.
-  std::mutex data_exchange_mutex_;
-
-  // Set by acquire_data_snapshot when a consumer takes the snapshot; the physics loop only
-  // runs the expensive full refresh when this is set, so refresh bandwidth tracks consumer
-  // demand instead of the batch rate. Starts true so the first refresh happens.
-  std::atomic<bool> snapshot_refresh_requested_{ true };
-
-  // Guards the staged control inputs (ctrl_staged_, qfrc_applied_staged_, xfrc_plugin_desired_,
-  // control_inputs_staged_, qvel_override_staged_). Separate from data_exchange_mutex_ so
-  // that staging commands in write() and applying them before each physics step never queue
-  // behind a full mjData copy.
-  // Critical sections are all small buffer copies.
-  // Lock order: sim_mutex_ (if needed) before this one; never held with data_exchange_mutex_.
+  // Guards the staged actuator commands (ctrl_staged_). Separate from the sim mutex so that
+  // staging commands in write() and merging them before each physics step never queue behind
+  // physics stepping. Critical sections are all small buffer copies.
+  // Lock order: sim_mutex_ (if needed) before this one.
   std::mutex control_staging_mutex_;
 
-  // Per-step control state served by copy_control_state. Guarded by its own mutex, separate
-  // from data_exchange_mutex_, so the reduced control-state copies never queue behind a full
-  // mjData snapshot copy.
-  // Lock order: sim_mutex_ (if needed) before this one; never held with data_exchange_mutex_.
+  // Per-step control state served by copy_control_state. Guarded by its own mutex so the reduced
+  // control-state copies never queue behind physics stepping.
+  // Lock order: sim_mutex_ (if needed) before this one.
   ControlState control_state_;
   std::mutex control_state_mutex_;
 

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -328,10 +328,10 @@ private:
   std::unordered_map<std::string, hardware_interface::ComponentInfo> joint_hw_info_;
   std::unordered_map<std::string, std::vector<hardware_interface::ComponentInfo>> sensors_hw_info_;
 
-  // Container for interacting with the underlying physics sim's data.
-  // Handed to plugins during `write` and used to stage control inputs.
-  // Its full-data refresh is skipped when no plugins are loaded.
-  mjData* mj_data_control_{ nullptr };
+  // Per-actuator commands composed in `write` and handed to the simulation for staging.
+  // Sized `nu`; entries left NaN mean "not commanded", so passive and uncommanded actuators keep
+  // whatever the simulation last had.
+  std::vector<mjtNum> actuator_commands_;
 
   // Per-step robot state snapshot used by `read` and `write`.
   MujocoSimulation::ControlState control_state_;

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -706,18 +706,17 @@ bool MujocoSimulation::initialize(rclcpp::Node::SharedPtr node, const std::strin
   {
     std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
     mj_data_ = mj_makeData(mj_model_);
-    control_data_ = mj_makeData(mj_model_);
 
-    // Nothing is commanded yet: NaN means "leave unchanged", so the simulation keeps whatever
+    // Nothing is commanded yet, and unset means "leave unchanged", so the simulation keeps whatever
     // initial ctrl the model / keyframe provided until a caller stages real commands.
-    ctrl_staged_.assign(mj_model_->nu, std::numeric_limits<mjtNum>::quiet_NaN());
+    ctrl_staged_.assign(mj_model_->nu, mujoco_ros2_control_plugins::kUnsetCommand);
 
     if (mj_data_)
     {
       publish_control_state();
     }
   }
-  if (!mj_data_ || !control_data_)
+  if (!mj_data_)
   {
     RCLCPP_FATAL(get_logger(), "Could not allocate mjData for '%s'", model_path_.c_str());
     return false;
@@ -852,10 +851,10 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
 
   {
     // Discard staged actuator commands so stale pre-reset commands are not re-applied on the next
-    // step. NaN means "leave unchanged", so the reset ctrl values above survive until the
+    // step. Unset means "leave unchanged", so the reset ctrl values above survive until the
     // hardware interface stages fresh commands.
     const std::lock_guard<std::mutex> staging_lock(control_staging_mutex_);
-    std::fill(ctrl_staged_.begin(), ctrl_staged_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
+    std::fill(ctrl_staged_.begin(), ctrl_staged_.end(), mujoco_ros2_control_plugins::kUnsetCommand);
   }
 
   // Restore simulation time to preserve ROS clock continuity
@@ -1314,8 +1313,51 @@ void MujocoSimulation::register_plugins(
   // Plugins are typically registered after the physics thread is already running, so the loop
   // could otherwise be iterating plugins_ while we assign to it.
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
-  plugins_ = std::move(plugins);
+
+  // Drop nulls here so the physics loop can iterate unconditionally.
+  plugins_.clear();
+  for (auto& plugin : plugins)
+  {
+    if (plugin)
+    {
+      plugins_.push_back(std::move(plugin));
+    }
+  }
+
+  // A full mjData is a large allocation (it carries contact, Jacobian and constraint arenas), so
+  // only pay for the command buffer once something is actually going to command the simulation.
+  if (!plugins_.empty() && control_data_ == nullptr)
+  {
+    control_data_ = mj_makeData(mj_model_);
+    if (control_data_ == nullptr)
+    {
+      RCLCPP_FATAL(get_logger(), "Could not allocate the plugin command buffer; plugins will not be updated.");
+      plugins_.clear();
+      return;
+    }
+  }
+
   RCLCPP_INFO(get_logger(), "Registered %zu MuJoCo plugin(s) with the physics loop.", plugins_.size());
+}
+
+void MujocoSimulation::detach_plugins()
+{
+  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+  plugins_.clear();
+}
+
+std::vector<MujocoSimulation::CommandableField> MujocoSimulation::commandable_fields()
+{
+  // One list, used both to present the fields as unset and to merge them back. Keeping it single
+  // is what stops a field from being filled but never merged (plugin writes silently dropped) or
+  // merged but never filled (unset entries leaking into the simulation).
+  return {
+    { control_data_->ctrl, mj_data_->ctrl, static_cast<int>(mj_model_->nu) },
+    { control_data_->qfrc_applied, mj_data_->qfrc_applied, static_cast<int>(mj_model_->nv) },
+    { control_data_->xfrc_applied, mj_data_->xfrc_applied, 6 * static_cast<int>(mj_model_->nbody) },
+    { control_data_->qpos, mj_data_->qpos, static_cast<int>(mj_model_->nq) },
+    { control_data_->qvel, mj_data_->qvel, static_cast<int>(mj_model_->nv) },
+  };
 }
 
 void MujocoSimulation::run_plugin_updates()
@@ -1327,43 +1369,27 @@ void MujocoSimulation::run_plugin_updates()
     return;
   }
 
-  const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
-  constexpr mjtNum kUnset = std::numeric_limits<mjtNum>::quiet_NaN();
+  const auto fields = commandable_fields();
 
-  // Present every commandable field as "unset", so a plugin only has to write what it commands
-  // and nothing leaks across iterations.
-  mju_fill(control_data_->ctrl, kUnset, mj_model_->nu);
-  mju_fill(control_data_->qfrc_applied, kUnset, mj_model_->nv);
-  mju_fill(control_data_->xfrc_applied, kUnset, nbody6);
-  mju_fill(control_data_->qpos, kUnset, mj_model_->nq);
-  mju_fill(control_data_->qvel, kUnset, mj_model_->nv);
+  // Present every commandable field as unset, so a plugin only has to write what it commands and
+  // nothing leaks across iterations.
+  for (const CommandableField& field : fields)
+  {
+    mujoco_ros2_control_plugins::mark_unset(field.commanded, field.count);
+  }
 
   for (auto& plugin : plugins_)
   {
-    if (plugin)
-    {
-      plugin->update(control_data_);
-    }
+    plugin->update(control_data_);
   }
 
-  // Merge back only what the plugins actually set. Leaving an entry untouched preserves whatever
-  // is already in mj_data_, which is what lets the viewer's interactive drag forces survive on
-  // bodies no plugin commands.
-  auto merge = [](const mjtNum* commanded, mjtNum* destination, int count) {
-    for (int i = 0; i < count; ++i)
-    {
-      if (!std::isnan(commanded[i]))
-      {
-        destination[i] = commanded[i];
-      }
-    }
-  };
-
-  merge(control_data_->ctrl, mj_data_->ctrl, mj_model_->nu);
-  merge(control_data_->qfrc_applied, mj_data_->qfrc_applied, mj_model_->nv);
-  merge(control_data_->xfrc_applied, mj_data_->xfrc_applied, nbody6);
-  merge(control_data_->qpos, mj_data_->qpos, mj_model_->nq);
-  merge(control_data_->qvel, mj_data_->qvel, mj_model_->nv);
+  // Merge back only what the plugins actually set. Leaving an entry unset preserves whatever is
+  // already in mj_data_, which is what lets the viewer's interactive drag forces survive on bodies
+  // no plugin commands.
+  for (const CommandableField& field : fields)
+  {
+    mujoco_ros2_control_plugins::merge_commands(field.commanded, field.live, field.count);
+  }
 }
 
 void MujocoSimulation::publish_control_state()
@@ -1387,6 +1413,11 @@ void MujocoSimulation::copy_control_state(ControlState& destination)
 void MujocoSimulation::refresh_control_state()
 {
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+  // Recompute derived quantities first. A caller that edited qpos / ctrl directly has left
+  // sensordata and qfrc_actuator describing the previous configuration, and publishing that
+  // mixture would hand readers a state that never existed. Every other mutator in this class
+  // pairs its edit with a forward for the same reason.
+  mj_forward(mj_model_, mj_data_);
   publish_control_state();
 }
 
@@ -1394,15 +1425,9 @@ void MujocoSimulation::apply_staged_control_inputs()
 {
   const std::lock_guard<std::mutex> lock(control_staging_mutex_);
 
-  // NaN means "not commanded", so initial, reset and plugin-set ctrl values survive for any
+  // Unset means "not commanded", so initial, reset and plugin-set ctrl values survive for any
   // actuator the hardware interface is not driving (e.g. passive actuators).
-  for (int i = 0; i < mj_model_->nu; ++i)
-  {
-    if (!std::isnan(ctrl_staged_[i]))
-    {
-      mj_data_->ctrl[i] = ctrl_staged_[i];
-    }
-  }
+  mujoco_ros2_control_plugins::merge_commands(ctrl_staged_.data(), mj_data_->ctrl, static_cast<int>(mj_model_->nu));
 }
 
 // simulate in background thread (while rendering in main thread)
@@ -1456,13 +1481,8 @@ void MujocoSimulation::physics_loop()
       // run only if model is present
       if (mj_model_)
       {
-        // Drive the plugins once per outer iteration, before any stepping. Plugins read the live
-        // data directly and write into the NaN-filled control_data_, of which only the entries
-        // they set are merged into mj_data_.
-        //
-        // Because the merge is per-entry rather than a whole-array overwrite, forces applied
-        // interactively in the native viewer survive on any body no plugin commands: the render
-        // thread's writes to mj_data_->xfrc_applied are simply left alone.
+        // Drive the plugins once per outer iteration, before any stepping (see
+        // run_plugin_updates()).
         run_plugin_updates();
 
         // running (ie, not paused)

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -22,6 +22,7 @@
 #include "mujoco_ros2_control/sim_display_text.hpp"
 
 #include <unistd.h>
+#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <cmath>
@@ -39,6 +40,8 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include <std_msgs/msg/string.hpp>
 
@@ -514,12 +517,9 @@ MujocoSimulation::~MujocoSimulation()
   {
     mj_deleteData(mj_data_);
   }
-  for (mjData* snapshot : { snapshot_write_, snapshot_read_ })
+  if (control_data_)
   {
-    if (snapshot)
-    {
-      mj_deleteData(snapshot);
-    }
+    mj_deleteData(control_data_);
   }
   if (mj_model_)
   {
@@ -706,29 +706,18 @@ bool MujocoSimulation::initialize(rclcpp::Node::SharedPtr node, const std::strin
   {
     std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
     mj_data_ = mj_makeData(mj_model_);
-    snapshot_write_ = mj_makeData(mj_model_);
-    snapshot_read_ = mj_makeData(mj_model_);
-    snapshot_ready_ = false;
+    control_data_ = mj_makeData(mj_model_);
 
-    // Initialize containers for data sharing
-    ctrl_staged_.assign(mj_model_->nu, 0.0);
-    qfrc_applied_staged_.assign(mj_model_->nv, 0.0);
-    control_inputs_staged_ = false;
-    xfrc_plugin_desired_.assign(6 * mj_model_->nbody, 0.0);
-    xfrc_viewer_capture_.assign(6 * mj_model_->nbody, 0.0);
-    xfrc_last_written_.assign(6 * mj_model_->nbody, 0.0);
-    qvel_override_staged_.assign(mj_model_->nv, std::numeric_limits<mjtNum>::quiet_NaN());
+    // Nothing is commanded yet: NaN means "leave unchanged", so the simulation keeps whatever
+    // initial ctrl the model / keyframe provided until a caller stages real commands.
+    ctrl_staged_.assign(mj_model_->nu, std::numeric_limits<mjtNum>::quiet_NaN());
 
-    if (mj_data_ && snapshot_write_ && snapshot_read_)
+    if (mj_data_)
     {
-      // Seed both snapshot buffers so a consumer that arrives before the first physics-loop
-      // refresh still sees valid initial data.
-      mj_copyData(snapshot_read_, mj_model_, mj_data_);
-      refresh_data_snapshot();
       publish_control_state();
     }
   }
-  if (!mj_data_ || !snapshot_write_ || !snapshot_read_)
+  if (!mj_data_ || !control_data_)
   {
     RCLCPP_FATAL(get_logger(), "Could not allocate mjData for '%s'", model_path_.c_str());
     return false;
@@ -862,17 +851,12 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
   std::fill(mj_data_->xfrc_applied, mj_data_->xfrc_applied + 6 * mj_model_->nbody, 0.0);
 
   {
-    // Clear staged control inputs and plugin contributions so stale commands from before the
-    // reset are not re-applied on the next step.
+    // Discard staged actuator commands so stale pre-reset commands are not re-applied on the next
+    // step. NaN means "leave unchanged", so the reset ctrl values above survive until the
+    // hardware interface stages fresh commands.
     const std::lock_guard<std::mutex> staging_lock(control_staging_mutex_);
-    control_inputs_staged_ = false;
-    std::fill(ctrl_staged_.begin(), ctrl_staged_.end(), 0.0);
-    std::fill(qfrc_applied_staged_.begin(), qfrc_applied_staged_.end(), 0.0);
-    std::fill(xfrc_plugin_desired_.begin(), xfrc_plugin_desired_.end(), 0.0);
-    std::fill(qvel_override_staged_.begin(), qvel_override_staged_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
+    std::fill(ctrl_staged_.begin(), ctrl_staged_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
   }
-  std::fill(xfrc_viewer_capture_.begin(), xfrc_viewer_capture_.end(), 0.0);
-  std::fill(xfrc_last_written_.begin(), xfrc_last_written_.end(), 0.0);
 
   // Restore simulation time to preserve ROS clock continuity
   mj_data_->time = saved_time;
@@ -891,8 +875,7 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
   // Run forward dynamics to update derived quantities
   mj_forward(mj_model_, mj_data_);
 
-  // Make the reset state visible to snapshot readers before HW-side bookkeeping runs
-  refresh_data_snapshot();
+  // Make the reset state visible to control-state readers before HW-side bookkeeping runs
   publish_control_state();
 
   // Delegate HW-side bookkeeping (PID resets, command/state interface sync, etc.)
@@ -1260,7 +1243,6 @@ bool MujocoSimulation::set_free_joint_states(
 
   apply_free_joint_states(free_joints);
 
-  refresh_data_snapshot();
   publish_control_state();
   mj_forward(mj_model_, mj_data_);
   return true;
@@ -1295,7 +1277,6 @@ void MujocoSimulation::overwrite_physics_data(mjData* source)
 {
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
   mj_copyData(mj_data_, mj_model_, source);
-  refresh_data_snapshot();
   publish_control_state();
 }
 
@@ -1307,58 +1288,82 @@ void MujocoSimulation::copy_physics_data(mjData*& destination)
   }
 
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
-  // Authoritative copies also refresh the snapshots, so that snapshot readers immediately see
-  // any direct mj_data_ manipulation the caller performed before this call (e.g. during setup).
-  refresh_data_snapshot();
+  // Also republish the control state, so that its readers immediately see any direct mj_data_
+  // manipulation the caller performed before this call (e.g. during setup).
   publish_control_state();
   mj_copyData(destination, mj_model_, mj_data_);
 }
 
-mjData* MujocoSimulation::acquire_data_snapshot()
+void MujocoSimulation::stage_actuator_commands(const std::vector<mjtNum>& ctrl_commands)
 {
+  if (static_cast<int>(ctrl_commands.size()) != mj_model_->nu)
   {
-    const std::lock_guard<std::mutex> lock(data_exchange_mutex_);
-    if (snapshot_ready_)
+    RCLCPP_WARN_THROTTLE(get_logger(), *node_->get_clock(), 5000,
+                         "Ignoring staged actuator commands: got %zu values but the model has %d actuators.",
+                         ctrl_commands.size(), mj_model_->nu);
+    return;
+  }
+
+  const std::lock_guard<std::mutex> lock(control_staging_mutex_);
+  std::copy(ctrl_commands.begin(), ctrl_commands.end(), ctrl_staged_.begin());
+}
+
+void MujocoSimulation::register_plugins(
+    std::vector<std::shared_ptr<mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase>> plugins)
+{
+  // Plugins are typically registered after the physics thread is already running, so the loop
+  // could otherwise be iterating plugins_ while we assign to it.
+  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+  plugins_ = std::move(plugins);
+  RCLCPP_INFO(get_logger(), "Registered %zu MuJoCo plugin(s) with the physics loop.", plugins_.size());
+}
+
+void MujocoSimulation::run_plugin_updates()
+{
+  /// @note This method assumes sim_mutex_ is already held by the caller
+
+  if (plugins_.empty())
+  {
+    return;
+  }
+
+  const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
+  constexpr mjtNum kUnset = std::numeric_limits<mjtNum>::quiet_NaN();
+
+  // Present every commandable field as "unset", so a plugin only has to write what it commands
+  // and nothing leaks across iterations.
+  mju_fill(control_data_->ctrl, kUnset, mj_model_->nu);
+  mju_fill(control_data_->qfrc_applied, kUnset, mj_model_->nv);
+  mju_fill(control_data_->xfrc_applied, kUnset, nbody6);
+  mju_fill(control_data_->qpos, kUnset, mj_model_->nq);
+  mju_fill(control_data_->qvel, kUnset, mj_model_->nv);
+
+  for (auto& plugin : plugins_)
+  {
+    if (plugin)
     {
-      // Take ownership of the completed snapshot and recycle the previous one back to the
-      // producer. O(1): the consumer never copies and never waits on a fill.
-      std::swap(snapshot_write_, snapshot_read_);
-      snapshot_ready_ = false;
+      plugin->update(control_data_);
     }
   }
 
-  // Ask the physics loop for a fresh snapshot now that this one has been consumed.
-  // Data is therefore at most one consumer period + one physics batch old, while the
-  // expensive refresh runs at the aggregate consumer rate instead of every batch.
-  snapshot_refresh_requested_.store(true, std::memory_order_release);
-  return snapshot_read_;
-}
+  // Merge back only what the plugins actually set. Leaving an entry untouched preserves whatever
+  // is already in mj_data_, which is what lets the viewer's interactive drag forces survive on
+  // bodies no plugin commands.
+  auto merge = [](const mjtNum* commanded, mjtNum* destination, int count) {
+    for (int i = 0; i < count; ++i)
+    {
+      if (!std::isnan(commanded[i]))
+      {
+        destination[i] = commanded[i];
+      }
+    }
+  };
 
-void MujocoSimulation::apply_control_data(mjData* control_data)
-{
-  const std::lock_guard<std::mutex> lock(control_staging_mutex_);
-  mju_copy(ctrl_staged_.data(), control_data->ctrl, static_cast<int>(mj_model_->nu));
-  mju_copy(qfrc_applied_staged_.data(), control_data->qfrc_applied, static_cast<int>(mj_model_->nv));
-  mju_copy(xfrc_plugin_desired_.data(), control_data->xfrc_applied, 6 * static_cast<int>(mj_model_->nbody));
-  mju_copy(qvel_override_staged_.data(), control_data->qvel, static_cast<int>(mj_model_->nv));
-  control_inputs_staged_ = true;
-}
-
-void MujocoSimulation::refresh_data_snapshot()
-{
-  {
-    // Reclaim the producer-side buffer. Once snapshot_ready_ is lowered the consumer can no
-    // longer swap it away mid-fill, so the copy below can safely run outside the lock.
-    const std::lock_guard<std::mutex> lock(data_exchange_mutex_);
-    snapshot_ready_ = false;
-  }
-
-  // Scene-sized copy, paid by the producer, outside any shared lock.
-  // Writers are serialized by the sim mutex and the consumer never touches snapshot_write_.
-  mj_copyData(snapshot_write_, mj_model_, mj_data_);
-
-  const std::lock_guard<std::mutex> lock(data_exchange_mutex_);
-  snapshot_ready_ = true;
+  merge(control_data_->ctrl, mj_data_->ctrl, mj_model_->nu);
+  merge(control_data_->qfrc_applied, mj_data_->qfrc_applied, mj_model_->nv);
+  merge(control_data_->xfrc_applied, mj_data_->xfrc_applied, nbody6);
+  merge(control_data_->qpos, mj_data_->qpos, mj_model_->nq);
+  merge(control_data_->qvel, mj_data_->qvel, mj_model_->nv);
 }
 
 void MujocoSimulation::publish_control_state()
@@ -1379,29 +1384,23 @@ void MujocoSimulation::copy_control_state(ControlState& destination)
   destination = control_state_;
 }
 
+void MujocoSimulation::refresh_control_state()
+{
+  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+  publish_control_state();
+}
+
 void MujocoSimulation::apply_staged_control_inputs()
 {
   const std::lock_guard<std::mutex> lock(control_staging_mutex_);
 
-  // Only apply ctrl / qfrc_applied once the hw interface has staged control inputs,
-  // so that initial or reset values in mj_data_ are not overwritten with zeros.
-  if (control_inputs_staged_)
+  // NaN means "not commanded", so initial, reset and plugin-set ctrl values survive for any
+  // actuator the hardware interface is not driving (e.g. passive actuators).
+  for (int i = 0; i < mj_model_->nu; ++i)
   {
-    mju_copy(mj_data_->ctrl, ctrl_staged_.data(), static_cast<int>(mj_model_->nu));
-    mju_copy(mj_data_->qfrc_applied, qfrc_applied_staged_.data(), static_cast<int>(mj_model_->nv));
-  }
-
-  const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
-  mju_copy(mj_data_->xfrc_applied, xfrc_viewer_capture_.data(), nbody6);
-  mju_addTo(mj_data_->xfrc_applied, xfrc_plugin_desired_.data(), nbody6);
-  mju_copy(xfrc_last_written_.data(), mj_data_->xfrc_applied, nbody6);
-
-  // Apply plugin-requested velocity overrides as direct qvel writes
-  for (int i = 0; i < static_cast<int>(mj_model_->nv); ++i)
-  {
-    if (std::isfinite(qvel_override_staged_[i]))
+    if (!std::isnan(ctrl_staged_[i]))
     {
-      mj_data_->qvel[i] = qvel_override_staged_[i];
+      mj_data_->ctrl[i] = ctrl_staged_[i];
     }
   }
 }
@@ -1457,24 +1456,14 @@ void MujocoSimulation::physics_loop()
       // run only if model is present
       if (mj_model_)
       {
-        // Determine the viewer (drag) forces for this outer iteration.
+        // Drive the plugins once per outer iteration, before any stepping. Plugins read the live
+        // data directly and write into the NaN-filled control_data_, of which only the entries
+        // they set are merged into mj_data_.
         //
-        // mjv_updateScene in simulate.cc reads mj_data_->xfrc_applied BEFORE zeroing it, so
-        // plugin forces written here are visible as arrows in the native viewer. To avoid
-        // accumulation across outer iterations we must preserve the viewer-drag portion.
-        // We do this in xfrc_viewer_capture_.
-        //
-        // After each outer iteration we restore mj_data_->xfrc_applied = viewer + plugin and
-        // record it in xfrc_last_written_. We can then combine the desired forces from the plugins
-        // as well as the viewers prior to stepping, without either of them stacking in
-        // undesirable ways.
-        const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
-        if (std::memcmp(mj_data_->xfrc_applied, xfrc_last_written_.data(), nbody6 * sizeof(mjtNum)) != 0)
-        {
-          // Render thread ran: xfrc_applied was zeroed then drag was applied.
-          mju_copy(xfrc_viewer_capture_.data(), mj_data_->xfrc_applied, nbody6);
-        }
-        // else: render thread did not run; keep the existing xfrc_viewer_capture_.
+        // Because the merge is per-entry rather than a whole-array overwrite, forces applied
+        // interactively in the native viewer survive on any body no plugin commands: the render
+        // thread's writes to mj_data_->xfrc_applied are simply left alone.
+        run_plugin_updates();
 
         // running (ie, not paused)
         if (sim_->run)
@@ -1488,11 +1477,6 @@ void MujocoSimulation::physics_loop()
             pending_steps_.store(0);
             steps_interrupted_.store(true);
             steps_cv_.notify_all();
-          }
-
-          if (snapshot_refresh_requested_.exchange(false, std::memory_order_acq_rel))
-          {
-            refresh_data_snapshot();
           }
 
           bool stepped = false;
@@ -1624,8 +1608,8 @@ void MujocoSimulation::physics_loop()
             pending_steps_.fetch_add(1);
           }
 
-          // Record so the next iteration can detect render thread changes, only necessary once
-          // when paused
+          // Merge staged actuator commands even while paused, so a queued step (and the viewer's
+          // display of ctrl) reflects the latest commands.
           apply_staged_control_inputs();
 
           // Execute one pending step per physics loop iteration so the clock publisher
@@ -1665,11 +1649,7 @@ void MujocoSimulation::physics_loop()
             update_sim_display();
           }
 
-          // Keep the snapshots in sync while paused so reads reflect steps and UI edits
-          if (snapshot_refresh_requested_.exchange(false, std::memory_order_acq_rel))
-          {
-            refresh_data_snapshot();
-          }
+          // Keep the control state in sync while paused so reads reflect steps and UI edits
           publish_control_state();
         }
 

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -22,6 +22,7 @@
 #include <fmt/compile.h>
 #include <fmt/ranges.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -242,6 +243,13 @@ MujocoSystemInterface::MujocoSystemInterface() = default;
 
 MujocoSystemInterface::~MujocoSystemInterface()
 {
+  // Detach the plugins from the physics loop first. register_plugins takes the sim mutex, so once
+  // it returns the loop cannot be in the middle of a plugin update while we clean them up.
+  if (simulation_)
+  {
+    simulation_->register_plugins({});
+  }
+
   // Stop plugins
   for (auto& plugin : plugin_instances_)
   {
@@ -261,10 +269,6 @@ MujocoSystemInterface::~MujocoSystemInterface()
   if (executor_thread_.joinable())
   {
     executor_thread_.join();
-  }
-  if (mj_data_control_)
-  {
-    mj_deleteData(mj_data_control_);
   }
 
   // Tear down the actual simulation
@@ -471,6 +475,9 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
       static_cast<unsigned long>(1.0 / simulation_->model()->opt.timestep), simulation_->model()->opt.timestep,
       static_cast<unsigned long>(get_hardware_info().rw_rate));
 #endif
+
+  // Allocate the command buffer once, so write() never allocates in the control loop.
+  actuator_commands_.assign(simulation_->model()->nu, std::numeric_limits<mjtNum>::quiet_NaN());
 
   // Start the physics thread.
   simulation_->start_physics_thread();
@@ -1038,13 +1045,11 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
 #endif
   };
 
-  mjData* control_data = plugin_instances_.empty() ? mj_data_control_ : simulation_->acquire_data_snapshot();
+  // Start from "nothing commanded": actuators we skip below (e.g. passive ones) are left NaN, so
+  // the simulation keeps their current value instead of us having to mirror it here first.
+  std::fill(actuator_commands_.begin(), actuator_commands_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
 
-  // Mirror the sim's actual ctrl so entries we do not command below (e.g., passive actuators)
-  // are staged with their current values rather than a possibly stale snapshot.
-  mju_copy(control_data->ctrl, control_state_.ctrl.data(), static_cast<int>(control_state_.ctrl.size()));
-
-  // Update control data based on the latest readings
+  // Compose actuator commands based on the latest readings
   for (auto& actuator : mujoco_actuator_data_)
   {
     if (actuator.actuator_type == ActuatorType::PASSIVE)
@@ -1053,42 +1058,31 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
     }
     if (actuator.is_position_control_enabled)
     {
-      control_data->ctrl[actuator.mj_actuator_id] = actuator.position_interface.command_;
+      actuator_commands_[actuator.mj_actuator_id] = actuator.position_interface.command_;
     }
     else if (actuator.is_position_pid_control_enabled)
     {
       const double error = actuator.position_interface.command_ - control_state_.qpos[actuator.mj_pos_adr];
-      control_data->ctrl[actuator.mj_actuator_id] = pid_compute_command(actuator.pos_pid, error, period);
+      actuator_commands_[actuator.mj_actuator_id] = pid_compute_command(actuator.pos_pid, error, period);
     }
     else if (actuator.is_velocity_control_enabled)
     {
-      control_data->ctrl[actuator.mj_actuator_id] = actuator.velocity_interface.command_;
+      actuator_commands_[actuator.mj_actuator_id] = actuator.velocity_interface.command_;
     }
     else if (actuator.is_velocity_pid_control_enabled)
     {
       const double error = actuator.velocity_interface.command_ - control_state_.qvel[actuator.mj_vel_adr];
-      control_data->ctrl[actuator.mj_actuator_id] = pid_compute_command(actuator.vel_pid, error, period);
+      actuator_commands_[actuator.mj_actuator_id] = pid_compute_command(actuator.vel_pid, error, period);
     }
     else if (actuator.is_effort_control_enabled)
     {
-      control_data->ctrl[actuator.mj_actuator_id] = actuator.effort_interface.command_;
+      actuator_commands_[actuator.mj_actuator_id] = actuator.effort_interface.command_;
     }
   }
 
-  // Update plugins.
-  // Clear plugin data, then let each plugin update as needed, in order. This enables plugins to read and
-  // rewrite control inputs immediately before they are sent to the simulation. Namely, we have to zero
-  // out xfrc_applied so plugins can update as needed. qvel is NaN-filled rather than zeroed: a plugin
-  // requests a hard velocity override on a DOF by writing a finite value into it.
-  mju_zero(control_data->xfrc_applied, 6 * static_cast<int>(simulation_->model()->nbody));
-  std::fill(control_data->qvel, control_data->qvel + simulation_->model()->nv, std::numeric_limits<mjtNum>::quiet_NaN());
-  for (auto& plugin : plugin_instances_)
-  {
-    plugin->update(simulation_->model(), control_data);
-  }
-
-  // Trigger to simulation to update its control inputs (this locks)
-  simulation_->apply_control_data(control_data);
+  // Hand the commands to the simulation, which merges them into mj_data_->ctrl immediately before
+  // the next step. Plugins are driven by the physics loop itself, not from here.
+  simulation_->stage_actuator_commands(actuator_commands_);
 
   return hardware_interface::return_type::OK;
 }
@@ -2148,16 +2142,14 @@ void MujocoSystemInterface::set_initial_pose()
     }
   }
 
-  // Copy into the control data for reads
-  simulation_->copy_physics_data(mj_data_control_);
+  // We wrote qpos / ctrl directly above, so republish the control state. Otherwise the seed in
+  // on_init would read a pre-initial-pose state until the physics loop happened to step.
+  simulation_->refresh_control_state();
 }
 
 void MujocoSystemInterface::reset_simulation_state(bool /*fill_initial_state*/)
 {
   /// @note This method assumes sim_mutex_ is already held by the caller
-
-  // Copy to control data for reads - this ensures the physics loop uses the reset state
-  simulation_->copy_physics_data(mj_data_control_);
 
   // Reset command interfaces to initial position commands
   for (auto& actuator : mujoco_actuator_data_)
@@ -2191,11 +2183,9 @@ void MujocoSystemInterface::reset_simulation_state(bool /*fill_initial_state*/)
       actuator.velocity_interface.command_ = 0.0;
       actuator.effort_interface.command_ = 0.0;
 
-      // Also update the ctrl buffer in mj_data_control_ which is used by the physics loop
-      if (actuator.is_position_control_enabled && actuator.mj_actuator_id >= 0)
-      {
-        mj_data_control_->ctrl[actuator.mj_actuator_id] = actuator.position_interface.state_;
-      }
+      // No need to poke a staging buffer here: reset_world_state() has already discarded the
+      // staged commands (leaving them NaN), so the reset ctrl in mj_data_ stands until the next
+      // write() stages the commands set above.
     }
   }
 
@@ -2276,7 +2266,7 @@ void MujocoSystemInterface::load_mujoco_plugins()
         }
         const std::string plugin_type = get_node()->get_parameter(plugin_type_param).as_string();
         auto plugin = plugin_loader_->createSharedInstance(plugin_type);
-        if (plugin->init(get_node()->create_sub_node(plugin_name), simulation_->model(), simulation_->data()))
+        if (plugin->initialize(get_node()->create_sub_node(plugin_name), simulation_->model(), simulation_->data()))
         {
           plugin_instances_.push_back(plugin);
           RCLCPP_INFO(get_logger(), "Successfully loaded and initialized plugin: %s", plugin_name.c_str());
@@ -2304,6 +2294,10 @@ void MujocoSystemInterface::load_mujoco_plugins()
   {
     RCLCPP_ERROR(get_logger(), "Failed to create plugin loader: %s", ex.what());
   }
+
+  // Hand the fully loaded set to the physics loop, which drives their update() from here on.
+  // Done after the legacy camera/lidar auto-registration above so those instances are included.
+  simulation_->register_plugins(plugin_instances_);
 }
 
 ///
@@ -2329,7 +2323,7 @@ bool MujocoSystemInterface::auto_register_plugin_if_needed(const std::string& pl
   try
   {
     auto plugin = plugin_loader_->createSharedInstance(plugin_type);
-    if (plugin->init(get_node()->create_sub_node(plugin_ns), simulation_->model(), simulation_->data()))
+    if (plugin->initialize(get_node()->create_sub_node(plugin_ns), simulation_->model(), simulation_->data()))
     {
       plugin_instances_.push_back(plugin);
       RCLCPP_INFO(get_logger(), "Auto-registered plugin: %s", plugin_type.c_str());

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -243,11 +243,11 @@ MujocoSystemInterface::MujocoSystemInterface() = default;
 
 MujocoSystemInterface::~MujocoSystemInterface()
 {
-  // Detach the plugins from the physics loop first. register_plugins takes the sim mutex, so once
-  // it returns the loop cannot be in the middle of a plugin update while we clean them up.
+  // Plugins cache the live model and data pointers, so they must stop being driven before we clean
+  // them up, and be cleaned up before the simulation frees that data.
   if (simulation_)
   {
-    simulation_->register_plugins({});
+    simulation_->detach_plugins();
   }
 
   // Stop plugins
@@ -477,7 +477,7 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
 #endif
 
   // Allocate the command buffer once, so write() never allocates in the control loop.
-  actuator_commands_.assign(simulation_->model()->nu, std::numeric_limits<mjtNum>::quiet_NaN());
+  actuator_commands_.assign(simulation_->model()->nu, mujoco_ros2_control_plugins::kUnsetCommand);
 
   // Start the physics thread.
   simulation_->start_physics_thread();
@@ -1045,9 +1045,15 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
 #endif
   };
 
-  // Start from "nothing commanded": actuators we skip below (e.g. passive ones) are left NaN, so
-  // the simulation keeps their current value instead of us having to mirror it here first.
-  std::fill(actuator_commands_.begin(), actuator_commands_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
+  // Start from "nothing commanded": actuators we skip below (e.g. passive ones) stay unset, so the
+  // simulation keeps their current value instead of us having to mirror it here first. Refilling
+  // every cycle matters because a command mode can be switched off at runtime, and the actuator
+  // must then revert to uncommanded rather than keep its last value.
+  //
+  // Note this composes with a second, pre-existing use of NaN: an InterfaceData command_ that no
+  // controller has written is also NaN (see data.hpp), and copying it through here leaves that
+  // actuator alone. That is intended -- do not "fix" it with an isfinite guard.
+  std::fill(actuator_commands_.begin(), actuator_commands_.end(), mujoco_ros2_control_plugins::kUnsetCommand);
 
   // Compose actuator commands based on the latest readings
   for (auto& actuator : mujoco_actuator_data_)

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -19,13 +19,13 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -85,7 +85,7 @@ void write_test_model()
 
 constexpr double TEST_TOLERANCE = 1e-9;
 
-constexpr mjtNum kNaN = std::numeric_limits<mjtNum>::quiet_NaN();
+constexpr mjtNum kUnset = mujoco_ros2_control_plugins::kUnsetCommand;
 
 /**
  * @brief Plugin implementing the current API, driving an injected callback on every update.
@@ -120,7 +120,7 @@ public:
 
 /**
  * @brief Plugin implementing *only* the deprecated two-argument update(), to pin the compatibility
- * contract: it must keep receiving live, readable mjData rather than the NaN command buffer.
+ * contract: it must keep receiving live, readable mjData rather than the command buffer.
  */
 class LegacyTestPlugin : public mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase
 {
@@ -148,6 +148,26 @@ public:
 };
 
 /**
+ * @brief Plugin implementing *neither* update() overload -- the shape a mis-typed signature takes.
+ *
+ * Both overloads have default bodies, so this compiles; the base class is expected to notice and
+ * complain rather than silently do nothing, and the mutual dispatch between the two defaults must
+ * not recurse.
+ */
+class NoUpdateTestPlugin : public mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase
+{
+public:
+  bool init(rclcpp::Node::SharedPtr, const mjModel*, mjData*) override
+  {
+    return true;
+  }
+
+  void cleanup() override
+  {
+  }
+};
+
+/**
  * @brief Shared-ownership slot for values a plugin callback records for the test to assert on.
  *
  * The physics loop keeps calling registered plugins until the simulation is shut down in
@@ -161,30 +181,16 @@ std::shared_ptr<std::atomic<T>> make_recorder(T initial)
   return std::make_shared<std::atomic<T>>(initial);
 }
 
-// True if any entry of the array is NaN. Used to prove the sentinel never leaks into the sim.
-bool contains_nan(const mjtNum* values, int count)
+// True if any entry is unset. Used to prove the sentinel never leaks into the sim.
+bool contains_unset(const mjtNum* values, int count)
 {
-  for (int i = 0; i < count; ++i)
-  {
-    if (std::isnan(values[i]))
-    {
-      return true;
-    }
-  }
-  return false;
+  return !std::all_of(values, values + count, mujoco_ros2_control_plugins::is_commanded);
 }
 
-// True if every entry of the array is NaN, i.e. the buffer arrived fully unset.
-bool all_nan(const mjtNum* values, int count)
+// True if every entry is unset, i.e. the buffer arrived commanding nothing.
+bool all_unset(const mjtNum* values, int count)
 {
-  for (int i = 0; i < count; ++i)
-  {
-    if (!std::isnan(values[i]))
-    {
-      return false;
-    }
-  }
-  return true;
+  return std::none_of(values, values + count, mujoco_ros2_control_plugins::is_commanded);
 }
 }  // namespace
 
@@ -267,7 +273,7 @@ protected:
   // Returns an all-NaN command vector sized for the model's actuators, i.e. "command nothing".
   std::vector<mjtNum> unset_actuator_commands() const
   {
-    return std::vector<mjtNum>(sim_->model()->nu, kNaN);
+    return std::vector<mjtNum>(sim_->model()->nu, kUnset);
   }
 
   // Helper function to poll a condition until it returns true or the timeout expires.
@@ -380,9 +386,9 @@ TEST_F(MujocoSimulationTest, PluginControlDataIsNanFilled)
   plugin->on_update = [arrived_unset](mjData* control_data, const mjData*, const mjModel* model) {
     // Every commandable field must arrive fully unset, so nothing a plugin wrote on a previous
     // iteration is silently re-applied on this one.
-    const bool unset = all_nan(control_data->ctrl, model->nu) && all_nan(control_data->qfrc_applied, model->nv) &&
-                       all_nan(control_data->xfrc_applied, 6 * model->nbody) &&
-                       all_nan(control_data->qpos, model->nq) && all_nan(control_data->qvel, model->nv);
+    const bool unset = all_unset(control_data->ctrl, model->nu) && all_unset(control_data->qfrc_applied, model->nv) &&
+                       all_unset(control_data->xfrc_applied, 6 * model->nbody) &&
+                       all_unset(control_data->qpos, model->nq) && all_unset(control_data->qvel, model->nv);
     if (!unset)
     {
       arrived_unset->store(false);
@@ -414,11 +420,11 @@ TEST_F(MujocoSimulationTest, PluginPartialWriteLeavesRestUntouched)
   const mjData* data = sim_->data();
 
   // Fields the plugin left unset must never receive the NaN sentinel itself.
-  EXPECT_FALSE(contains_nan(data->ctrl, model->nu));
-  EXPECT_FALSE(contains_nan(data->qpos, model->nq));
-  EXPECT_FALSE(contains_nan(data->qvel, model->nv));
-  EXPECT_FALSE(contains_nan(data->qfrc_applied, model->nv));
-  EXPECT_FALSE(contains_nan(data->xfrc_applied, 6 * model->nbody));
+  EXPECT_FALSE(contains_unset(data->ctrl, model->nu));
+  EXPECT_FALSE(contains_unset(data->qpos, model->nq));
+  EXPECT_FALSE(contains_unset(data->qvel, model->nv));
+  EXPECT_FALSE(contains_unset(data->qfrc_applied, model->nv));
+  EXPECT_FALSE(contains_unset(data->xfrc_applied, 6 * model->nbody));
 
   // Nothing writes qfrc_applied in this test, so it must remain at its reset value.
   for (int i = 0; i < model->nv; ++i)
@@ -453,7 +459,7 @@ TEST_F(MujocoSimulationTest, PluginSeesLiveSimState)
   auto saw_valid_state = make_recorder<bool>(false);
   auto plugin = add_plugin<TestControlPlugin>();
   plugin->on_update = [observed_time, saw_valid_state](mjData*, const mjData* sim_data, const mjModel* model) {
-    if (sim_data != nullptr && model != nullptr && !contains_nan(sim_data->qpos, model->nq))
+    if (sim_data != nullptr && model != nullptr && !contains_unset(sim_data->qpos, model->nq))
     {
       saw_valid_state->store(true);
       observed_time->store(sim_data->time);
@@ -479,7 +485,7 @@ TEST_F(MujocoSimulationTest, LegacyPluginReceivesLiveData)
   auto observed_time = make_recorder<double>(-1.0);
   auto plugin = add_plugin<LegacyTestPlugin>();
   plugin->on_update = [saw_readable_data, observed_time](const mjModel* model, mjData* data) {
-    if (model != nullptr && data != nullptr && !contains_nan(data->qpos, model->nq) && !std::isnan(data->time))
+    if (model != nullptr && data != nullptr && !contains_unset(data->qpos, model->nq) && !std::isnan(data->time))
     {
       saw_readable_data->store(true);
       observed_time->store(data->time);
@@ -494,6 +500,27 @@ TEST_F(MujocoSimulationTest, LegacyPluginReceivesLiveData)
   EXPECT_TRUE(wait_until([observed_time]() { return observed_time->load() > 0.0; }));
   EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 0], 5.0)
       << "Legacy plugin's direct write to the live data did not survive the merge";
+}
+
+TEST_F(MujocoSimulationTest, PluginImplementingNeitherOverloadIsHarmless)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  // A plugin that overrides neither update() overload still compiles, because both have default
+  // bodies. The two defaults dispatch to each other, so the thing to pin down is that this neither
+  // recurses nor disturbs the simulation -- the base class reports it instead.
+  add_plugin<NoUpdateTestPlugin>();
+
+  sim_->start_physics_thread();
+  const uint64_t start_steps = sim_->step_count();
+  ASSERT_TRUE(wait_until([&]() { return sim_->step_count() > start_steps + 5; }))
+      << "Physics loop stopped stepping with a plugin that implements no update()";
+
+  const mjModel* model = sim_->model();
+  const mjData* data = sim_->data();
+  EXPECT_FALSE(contains_unset(data->ctrl, model->nu));
+  EXPECT_FALSE(contains_unset(data->qpos, model->nq));
+  EXPECT_FALSE(contains_unset(data->xfrc_applied, 6 * model->nbody));
 }
 
 TEST_F(MujocoSimulationTest, ExistingXfrcSurvivesPluginMerge)

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -19,11 +19,16 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <functional>
+#include <limits>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include <mujoco/mujoco.h>
 #include <rclcpp/rclcpp.hpp>
@@ -79,6 +84,108 @@ void write_test_model()
 }
 
 constexpr double TEST_TOLERANCE = 1e-9;
+
+constexpr mjtNum kNaN = std::numeric_limits<mjtNum>::quiet_NaN();
+
+/**
+ * @brief Plugin implementing the current API, driving an injected callback on every update.
+ *
+ * The callback runs on the physics thread with the sim mutex held, so anything it records for the
+ * test thread to inspect must be atomic.
+ */
+class TestControlPlugin : public mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase
+{
+public:
+  bool init(rclcpp::Node::SharedPtr, const mjModel*, mjData*) override
+  {
+    return true;
+  }
+
+  void update(mjData* control_data) override
+  {
+    if (on_update)
+    {
+      on_update(control_data, get_sim_data(), get_mujoco_model());
+    }
+    update_count.fetch_add(1);
+  }
+
+  void cleanup() override
+  {
+  }
+
+  std::function<void(mjData*, const mjData*, const mjModel*)> on_update;
+  std::atomic<uint64_t> update_count{ 0 };
+};
+
+/**
+ * @brief Plugin implementing *only* the deprecated two-argument update(), to pin the compatibility
+ * contract: it must keep receiving live, readable mjData rather than the NaN command buffer.
+ */
+class LegacyTestPlugin : public mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase
+{
+public:
+  bool init(rclcpp::Node::SharedPtr, const mjModel*, mjData*) override
+  {
+    return true;
+  }
+
+  void update(const mjModel* model, mjData* data) override
+  {
+    if (on_update)
+    {
+      on_update(model, data);
+    }
+    update_count.fetch_add(1);
+  }
+
+  void cleanup() override
+  {
+  }
+
+  std::function<void(const mjModel*, mjData*)> on_update;
+  std::atomic<uint64_t> update_count{ 0 };
+};
+
+/**
+ * @brief Shared-ownership slot for values a plugin callback records for the test to assert on.
+ *
+ * The physics loop keeps calling registered plugins until the simulation is shut down in
+ * TearDown, which is *after* the test body's locals have been destroyed. Capturing a stack local
+ * by reference would therefore leave the callback writing through a dangling reference. Giving the
+ * slot shared ownership keeps it alive for as long as the callback that writes it.
+ */
+template <typename T>
+std::shared_ptr<std::atomic<T>> make_recorder(T initial)
+{
+  return std::make_shared<std::atomic<T>>(initial);
+}
+
+// True if any entry of the array is NaN. Used to prove the sentinel never leaks into the sim.
+bool contains_nan(const mjtNum* values, int count)
+{
+  for (int i = 0; i < count; ++i)
+  {
+    if (std::isnan(values[i]))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+// True if every entry of the array is NaN, i.e. the buffer arrived fully unset.
+bool all_nan(const mjtNum* values, int count)
+{
+  for (int i = 0; i < count; ++i)
+  {
+    if (!std::isnan(values[i]))
+    {
+      return false;
+    }
+  }
+  return true;
+}
 }  // namespace
 
 class MujocoSimulationTest : public ::testing::Test
@@ -146,6 +253,23 @@ protected:
     return sim_->initialize(node_, kTestModelPath, "/mujoco_robot_description", -1.0, true);
   }
 
+  // Construct, initialize and register a plugin, mirroring what the hardware interface does in
+  // load_mujoco_plugins(). Replaces any previously registered plugins.
+  template <typename PluginT>
+  std::shared_ptr<PluginT> add_plugin()
+  {
+    auto plugin = std::make_shared<PluginT>();
+    EXPECT_TRUE(plugin->initialize(node_, sim_->model(), sim_->data()));
+    sim_->register_plugins({ plugin });
+    return plugin;
+  }
+
+  // Returns an all-NaN command vector sized for the model's actuators, i.e. "command nothing".
+  std::vector<mjtNum> unset_actuator_commands() const
+  {
+    return std::vector<mjtNum>(sim_->model()->nu, kNaN);
+  }
+
   // Helper function to poll a condition until it returns true or the timeout expires.
   bool wait_until(std::function<bool()> condition, std::chrono::milliseconds timeout = std::chrono::seconds(5),
                   std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
@@ -205,56 +329,193 @@ TEST_F(MujocoSimulationTest, ControlUpdateTests)
 {
   ASSERT_TRUE(initialize_sim());
 
-  // Simulate the read/write cycle in the ros2_control loop, making sure data
-  // is updated where expected
-  mjData* control = nullptr;
-  sim_->copy_physics_data(control);
-  ASSERT_NE(control, nullptr);
+  // Seed a known control value so we can prove an unset (NaN) command leaves it alone.
+  sim_->data()->ctrl[0] = 0.25;
 
-  // Update control inputs
-  control->ctrl[0] = 0.75;
-  control->qfrc_applied[0] = 1.5;
+  // Staging an all-NaN command means "command nothing", so ctrl must survive untouched. This is
+  // what lets the hardware interface skip passive / uncommanded actuators without first mirroring
+  // the simulation's current ctrl into the buffer.
+  auto commands = unset_actuator_commands();
+  sim_->stage_actuator_commands(commands);
 
-  // Apply to sim. Inputs are staged and copied into the sim data by the physics loop
-  // immediately before each step, so they must not appear until stepping occurs.
-  sim_->apply_control_data(control);
-  EXPECT_DOUBLE_EQ(sim_->data()->ctrl[0], 0.0);
-  EXPECT_DOUBLE_EQ(sim_->data()->qfrc_applied[0], 0.0);
-
-  // Once the physics loop starts stepping, the staged inputs should land in the sim data
   sim_->start_physics_thread();
-  EXPECT_TRUE(wait_until([this]() { return sim_->data()->ctrl[0] == 0.75 && sim_->data()->qfrc_applied[0] == 1.5; }))
-      << "Staged control inputs were not applied by the physics loop";
+  const uint64_t start_steps = sim_->step_count();
+  ASSERT_TRUE(wait_until([&]() { return sim_->step_count() > start_steps + 5; }));
+  EXPECT_DOUBLE_EQ(sim_->data()->ctrl[0], 0.25) << "An unset (NaN) command overwrote the existing ctrl value";
 
-  mj_deleteData(control);
+  // A finite command is merged into the sim data by the physics loop before the next step.
+  commands[0] = 0.75;
+  sim_->stage_actuator_commands(commands);
+  EXPECT_TRUE(wait_until([this]() { return sim_->data()->ctrl[0] == 0.75; }))
+      << "Staged actuator command was not applied by the physics loop";
 }
 
 TEST_F(MujocoSimulationTest, XfrcAppliedTests)
 {
   ASSERT_TRUE(initialize_sim());
 
-  // Simulate the read/write cycle in the ros2_control loop, making sure data
-  // is updated where expected
-  mjData* control = nullptr;
-  sim_->copy_physics_data(control);
-  ASSERT_NE(control, nullptr);
+  // A plugin commands a Cartesian force by writing it into control_data; the physics loop merges
+  // it into the sim data immediately before stepping.
+  constexpr int body_id = 1;
+  auto plugin = add_plugin<TestControlPlugin>();
+  plugin->on_update = [](mjData* control_data, const mjData*, const mjModel*) {
+    control_data->xfrc_applied[body_id * 6 + 0] = 1.0;
+    control_data->xfrc_applied[body_id * 6 + 1] = 2.0;
+    control_data->xfrc_applied[body_id * 6 + 2] = 3.0;
+  };
 
-  // Zero xfrc_applied (like for plugins), and apply a force
-  const size_t body_id = 1;
-  mju_zero(control->xfrc_applied, 6 * sim_->model()->nbody);
-  control->xfrc_applied[body_id * 6 + 0] = 1.0;
-  control->xfrc_applied[body_id * 6 + 1] = 2.0;
-  control->xfrc_applied[body_id * 6 + 2] = 3.0;
+  sim_->start_physics_thread();
+  EXPECT_TRUE(wait_until([this]() {
+    return sim_->data()->xfrc_applied[body_id * 6 + 0] == 1.0 && sim_->data()->xfrc_applied[body_id * 6 + 1] == 2.0 &&
+           sim_->data()->xfrc_applied[body_id * 6 + 2] == 3.0;
+  })) << "Plugin Cartesian force never reached the simulation data";
+}
 
-  sim_->apply_control_data(control);
+TEST_F(MujocoSimulationTest, PluginControlDataIsNanFilled)
+{
+  ASSERT_TRUE(initialize_sim());
 
-  // xfrc_applied should NOT be in mj_data_ directly, it goes through the triple
-  // plugin buffer and gets composed in the physics loop
-  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 0], 0.0);
-  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 1], 0.0);
-  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 2], 0.0);
+  auto arrived_unset = make_recorder<bool>(true);
+  auto plugin = add_plugin<TestControlPlugin>();
+  plugin->on_update = [arrived_unset](mjData* control_data, const mjData*, const mjModel* model) {
+    // Every commandable field must arrive fully unset, so nothing a plugin wrote on a previous
+    // iteration is silently re-applied on this one.
+    const bool unset = all_nan(control_data->ctrl, model->nu) && all_nan(control_data->qfrc_applied, model->nv) &&
+                       all_nan(control_data->xfrc_applied, 6 * model->nbody) &&
+                       all_nan(control_data->qpos, model->nq) && all_nan(control_data->qvel, model->nv);
+    if (!unset)
+    {
+      arrived_unset->store(false);
+    }
+    // Write something, so the next iteration proves the buffer really is refilled.
+    control_data->ctrl[0] = 0.5;
+  };
 
-  mj_deleteData(control);
+  sim_->start_physics_thread();
+  ASSERT_TRUE(wait_until([&plugin]() { return plugin->update_count.load() >= 3; }))
+      << "Plugin update was never called from the physics loop";
+  EXPECT_TRUE(arrived_unset->load()) << "control_data was not NaN-filled before a plugin update";
+}
+
+TEST_F(MujocoSimulationTest, PluginPartialWriteLeavesRestUntouched)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  auto plugin = add_plugin<TestControlPlugin>();
+  plugin->on_update = [](mjData* control_data, const mjData*, const mjModel*) {
+    // Command a single actuator and nothing else.
+    control_data->ctrl[0] = 0.4;
+  };
+
+  sim_->start_physics_thread();
+  ASSERT_TRUE(wait_until([&plugin]() { return plugin->update_count.load() >= 3; }));
+
+  const mjModel* model = sim_->model();
+  const mjData* data = sim_->data();
+
+  // Fields the plugin left unset must never receive the NaN sentinel itself.
+  EXPECT_FALSE(contains_nan(data->ctrl, model->nu));
+  EXPECT_FALSE(contains_nan(data->qpos, model->nq));
+  EXPECT_FALSE(contains_nan(data->qvel, model->nv));
+  EXPECT_FALSE(contains_nan(data->qfrc_applied, model->nv));
+  EXPECT_FALSE(contains_nan(data->xfrc_applied, 6 * model->nbody));
+
+  // Nothing writes qfrc_applied in this test, so it must remain at its reset value.
+  for (int i = 0; i < model->nv; ++i)
+  {
+    EXPECT_DOUBLE_EQ(data->qfrc_applied[i], 0.0) << "qfrc_applied[" << i << "] was disturbed";
+  }
+}
+
+TEST_F(MujocoSimulationTest, PluginCanCommandQposAndQvel)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  // Pin the hinge by commanding its position and velocity every iteration. The merge happens
+  // immediately before the step, so the joint should stay within one timestep of the command.
+  constexpr mjtNum kPinnedPosition = 0.4;
+  auto plugin = add_plugin<TestControlPlugin>();
+  plugin->on_update = [](mjData* control_data, const mjData*, const mjModel*) {
+    control_data->qpos[0] = kPinnedPosition;
+    control_data->qvel[0] = 0.0;
+  };
+
+  sim_->start_physics_thread();
+  ASSERT_TRUE(wait_until([&plugin]() { return plugin->update_count.load() >= 5; }));
+  EXPECT_NEAR(sim_->data()->qpos[0], kPinnedPosition, 1e-2) << "Plugin qpos command did not reach the simulation";
+}
+
+TEST_F(MujocoSimulationTest, PluginSeesLiveSimState)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  auto observed_time = make_recorder<double>(-1.0);
+  auto saw_valid_state = make_recorder<bool>(false);
+  auto plugin = add_plugin<TestControlPlugin>();
+  plugin->on_update = [observed_time, saw_valid_state](mjData*, const mjData* sim_data, const mjModel* model) {
+    if (sim_data != nullptr && model != nullptr && !contains_nan(sim_data->qpos, model->nq))
+    {
+      saw_valid_state->store(true);
+      observed_time->store(sim_data->time);
+    }
+  };
+
+  sim_->start_physics_thread();
+  // The observed sim time must advance, proving get_sim_data() tracks the live data rather than a
+  // stale copy captured at init.
+  EXPECT_TRUE(wait_until([observed_time]() { return observed_time->load() > 0.0; }))
+      << "get_sim_data() never reported advancing simulation time";
+  EXPECT_TRUE(saw_valid_state->load()) << "get_sim_data() did not expose readable state";
+}
+
+TEST_F(MujocoSimulationTest, LegacyPluginReceivesLiveData)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  // A plugin that only implements the deprecated two-argument update() must still be handed live,
+  // readable mjData -- not the NaN command buffer -- and its direct writes must take effect.
+  constexpr int body_id = 2;
+  auto saw_readable_data = make_recorder<bool>(false);
+  auto observed_time = make_recorder<double>(-1.0);
+  auto plugin = add_plugin<LegacyTestPlugin>();
+  plugin->on_update = [saw_readable_data, observed_time](const mjModel* model, mjData* data) {
+    if (model != nullptr && data != nullptr && !contains_nan(data->qpos, model->nq) && !std::isnan(data->time))
+    {
+      saw_readable_data->store(true);
+      observed_time->store(data->time);
+    }
+    data->xfrc_applied[body_id * 6 + 0] = 5.0;
+  };
+
+  sim_->start_physics_thread();
+  ASSERT_TRUE(wait_until([&plugin]() { return plugin->update_count.load() >= 3; }))
+      << "Deprecated update() overload was never called";
+  EXPECT_TRUE(saw_readable_data->load()) << "Legacy plugin received a NaN buffer instead of live sim data";
+  EXPECT_TRUE(wait_until([observed_time]() { return observed_time->load() > 0.0; }));
+  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 0], 5.0)
+      << "Legacy plugin's direct write to the live data did not survive the merge";
+}
+
+TEST_F(MujocoSimulationTest, ExistingXfrcSurvivesPluginMerge)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  // Forces already present in the sim data (e.g. the viewer's interactive drag) must survive on
+  // bodies the plugin does not command, because the merge no longer overwrites the whole array.
+  constexpr int untouched_body = 2;
+  constexpr int commanded_body = 3;
+  sim_->data()->xfrc_applied[untouched_body * 6 + 0] = 7.0;
+
+  auto plugin = add_plugin<TestControlPlugin>();
+  plugin->on_update = [](mjData* control_data, const mjData*, const mjModel*) {
+    control_data->xfrc_applied[commanded_body * 6 + 0] = 9.0;
+  };
+
+  sim_->start_physics_thread();
+  ASSERT_TRUE(wait_until([this]() { return sim_->data()->xfrc_applied[commanded_body * 6 + 0] == 9.0; }))
+      << "Plugin force never reached the commanded body";
+  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[untouched_body * 6 + 0], 7.0)
+      << "Pre-existing force on an uncommanded body was clobbered by the merge";
 }
 
 TEST_F(MujocoSimulationTest, PauseStepUnpause)

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -639,7 +639,7 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
      const mjData* data = get_sim_data();
 
      // ...and command the simulation by writing into control_data.
-     // Entries you do not write stay NaN, which means "leave unchanged".
+     // Entries you do not write stay unset, which means "leave unchanged".
      control_data->ctrl[0] = 0.5;
    }
 
@@ -706,8 +706,10 @@ Reads and writes are deliberately separated:
 * **Writing** commands uses the ``control_data`` buffer passed to ``update()``. This buffer is
   *write-only*: do not read simulation state out of it.
 
-``control_data`` uses a NaN sentinel. Every commandable field arrives filled with NaN, and only
-the entries a plugin actually writes are merged into the simulation. The commandable fields are:
+``control_data`` uses a sentinel: every commandable field arrives filled with
+``mujoco_ros2_control_plugins::kUnsetCommand``, and only the entries a plugin actually writes are
+merged into the simulation. Use that constant and the ``is_commanded()`` helper from the plugin base
+header rather than spelling out NaN yourself. The commandable fields are:
 
 .. list-table::
    :widths: 30 70
@@ -730,9 +732,9 @@ Every other field of ``control_data`` is unspecified and must not be read.
 
 .. warning::
 
-   NaN means "leave unchanged", so a command **persists** in the simulation until something
-   overwrites it. To *release* a command, write an explicit value (usually ``0.0``) rather than
-   simply stopping writing to that entry. The ``ExternalWrenchPlugin`` does exactly this when a
+   An unset entry means "leave unchanged", so a command **persists** in the simulation until
+   something overwrites it. To *release* a command, write an explicit value (usually ``0.0``) rather
+   than simply stopping writing to that entry. The ``ExternalWrenchPlugin`` does exactly this when a
    wrench expires.
 
 Because the merge is per entry rather than a whole-array overwrite, values a plugin does not

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -8,7 +8,8 @@ This separation allows for modular, optional features without adding complexity 
 .. note::
 
    This interface provides flexibility for accessing information from the MuJoCo model and data.
-   Users are responsible for handling that data correctly and avoiding changes to critical information.
+   Users are responsible for handling that data correctly and avoiding changes to critical
+   information. See `Reading State and Commanding the Simulation`_ for the read/write contract.
 
 
 Available Plugins
@@ -602,7 +603,7 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
    {
    public:
      bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-     void update(const mjModel* model, mjData* data) override;
+     void update(mjData* control_data) override;
      void cleanup() override;
 
    private:
@@ -631,9 +632,15 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
      return true;
    }
 
-   void MyCustomPlugin::update(const mjModel* model, mjData* data)
+   void MyCustomPlugin::update(mjData* control_data)
    {
-     // Called every control loop iteration
+     // Read simulation state through the const accessors...
+     const mjModel* model = get_mujoco_model();
+     const mjData* data = get_sim_data();
+
+     // ...and command the simulation by writing into control_data.
+     // Entries you do not write stay NaN, which means "leave unchanged".
+     control_data->ctrl[0] = 0.5;
    }
 
    void MyCustomPlugin::cleanup()
@@ -688,32 +695,84 @@ Create ``my_plugins.xml``:
    )
 
 
+Reading State and Commanding the Simulation
+-------------------------------------------
+
+Reads and writes are deliberately separated:
+
+* **Reading** simulation state uses ``get_sim_data()`` and ``get_mujoco_model()``, which return
+  the live MuJoCo containers as ``const`` pointers. They are populated before ``init()`` is called
+  and remain valid for the lifetime of the plugin.
+* **Writing** commands uses the ``control_data`` buffer passed to ``update()``. This buffer is
+  *write-only*: do not read simulation state out of it.
+
+``control_data`` uses a NaN sentinel. Every commandable field arrives filled with NaN, and only
+the entries a plugin actually writes are merged into the simulation. The commandable fields are:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Field
+     - Meaning
+   * - ``ctrl[nu]``
+     - Actuator controls
+   * - ``qfrc_applied[nv]``
+     - Applied generalized forces
+   * - ``xfrc_applied[6*nbody]``
+     - Applied Cartesian force/torque per body
+   * - ``qpos[nq]``
+     - Generalized positions
+   * - ``qvel[nv]``
+     - Generalized velocities
+
+Every other field of ``control_data`` is unspecified and must not be read.
+
+.. warning::
+
+   NaN means "leave unchanged", so a command **persists** in the simulation until something
+   overwrites it. To *release* a command, write an explicit value (usually ``0.0``) rather than
+   simply stopping writing to that entry. The ``ExternalWrenchPlugin`` does exactly this when a
+   wrench expires.
+
+Because the merge is per entry rather than a whole-array overwrite, values a plugin does not
+command are left alone. In particular, forces applied interactively by dragging a body in the
+native viewer survive on any body no plugin is commanding.
+
+.. note::
+
+   Writing ``qpos`` / ``qvel`` moves the simulation directly and bypasses the validation performed
+   by the ``~/reset_world`` and ``~/set_free_joint_state`` services. Invalid values will diverge
+   the simulation. Prefer those services where they fit.
+
+
 Plugin Lifecycle
 ----------------
 
 1. **Initialization** (``init``): Called once when the plugin is loaded. Use this to read
    parameters and set up publishers, subscribers, and services.
-2. **Update** (``update``): Called every simulation step at the **end of the** ``read`` **loop**,
-   before the controller update and ``write`` loops. Changes to ``mjData`` here are visible to
-   controllers and affect the next simulation step. This runs in a real-time thread — avoid
-   blocking operations.
+2. **Update** (``update``): Called once per physics-loop iteration, on the MuJoCo physics thread,
+   with the simulation mutex held, immediately before the simulation is stepped. Commands written
+   into ``control_data`` therefore affect the very next step.
 
-   ``data->qvel`` here has one special property: it is **NaN-filled before every plugin's**
-   ``update()`` **runs this cycle**. Most plugins never touch it and can ignore this entirely.
-   A plugin that needs to *dictate* a free joint's velocity exactly (``BaseVelocityPlugin`` is
-   the example in this package) can write a finite value into any ``qvel`` entry to request a
-   hard velocity override there — the core simulation applies every non-NaN entry as a direct
-   ``qvel`` write immediately before the next ``mj_step``, bypassing the normal mass/contact
-   dynamics for that DOF. This exists because plugins only ever see a throwaway copy of
-   ``mjData`` — only ``ctrl``, ``qfrc_applied``, and ``xfrc_applied`` are otherwise copied back
-   into the real simulation state, so this NaN convention is the only way a plugin can
-   influence ``qvel`` at all. Leaving an entry ``NaN`` keeps its normal physics-driven value;
-   because of this, ``data->qvel`` cannot be read here for the body's actual velocity either,
-   since it isn't restored to a real value until after every plugin's ``update()`` has run.
-   See ``MuJoCoROS2ControlPluginBase::update()``'s doc comment in
-   ``mujoco_ros2_control_plugins_base.hpp`` for the authoritative reference.
+   ``BaseVelocityPlugin`` is the example in this package of a plugin that dictates a free joint's
+   velocity exactly, by writing a finite value into ``control_data->qvel`` (see the commandable
+   fields table above).
 3. **Cleanup** (``cleanup``): Called when shutting down. Release any resources acquired in
    ``init``.
+
+.. warning::
+
+   ``update()`` runs on the physics thread while it holds the simulation mutex, which the native
+   viewer's render thread also needs. Blocking in ``update()`` stalls both the physics loop and
+   the viewer. Rate-limit expensive work and use non-blocking (realtime) publishers.
+
+.. note::
+
+   **Deprecated:** the older ``update(const mjModel* model, mjData* data)`` overload still
+   compiles and still receives the live, readable ``mjData``, so existing plugins keep working
+   unchanged. It logs a deprecation warning on its first call. Port to
+   ``update(mjData* control_data)`` with ``get_sim_data()`` / ``get_mujoco_model()``.
 
 
 Building

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -324,14 +324,14 @@ Velocity Override Behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each cycle, the commanded body-frame ``vx``/``vy`` is clamped to ``max_linear_velocity`` (preserving
-direction) and rotated into the world frame using the body's current orientation, since a free
-joint's linear ``qvel`` is expressed in the world frame. The commanded yaw-rate is clamped to
-``max_yaw_rate`` and used as-is, since a free joint's rotational ``qvel`` is already expressed in
-the body-local frame. The result is written directly into ``data->qvel`` during ``update()``:
-the core NaN-fills ``qvel`` before every plugin's ``update()`` runs, so writing a finite value
-into an entry requests a hard velocity override there, applied by the core simulation as a direct
-``qvel`` write immediately before the next physics step (see "Creating Your Own Plugin" below for
-the full mechanism, which is not available through ``xfrc_applied`` alone).
+direction) and rotated into the world frame using the body's current orientation (read via
+``get_sim_data()``), since a free joint's linear ``qvel`` is expressed in the world frame. The
+commanded yaw-rate is clamped to ``max_yaw_rate`` and used as-is, since a free joint's rotational
+``qvel`` is already expressed in the body-local frame. The result is written into
+``control_data->qvel`` during ``update()``, one of the commandable fields listed in `Reading State
+and Commanding the Simulation`_: writing a finite value into an entry requests a hard velocity
+override there, merged into the live simulation as a direct ``qvel`` write immediately before the
+next physics step.
 
 A command that hasn't been refreshed within ``cmd_timeout`` seconds is treated as zero (safety
 stop) rather than left to coast on the last commanded velocity.

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -15,6 +15,8 @@
 #ifndef MUJOCO_ROS2_CONTROL_PLUGINS__PLUGIN_BASE_HPP_
 #define MUJOCO_ROS2_CONTROL_PLUGINS__PLUGIN_BASE_HPP_
 
+#include <typeinfo>
+
 #include <mujoco/mujoco.h>
 #include <rclcpp/rclcpp.hpp>
 
@@ -24,15 +26,38 @@ namespace mujoco_ros2_control_plugins
 /**
  * @brief Base class for MuJoCo ROS 2 control plugins
  *
- * This is an example base class that plugins can inherit from.
- * Plugins can extend the functionality of mujoco_ros2_control
- * by implementing custom behaviors.
+ * Plugins extend the functionality of mujoco_ros2_control by implementing custom behaviours,
+ * such as publishing extra sensor topics or applying external forces to the simulation.
+ *
+ * Reads and writes are deliberately separated:
+ *
+ * - **Reading** simulation state is done through `get_sim_data()` and `get_mujoco_model()`, which
+ *   expose the live physics containers as const pointers.
+ * - **Writing** commands is done through the `control_data` buffer handed to `update()`. That
+ *   buffer is *write-only*: every commandable field arrives filled with NaN, and only the entries
+ *   a plugin actually writes are merged back into the simulation. NaN means "leave unchanged".
+ *
+ * @note `update()` is called from the MuJoCo physics thread while the simulation mutex is held.
+ * Blocking there stalls both the physics loop and the native viewer, so plugins must not perform
+ * blocking operations. Rate-limit expensive work and prefer non-blocking (realtime) publishers.
  */
 class MuJoCoROS2ControlPluginBase
 {
 public:
   virtual ~MuJoCoROS2ControlPluginBase() = default;
 
+  /**
+   * @brief Caches the simulation handles and initializes the plugin.
+   *
+   * Called once by mujoco_ros2_control when the plugin is loaded. Stores @p model and @p data so
+   * that `get_mujoco_model()` / `get_sim_data()` work for the lifetime of the plugin, then
+   * delegates to `init()`.
+   *
+   * @param node Shared pointer to the ROS 2 node for accessing parameters
+   * @param model Pointer to the live MuJoCo model
+   * @param data Pointer to the live MuJoCo data
+   * @return whatever `init()` returned: true if initialization was successful
+   */
   bool initialize(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data)
   {
     model_ = model;
@@ -53,26 +78,62 @@ public:
   virtual bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) = 0;
 
   /**
-   * @brief Update the plugin (called every simulation step)
-   * @param model Pointer to the MuJoCo model
-   * @param control_data Pointer to the MuJoCo data
-   * @note This method will be called at the end of the mujoco_ros2_control read loop, before the update loop of
-   * controllers and the write loop. This means that changes to the data here will be visible to controllers and will
-   * affect the next simulation step.
-   * @note This method will be called in a real-time thread, so it should avoid blocking operations and should be
-   * efficient.
-   * @note data->qvel is NaN-filled before every plugin's update() runs this cycle. Write a finite value into any
-   * entry to request a hard velocity override on that DOF -- it bypasses the normal mass/contact dynamics for that
-   * DOF this step, overwriting mj_data_->qvel directly right before the next mj_step. Leave an entry NaN to keep its
-   * normal physics-driven value untouched. This is the only channel a plugin has to influence qvel: unlike
-   * ctrl/qfrc_applied/xfrc_applied, data->qvel here cannot be read for the body's actual velocity, since it is not
-   * restored to a real value until after every plugin's update() has run this cycle.
+   * @brief Update the plugin, optionally commanding the simulation.
+   *
+   * @param control_data Write-only command buffer. Read simulation state via `get_sim_data()`.
+   *
+   * Only these fields of @p control_data are merged into the simulation, and only where the value
+   * is not NaN:
+   *
+   * - `ctrl[nu]`                actuator controls
+   * - `qfrc_applied[nv]`        applied generalized forces
+   * - `xfrc_applied[6*nbody]`   applied Cartesian force/torque per body
+   * - `qpos[nq]`                generalized positions
+   * - `qvel[nv]`               generalized velocities
+   *
+   * Every other field of @p control_data is unspecified and must not be read.
+   *
+   * @note NaN means "leave unchanged", so a command persists in the simulation until it is
+   * overwritten. To *release* a command, write an explicit value (e.g. `0.0`) rather than leaving
+   * the entry as NaN.
+   *
+   * @note Called once per physics-loop iteration, on the physics thread, with the simulation mutex
+   * held, immediately before the simulation is stepped. Writes are therefore visible to the very
+   * next step. Avoid blocking operations: they stall physics and the viewer.
    */
-  virtual void update(const mjModel* model, mjData* control_data) = 0;
-
-  virtual void update(mjData* control_data) override
+  virtual void update(mjData* control_data)
   {
-    update(model_, control_data);
+    // Reaching this default body means the plugin only implements the deprecated two-argument
+    // overload below. Forward the *live* data rather than control_data: a legacy plugin expects a
+    // readable mjData, and because we now run under the simulation mutex its direct writes to the
+    // live data are safe and land before the next step.
+    if (!legacy_update_warned_)
+    {
+      legacy_update_warned_ = true;
+      RCLCPP_WARN(rclcpp::get_logger("MuJoCoROS2ControlPluginBase"),
+                  "Plugin '%s' implements the deprecated update(const mjModel*, mjData*). It is now called from the "
+                  "physics thread and still receives the live mjData, so behaviour is unchanged. Please port to "
+                  "update(mjData* control_data), reading state via get_sim_data() / get_mujoco_model().",
+                  typeid(*this).name());
+    }
+    (void)control_data;
+    update(model_, sim_data_);
+  }
+
+  /**
+   * @brief Update the plugin (deprecated).
+   *
+   * @deprecated Implement `update(mjData* control_data)` instead. Plugins that only override this
+   * overload keep receiving the live MuJoCo data in @p data and continue to work, but they bypass
+   * the NaN-sentinel command buffer and log a deprecation warning on their first update.
+   *
+   * @param model Pointer to the MuJoCo model
+   * @param data Pointer to the live MuJoCo data
+   */
+  virtual void update(const mjModel* model, mjData* data)
+  {
+    (void)model;
+    (void)data;
   }
 
   /**
@@ -80,11 +141,20 @@ public:
    */
   virtual void cleanup() = 0;
 
+  /**
+   * @brief The live MuJoCo model, as cached by `initialize()`.
+   */
   const mjModel* get_mujoco_model() const
   {
     return model_;
   }
 
+  /**
+   * @brief The live MuJoCo simulation data, as cached by `initialize()`.
+   *
+   * @note Only safe to dereference from inside `update()`, where the simulation mutex is held by
+   * the caller. Reading it from any other thread races the physics loop.
+   */
   const mjData* get_sim_data() const
   {
     return sim_data_;
@@ -94,6 +164,8 @@ private:
   const mjModel* model_ = nullptr;
   mjData* sim_data_ = nullptr;
 
+  // Latches the one-shot deprecation warning emitted by the default update(mjData*) body.
+  bool legacy_update_warned_ = false;
 };
 
 }  // namespace mujoco_ros2_control_plugins

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -33,6 +33,13 @@ class MuJoCoROS2ControlPluginBase
 public:
   virtual ~MuJoCoROS2ControlPluginBase() = default;
 
+  bool initialize(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data)
+  {
+    model_ = model;
+    sim_data_ = data;
+    return init(node, model_, sim_data_);
+  }
+
   /**
    * @brief Initialize the plugin
    * @param node Shared pointer to the ROS 2 node for accessing parameters
@@ -48,7 +55,7 @@ public:
   /**
    * @brief Update the plugin (called every simulation step)
    * @param model Pointer to the MuJoCo model
-   * @param data Pointer to the MuJoCo data
+   * @param control_data Pointer to the MuJoCo data
    * @note This method will be called at the end of the mujoco_ros2_control read loop, before the update loop of
    * controllers and the write loop. This means that changes to the data here will be visible to controllers and will
    * affect the next simulation step.
@@ -61,12 +68,32 @@ public:
    * ctrl/qfrc_applied/xfrc_applied, data->qvel here cannot be read for the body's actual velocity, since it is not
    * restored to a real value until after every plugin's update() has run this cycle.
    */
-  virtual void update(const mjModel* model, mjData* data) = 0;
+  virtual void update(const mjModel* model, mjData* control_data) = 0;
+
+  virtual void update(mjData* control_data) override
+  {
+    update(model_, control_data);
+  }
 
   /**
    * @brief Cleanup the plugin
    */
   virtual void cleanup() = 0;
+
+  const mjModel* get_mujoco_model() const
+  {
+    return model_;
+  }
+
+  const mjData* get_sim_data() const
+  {
+    return sim_data_;
+  }
+
+private:
+  const mjModel* model_ = nullptr;
+  mjData* sim_data_ = nullptr;
+
 };
 
 }  // namespace mujoco_ros2_control_plugins

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -15,13 +15,55 @@
 #ifndef MUJOCO_ROS2_CONTROL_PLUGINS__PLUGIN_BASE_HPP_
 #define MUJOCO_ROS2_CONTROL_PLUGINS__PLUGIN_BASE_HPP_
 
-#include <typeinfo>
+#include <cmath>
+#include <limits>
+#include <string>
 
 #include <mujoco/mujoco.h>
 #include <rclcpp/rclcpp.hpp>
 
 namespace mujoco_ros2_control_plugins
 {
+
+/**
+ * @brief The value an unwritten entry of a command buffer holds: "leave this unchanged".
+ *
+ * This is the sentinel the whole command path is built on, so refer to it rather than spelling out
+ * a NaN literal. Anything else -- including a deliberate 0.0 -- is a command.
+ */
+inline constexpr mjtNum kUnsetCommand = std::numeric_limits<mjtNum>::quiet_NaN();
+
+/**
+ * @brief Whether @p value is a command rather than an unwritten entry.
+ */
+inline bool is_commanded(mjtNum value)
+{
+  return !std::isnan(value);
+}
+
+/**
+ * @brief Marks @p count entries of @p values as unset, i.e. commanding nothing.
+ */
+inline void mark_unset(mjtNum* values, int count)
+{
+  mju_fill(values, kUnsetCommand, count);
+}
+
+/**
+ * @brief Copies the commanded (non-unset) entries of @p commanded over @p destination.
+ *
+ * Entries left unset are skipped, so whatever is already in @p destination survives.
+ */
+inline void merge_commands(const mjtNum* commanded, mjtNum* destination, int count)
+{
+  for (int i = 0; i < count; ++i)
+  {
+    if (is_commanded(commanded[i]))
+    {
+      destination[i] = commanded[i];
+    }
+  }
+}
 
 /**
  * @brief Base class for MuJoCo ROS 2 control plugins
@@ -34,8 +76,16 @@ namespace mujoco_ros2_control_plugins
  * - **Reading** simulation state is done through `get_sim_data()` and `get_mujoco_model()`, which
  *   expose the live physics containers as const pointers.
  * - **Writing** commands is done through the `control_data` buffer handed to `update()`. That
- *   buffer is *write-only*: every commandable field arrives filled with NaN, and only the entries
- *   a plugin actually writes are merged back into the simulation. NaN means "leave unchanged".
+ *   buffer is *write-only*: every commandable field arrives filled with `kUnsetCommand`, and only
+ *   the entries a plugin actually writes are merged back into the simulation.
+ *
+ * The commandable fields of `control_data` are:
+ *
+ * - `ctrl[nu]`                actuator controls
+ * - `qfrc_applied[nv]`        applied generalized forces
+ * - `xfrc_applied[6*nbody]`   applied Cartesian force/torque per body
+ * - `qpos[nq]`                generalized positions
+ * - `qvel[nv]`                generalized velocities
  *
  * @note `update()` is called from the MuJoCo physics thread while the simulation mutex is held.
  * Blocking there stalls both the physics loop and the native viewer, so plugins must not perform
@@ -62,6 +112,8 @@ public:
   {
     model_ = model;
     sim_data_ = data;
+    // Remembered only so diagnostics can name the plugin the way the user configured it.
+    plugin_name_ = node ? node->get_fully_qualified_name() : "<unknown>";
     return init(node, model_, sim_data_);
   }
 
@@ -82,42 +134,47 @@ public:
    *
    * @param control_data Write-only command buffer. Read simulation state via `get_sim_data()`.
    *
-   * Only these fields of @p control_data are merged into the simulation, and only where the value
-   * is not NaN:
+   * Only the commandable fields listed in the class documentation are merged into the simulation,
+   * and only where the entry is a command rather than `kUnsetCommand`. Every other field of
+   * @p control_data is unspecified and must not be read.
    *
-   * - `ctrl[nu]`                actuator controls
-   * - `qfrc_applied[nv]`        applied generalized forces
-   * - `xfrc_applied[6*nbody]`   applied Cartesian force/torque per body
-   * - `qpos[nq]`                generalized positions
-   * - `qvel[nv]`               generalized velocities
-   *
-   * Every other field of @p control_data is unspecified and must not be read.
-   *
-   * @note NaN means "leave unchanged", so a command persists in the simulation until it is
-   * overwritten. To *release* a command, write an explicit value (e.g. `0.0`) rather than leaving
-   * the entry as NaN.
+   * @note An unset entry means "leave unchanged", so a command persists in the simulation until it
+   * is overwritten. To *release* a command, write an explicit value (e.g. `0.0`) rather than
+   * leaving the entry unset.
    *
    * @note Called once per physics-loop iteration, on the physics thread, with the simulation mutex
    * held, immediately before the simulation is stepped. Writes are therefore visible to the very
    * next step. Avoid blocking operations: they stall physics and the viewer.
    */
-  virtual void update(mjData* control_data)
+  virtual void update(mjData* /*control_data*/)
   {
-    // Reaching this default body means the plugin only implements the deprecated two-argument
-    // overload below. Forward the *live* data rather than control_data: a legacy plugin expects a
-    // readable mjData, and because we now run under the simulation mutex its direct writes to the
-    // live data are safe and land before the next step.
-    if (!legacy_update_warned_)
+    // Reaching this default body means the plugin did not override this overload. It either
+    // implements the deprecated one below, or it implements neither -- which we can tell apart
+    // because the deprecated overload's own default body raises the flag.
+    //
+    // Forward the *live* data rather than control_data: a legacy plugin expects a readable mjData,
+    // and because we now run under the simulation mutex its direct writes to the live data are
+    // safe and land before the next step.
+    base_legacy_update_invoked_ = false;
+    update(model_, sim_data_);
+
+    if (base_legacy_update_invoked_)
+    {
+      RCLCPP_ERROR_ONCE(logger(),
+                        "Plugin '%s' implements neither update(mjData*) nor the deprecated "
+                        "update(const mjModel*, mjData*), so it will never do anything. Check the "
+                        "signature -- update(mjData* control_data) is the one to override.",
+                        plugin_name_.c_str());
+    }
+    else if (!legacy_update_warned_)
     {
       legacy_update_warned_ = true;
-      RCLCPP_WARN(rclcpp::get_logger("MuJoCoROS2ControlPluginBase"),
+      RCLCPP_WARN(logger(),
                   "Plugin '%s' implements the deprecated update(const mjModel*, mjData*). It is now called from the "
                   "physics thread and still receives the live mjData, so behaviour is unchanged. Please port to "
                   "update(mjData* control_data), reading state via get_sim_data() / get_mujoco_model().",
-                  typeid(*this).name());
+                  plugin_name_.c_str());
     }
-    (void)control_data;
-    update(model_, sim_data_);
   }
 
   /**
@@ -125,15 +182,15 @@ public:
    *
    * @deprecated Implement `update(mjData* control_data)` instead. Plugins that only override this
    * overload keep receiving the live MuJoCo data in @p data and continue to work, but they bypass
-   * the NaN-sentinel command buffer and log a deprecation warning on their first update.
+   * the command buffer and log a deprecation warning on their first update.
    *
    * @param model Pointer to the MuJoCo model
    * @param data Pointer to the live MuJoCo data
    */
-  virtual void update(const mjModel* model, mjData* data)
+  virtual void update(const mjModel* /*model*/, mjData* /*data*/)
   {
-    (void)model;
-    (void)data;
+    // Only reached when the plugin overrides neither overload; see update(mjData*).
+    base_legacy_update_invoked_ = true;
   }
 
   /**
@@ -161,10 +218,23 @@ public:
   }
 
 private:
+  static rclcpp::Logger logger()
+  {
+    return rclcpp::get_logger("MuJoCoROS2ControlPluginBase");
+  }
+
   const mjModel* model_ = nullptr;
   mjData* sim_data_ = nullptr;
 
-  // Latches the one-shot deprecation warning emitted by the default update(mjData*) body.
+  // Configured name of this plugin, used only to make diagnostics identifiable.
+  std::string plugin_name_ = "<uninitialized>";
+
+  // Set by the deprecated overload's default body so update(mjData*) can tell "implements the
+  // deprecated overload" apart from "implements neither".
+  bool base_legacy_update_invoked_ = false;
+
+  // Latches the one-shot deprecation warning. RCLCPP_WARN_ONCE would not do: its static local is
+  // shared by every instance, so only the first legacy plugin in the process would be reported.
   bool legacy_update_warned_ = false;
 };
 

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -128,8 +128,15 @@ void BaseVelocityPlugin::storeCommand(double vx, double vy, double wz)
   latest_cmd_ = { vx, vy, wz, node_->get_clock()->now() };
 }
 
-void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
+void BaseVelocityPlugin::update(mjData* control_data)
 {
+  const mjData* sim_data = get_sim_data();
+  if (sim_data == nullptr)
+  {
+    RCLCPP_ERROR_ONCE(logger_, "BaseVelocityPlugin has no simulation data; skipping velocity override.");
+    return;
+  }
+
   // Step 1 - refresh the cached command from the subscription callback without
   // blocking the real-time thread; if the lock is contended, keep using the last
   // successfully cached values.
@@ -161,11 +168,12 @@ void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
   wz_cmd = mju_clip(wz_cmd, -max_yaw_rate_, max_yaw_rate_);
 
   // Step 4 - rotate the commanded body-frame linear velocity into the world frame (a free
-  // joint's linear qvel is world-frame)
-  const mjtNum* xmat = data->xmat + body_id_ * 9;
-  data->qvel[qvel_adr_ + 0] = xmat[0] * vx_cmd + xmat[1] * vy_cmd;
-  data->qvel[qvel_adr_ + 1] = xmat[3] * vx_cmd + xmat[4] * vy_cmd;
-  data->qvel[qvel_adr_ + 5] = wz_cmd;
+  // joint's linear qvel is world-frame), reading the body's current orientation from the live
+  // simulation data.
+  const mjtNum* xmat = sim_data->xmat + body_id_ * 9;
+  control_data->qvel[qvel_adr_ + 0] = xmat[0] * vx_cmd + xmat[1] * vy_cmd;
+  control_data->qvel[qvel_adr_ + 1] = xmat[3] * vx_cmd + xmat[4] * vy_cmd;
+  control_data->qvel[qvel_adr_ + 5] = wz_cmd;
 }
 
 void BaseVelocityPlugin::cleanup()

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -31,14 +31,14 @@ namespace mujoco_ros2_control_plugins
 /**
  * @brief Drives a mobile/floating-base robot from a commanded planar body velocity
  *        (vx, vy, yaw-rate) by writing a hard kinematic override of the base's free-joint
- *        velocity directly into data->qvel every cycle (see
+ *        velocity into control_data->qvel every cycle (see
  *        MuJoCoROS2ControlPluginBase::update()'s doc comment for the NaN convention this
  *        relies on).
  *
  * Wheel-terrain friction/slip modelling is often unreliable enough to make it a poor
  * foundation for testing navigation stacks. This plugin instead subscribes to a
  * cmd_vel-style topic and, every cycle, writes the (optionally clamped) commanded planar
- * velocity directly into the base body's free-joint qvel entries in data. There is no
+ * velocity into the base body's free-joint qvel entries of control_data. There is no
  * gain to tune and no convergence delay: the measured body velocity on the driven DOFs is
  * exactly the commanded velocity on the very next simulation step.
  *
@@ -73,7 +73,7 @@ public:
   ~BaseVelocityPlugin() override = default;
 
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
   void cleanup() override;
 
 private:

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -28,11 +28,10 @@ bool CameraPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjDa
   return this->init(node, model, data, glfwInit);
 }
 
-bool CameraPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data, GlfwInitFn glfw_init_fn)
+bool CameraPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* /*data*/, GlfwInitFn glfw_init_fn)
 {
   node_ = node;
   mj_model_ = model;
-  mj_data_ = data;
 
   // Ensure the logger has a name
   logger_ = node_->get_logger().get_child(node->get_sub_namespace());

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -64,16 +64,20 @@ bool CameraPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjDa
   return true;
 }
 
-void CameraPlugin::update(const mjModel* model_arg, mjData* data)
+void CameraPlugin::update(mjData* /*control_data*/)
 {
   if (!publish_images_)
   {
     return;
   }
 
+  const mjModel* model_arg = get_mujoco_model();
+  const mjData* data = get_sim_data();
+
   // Streaming cameras render on a fixed-rate clock; polled cameras render as soon as a
-  // trigger has been received. Both are serviced here, on the sim thread, because this is
-  // the only place we can safely snapshot the live mjData without racing the simulation.
+  // trigger has been received. Both are serviced here, on the physics thread with the sim mutex
+  // held, because this is the only place we can safely snapshot the live mjData without racing
+  // the simulation.
   // TODO: Support per-camera publish rates?
   const auto now = node_->get_clock()->now();
   const bool stream_due =

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -228,7 +228,6 @@ private:
   // Ensures locked access to simulation data for rendering.
   std::recursive_mutex* sim_mutex_{ nullptr };
 
-  mjData* mj_data_;
   const mjModel* mj_model_;
   mjData* mj_camera_data_;
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -159,7 +159,7 @@ public:
    * @param glfw_init_fn Function used to attempt GLFW initialization; same signature as `glfwInit`.
    */
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data, GlfwInitFn glfw_init_fn);
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
   void cleanup() override;
 
   /**

--- a/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
@@ -55,15 +55,21 @@ bool ExternalWrenchPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* mod
   return true;
 }
 
-void ExternalWrenchPlugin::update(const mjModel* /*model_arg*/, mjData* data)
+void ExternalWrenchPlugin::update(mjData* control_data)
 {
-  // Step 0 - undo the xfrc_applied contributions written in the previous cycle
-  // so stale forces are never left in the array when all wrenches have expired.
-  // When the system interface also zeroes xfrc_applied before calling update(),
-  // this loop is a harmless no-op on already-zero values.
+  const mjData* sim_data = get_sim_data();
+  if (sim_data == nullptr)
+  {
+    RCLCPP_ERROR_ONCE(logger_, "ExternalWrenchPlugin has no simulation data; skipping wrench application.");
+    return;
+  }
+
+  // Step 0 - release the contributions commanded in the previous cycle. control_data arrives
+  // NaN-filled ("leave unchanged"), so an expired wrench has to be cleared with an explicit zero
+  // or the previously applied force would persist in the simulation indefinitely.
   for (const int body_id : prev_written_body_ids_)
   {
-    mjtNum* base = data->xfrc_applied + body_id * 6;
+    mjtNum* base = control_data->xfrc_applied + body_id * 6;
     for (int j = 0; j < 6; ++j)
     {
       base[j] = 0.0;
@@ -94,8 +100,7 @@ void ExternalWrenchPlugin::update(const mjModel* /*model_arg*/, mjData* data)
     return;
   }
 
-  // Step 2 - accumulate each active wrench into xfrc_applied.
-  // Step 0 already cleared our previous contributions, so += is equivalent to a fresh write.
+  // Step 2 - accumulate each active wrench into control_data->xfrc_applied.
   //
   // xfrc_applied[body*6 .. body*6+5] = (force_world[3], torque_world_at_xipos[3])
   const rclcpp::Time now_apply = node_->get_clock()->now();
@@ -114,10 +119,11 @@ void ExternalWrenchPlugin::update(const mjModel* /*model_arg*/, mjData* data)
       }
     }
 
-    // Body pose in world frame. xmat is row-major 3×3 (body → world).
-    const mjtNum* xpos = data->xpos + w.body_id * 3;
-    const mjtNum* xmat = data->xmat + w.body_id * 9;
-    const mjtNum* xipos = data->xipos + w.body_id * 3;  // inertial CoM in world frame
+    // Body pose in world frame, read from the live simulation data. xmat is row-major 3×3
+    // (body → world).
+    const mjtNum* xpos = sim_data->xpos + w.body_id * 3;
+    const mjtNum* xmat = sim_data->xmat + w.body_id * 9;
+    const mjtNum* xipos = sim_data->xipos + w.body_id * 3;  // inertial CoM in world frame
 
     // Transform application_point from body-local to world frame.
     const mjtNum point_world[3] = {
@@ -145,17 +151,25 @@ void ExternalWrenchPlugin::update(const mjModel* /*model_arg*/, mjData* data)
                                         torque_world[2] + r[0] * force_world[1] - r[1] * force_world[0] };
 
     const int base = w.body_id * 6;
-    for (int j = 0; j < 3; ++j)
-    {
-      data->xfrc_applied[base + j] += force_world[j];
-      data->xfrc_applied[base + 3 + j] += torque_at_xipos[j];
-    }
 
-    // Track which body slots we touched so Step 0 can undo them next cycle.
+    // Seed the slot the first time this cycle touches this body. Step 0 only zeroed the bodies
+    // commanded in the *previous* cycle, so a newly commanded body still holds the NaN sentinel
+    // and accumulating into it would produce NaN. Doubles as the record of which slots we
+    // commanded, so Step 0 can release them next cycle.
     if (std::find(prev_written_body_ids_.begin(), prev_written_body_ids_.end(), w.body_id) ==
         prev_written_body_ids_.end())
     {
       prev_written_body_ids_.push_back(w.body_id);
+      for (int j = 0; j < 6; ++j)
+      {
+        control_data->xfrc_applied[base + j] = 0.0;
+      }
+    }
+
+    for (int j = 0; j < 3; ++j)
+    {
+      control_data->xfrc_applied[base + j] += force_world[j];
+      control_data->xfrc_applied[base + 3 + j] += torque_at_xipos[j];
     }
   }
 

--- a/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
@@ -58,22 +58,17 @@ bool ExternalWrenchPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* mod
 void ExternalWrenchPlugin::update(mjData* control_data)
 {
   const mjData* sim_data = get_sim_data();
-  if (sim_data == nullptr)
-  {
-    RCLCPP_ERROR_ONCE(logger_, "ExternalWrenchPlugin has no simulation data; skipping wrench application.");
-    return;
-  }
 
-  // Step 0 - release the contributions commanded in the previous cycle. control_data arrives
-  // NaN-filled ("leave unchanged"), so an expired wrench has to be cleared with an explicit zero
-  // or the previously applied force would persist in the simulation indefinitely.
+  // Claims a body's slot for this cycle by commanding an explicit zero. Needed in two places:
+  // control_data arrives unset ("leave unchanged"), so an expired wrench must be released with a
+  // real zero rather than by simply not writing it, and a slot we are about to accumulate into has
+  // to start from zero rather than from the unset sentinel.
+  const auto claim_slot = [control_data](int body_id) { mju_zero(control_data->xfrc_applied + body_id * 6, 6); };
+
+  // Step 0 - release the contributions commanded in the previous cycle.
   for (const int body_id : prev_written_body_ids_)
   {
-    mjtNum* base = control_data->xfrc_applied + body_id * 6;
-    for (int j = 0; j < 6; ++j)
-    {
-      base[j] = 0.0;
-    }
+    claim_slot(body_id);
   }
   prev_written_body_ids_.clear();
 
@@ -100,7 +95,17 @@ void ExternalWrenchPlugin::update(mjData* control_data)
     return;
   }
 
-  // Step 2 - accumulate each active wrench into control_data->xfrc_applied.
+  // Step 2 - claim every slot we are about to command, and record it so Step 0 releases it next
+  // cycle. Doing this as a pre-pass keeps one meaning per variable and avoids searching
+  // prev_written_body_ids_ inside the accumulation loop; zeroing twice for two wrenches on the same
+  // body is harmless.
+  for (const ActiveWrench& wrench : active_wrenches_)
+  {
+    claim_slot(wrench.body_id);
+    prev_written_body_ids_.push_back(wrench.body_id);
+  }
+
+  // Step 3 - accumulate each active wrench into control_data->xfrc_applied.
   //
   // xfrc_applied[body*6 .. body*6+5] = (force_world[3], torque_world_at_xipos[3])
   const rclcpp::Time now_apply = node_->get_clock()->now();
@@ -151,29 +156,11 @@ void ExternalWrenchPlugin::update(mjData* control_data)
                                         torque_world[2] + r[0] * force_world[1] - r[1] * force_world[0] };
 
     const int base = w.body_id * 6;
-
-    // Seed the slot the first time this cycle touches this body. Step 0 only zeroed the bodies
-    // commanded in the *previous* cycle, so a newly commanded body still holds the NaN sentinel
-    // and accumulating into it would produce NaN. Doubles as the record of which slots we
-    // commanded, so Step 0 can release them next cycle.
-    if (std::find(prev_written_body_ids_.begin(), prev_written_body_ids_.end(), w.body_id) ==
-        prev_written_body_ids_.end())
-    {
-      prev_written_body_ids_.push_back(w.body_id);
-      for (int j = 0; j < 6; ++j)
-      {
-        control_data->xfrc_applied[base + j] = 0.0;
-      }
-    }
-
-    for (int j = 0; j < 3; ++j)
-    {
-      control_data->xfrc_applied[base + j] += force_world[j];
-      control_data->xfrc_applied[base + 3 + j] += torque_at_xipos[j];
-    }
+    mju_addTo3(control_data->xfrc_applied + base, force_world);
+    mju_addTo3(control_data->xfrc_applied + base + 3, torque_at_xipos);
   }
 
-  // Step 3 - remove expired wrenches.  Expiry is checked AFTER applying so
+  // Step 4 - remove expired wrenches.  Expiry is checked AFTER applying so
   //          that zero-duration wrenches are applied for exactly one simulation
   //          step before being discarded (as documented in the header).
   const rclcpp::Time now = node_->get_clock()->now();
@@ -183,7 +170,7 @@ void ExternalWrenchPlugin::update(mjData* control_data)
 
   service_requested_.store(!active_wrenches_.empty(), std::memory_order_release);
 
-  // Step 4 - publish RViz markers for all currently active (non-expired) wrenches.
+  // Step 5 - publish RViz markers for all currently active (non-expired) wrenches.
   publish_markers();
 }
 

--- a/mujoco_ros2_control_plugins/src/external_wrench_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/external_wrench_plugin.hpp
@@ -64,10 +64,11 @@ namespace mujoco_ros2_control_plugins
  *
  * Implementation notes
  * --------------------
- * Forces are written into data->xfrc_applied (Cartesian 6D force/torque per
- * body, world frame, applied at the body's inertial CoM xipos).  MuJoCo reads
- * this array during mj_step and both applies the force AND renders it as an
- * arrow in the native viewer when "Perturb forces" is enabled.
+ * Forces are commanded through control_data->xfrc_applied (Cartesian 6D
+ * force/torque per body, world frame, applied at the body's inertial CoM
+ * xipos).  MuJoCo reads this array during mj_step and both applies the force
+ * AND renders it as an arrow in the native viewer when "Perturb forces" is
+ * enabled.
  *
  * The service input is expressed in the body's local frame at an arbitrary
  * application point.  The plugin converts this to the world-frame wrench at
@@ -77,16 +78,17 @@ namespace mujoco_ros2_control_plugins
  *   τ_world      = R * τ_body
  *   τ_at_xipos   = τ_world + (p_world − xipos) × F_world
  *
- * where R = data->xmat (body → world rotation) and
- *       p_world = data->xpos + R * application_point_body.
+ * where R = get_sim_data()->xmat (body → world rotation) and
+ *       p_world = get_sim_data()->xpos + R * application_point_body.
  *
- * At the start of every update() call the plugin zeroes the xfrc_applied slots
- * it wrote during the previous cycle before re-accumulating the current active
- * wrenches.  This self-cleanup ensures the plugin leaves no stale contributions
- * in xfrc_applied when all wrenches have expired.  When the surrounding system
- * interface also zeroes xfrc_applied before calling update() (as
- * MujocoSystemInterface::read() does), the plugin's undo step is a harmless
- * no-op on already-zero values.
+ * Releasing a force requires an explicit write.  Entries left untouched in
+ * control_data are NaN, meaning "leave unchanged", so a force that is simply
+ * no longer written would persist in the simulation indefinitely.  The plugin
+ * therefore tracks the bodies it commanded in the previous cycle and writes an
+ * explicit 0.0 into their slots at the start of the next update(), before
+ * re-accumulating the currently active wrenches.  For the same reason, a body
+ * touched for the first time in a cycle has its slot zeroed before the
+ * per-wrench contributions are accumulated into it.
  */
 class ExternalWrenchPlugin : public MuJoCoROS2ControlPluginBase
 {
@@ -95,7 +97,7 @@ public:
   ~ExternalWrenchPlugin() override = default;
 
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
   void cleanup() override;
 
   /**
@@ -156,8 +158,10 @@ private:
   // Active wrenches — only modified inside update()
   std::vector<ActiveWrench> active_wrenches_;
 
-  // Body IDs whose xfrc_applied slots were written in the previous update() call.
-  // Zeroed at the start of the next update() before re-accumulating.
+  // Body IDs whose xfrc_applied slots were commanded in the previous update() call. Explicitly
+  // zeroed at the start of the next update() before re-accumulating, so an expired wrench is
+  // actually released rather than left in place by the NaN ("leave unchanged") sentinel. Also
+  // rebuilt during accumulation to track which slots have been zeroed this cycle.
   std::vector<int> prev_written_body_ids_;
 
   // Marker visualization scaling

--- a/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.cpp
@@ -142,8 +142,9 @@ bool FreeJointStatePublisherPlugin::init(rclcpp::Node::SharedPtr node, const mjM
   return true;
 }
 
-void FreeJointStatePublisherPlugin::update(const mjModel* /*model*/, mjData* data)
+void FreeJointStatePublisherPlugin::update(mjData* /*control_data*/)
 {
+  const mjData* data = get_sim_data();
   const rclcpp::Time now = node_->get_clock()->now();
   if (now - last_publish_time_ < publish_period_)
   {

--- a/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.hpp
@@ -57,7 +57,7 @@ public:
   ~FreeJointStatePublisherPlugin() override = default;
 
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
   void cleanup() override;
 
 private:

--- a/mujoco_ros2_control_plugins/src/heartbeat_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/heartbeat_publisher_plugin.cpp
@@ -36,8 +36,9 @@ bool HeartbeatPublisherPlugin::init(rclcpp::Node::SharedPtr node, const mjModel*
   return true;
 }
 
-void HeartbeatPublisherPlugin::update(const mjModel* /*model*/, mjData* data)
+void HeartbeatPublisherPlugin::update(mjData* /*control_data*/)
 {
+  const mjData* data = get_sim_data();
   auto current_time = node_->get_clock()->now();
   auto elapsed = current_time - last_publish_time_;
 

--- a/mujoco_ros2_control_plugins/src/heartbeat_publisher_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/heartbeat_publisher_plugin.hpp
@@ -39,7 +39,7 @@ public:
   /**
    * @brief Update the plugin (called every simulation step)
    */
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
 
   /**
    * @brief Cleanup the plugin

--- a/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.cpp
@@ -301,8 +301,9 @@ bool Mujoco3dLidarPlugin::register_sensor(const mjModel* model, int sensor_idx)
   return true;
 }
 
-void Mujoco3dLidarPlugin::update(const mjModel* /* model */, mjData* data)
+void Mujoco3dLidarPlugin::update(mjData* /*control_data*/)
 {
+  const mjData* data = get_sim_data();
   for (Lidar3dConfig& lidar : lidar_sensors_)
   {
     // Check for new sensor data, and skip if not yet computed, stale, or otherwise

--- a/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.hpp
@@ -99,7 +99,7 @@ public:
    * nothing. If so, this will copy the sensor data into a relevant message type and
    * publish it.
    */
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
 
   /**
    * @brief Destructs the plugin and all relevant data.

--- a/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.cpp
@@ -191,8 +191,9 @@ bool RangefinderLidarPlugin::register_sensor(const std::string& lidar_name, cons
   return true;
 }
 
-void RangefinderLidarPlugin::update(const mjModel* /*model*/, mjData* data)
+void RangefinderLidarPlugin::update(mjData* /*control_data*/)
 {
+  const mjData* data = get_sim_data();
   if (lidar_sensors_.empty())
   {
     return;

--- a/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.cpp
@@ -49,7 +49,6 @@ std::pair<std::string, int> RangefinderLidarPlugin::parse_lidar_name(const std::
 bool RangefinderLidarPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* /*data*/)
 {
   node_ = node;
-  model_ = model;
   lidar_sensors_.clear();
 
   const std::string param_prefix = "mujoco_plugins.rangefinder_lidar_plugin.";

--- a/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.hpp
@@ -83,7 +83,7 @@ class [[deprecated("We recommend using the 3d Lidar plugin instead."
 {
 public:
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-  void update(const mjModel* model, mjData* data) override;
+  void update(mjData* control_data) override;
   void cleanup() override;
 
 private:

--- a/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.hpp
@@ -115,7 +115,6 @@ private:
   static std::pair<std::string, int> parse_lidar_name(const std::string& sensor_name);
 
   rclcpp::Node::SharedPtr node_;
-  const mjModel* model_{ nullptr };
   double publish_rate_{ 5.0 };
   rclcpp::Time last_publish_time_{ 0, 0, RCL_ROS_TIME };
 

--- a/mujoco_ros2_control_plugins/test/test_3d_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_3d_lidar_plugin.cpp
@@ -31,6 +31,10 @@
 
 #include "mujoco_3d_lidar_plugin.hpp"
 
+// These plugins are read-only: they publish simulation state and never command anything, so the
+// write-only control_data buffer handed to update() is unused.
+static mjData* const kNoCommands = nullptr;
+
 class Mujoco3dLidarPluginTest : public ::testing::Test
 {
 protected:
@@ -151,8 +155,8 @@ TEST_F(Mujoco3dLidarPluginTest, InitSucceedsWithNoLidar)
 </mujoco>
 )");
   mujoco_ros2_control_plugins::Mujoco3dLidarPlugin plugin;
-  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
-  plugin.update(model_, data_);
+  EXPECT_TRUE(plugin.initialize(plugin_node_, model_, data_));
+  plugin.update(kNoCommands);
   plugin.cleanup();
 }
 
@@ -189,7 +193,7 @@ TEST_F(Mujoco3dLidarPluginTest, Test2dLidar)
 )");
 
   mujoco_ros2_control_plugins::Mujoco3dLidarPlugin plugin;
-  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
+  EXPECT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   // Create subscriber to default topic
   std::atomic<bool> got_scan{ false };
@@ -204,7 +208,7 @@ TEST_F(Mujoco3dLidarPluginTest, Test2dLidar)
   for (int i = 0; i < 20; ++i)
   {
     mj_step(model_, data_);
-    plugin.update(model_, data_);
+    plugin.update(kNoCommands);
     if (got_scan)
       break;
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -261,7 +265,7 @@ TEST_F(Mujoco3dLidarPluginTest, Test3dLidarSyncAsync)
 )");
 
     mujoco_ros2_control_plugins::Mujoco3dLidarPlugin plugin;
-    EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
+    EXPECT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
     // Create subscriber to default topic
     std::atomic<bool> got_cloud{ false };
@@ -276,7 +280,7 @@ TEST_F(Mujoco3dLidarPluginTest, Test3dLidarSyncAsync)
     for (int i = 0; i < 60; ++i)
     {
       mj_step(model_, data_);
-      plugin.update(model_, data_);
+      plugin.update(kNoCommands);
       if (got_cloud)
         break;
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -116,6 +116,10 @@ protected:
     data_ = mj_makeData(model_);
     ASSERT_NE(data_, nullptr);
     mj_forward(model_, data_);
+
+    // Separate write-only command buffer, mirroring what the physics loop hands to plugins.
+    control_data_ = mj_makeData(model_);
+    ASSERT_NE(control_data_, nullptr);
   }
 
   void TearDown() override
@@ -128,6 +132,8 @@ protected:
     executor_.reset();
     plugin_node_.reset();
     node_.reset();
+    mj_deleteData(control_data_);
+    control_data_ = nullptr;
     mj_deleteData(data_);
     data_ = nullptr;
     mj_deleteModel(model_);
@@ -149,16 +155,18 @@ protected:
     return model_->jnt_qposadr[0];
   }
 
-  /// NaN-fills this body's 6 qvel entries, mirroring the real system's per-cycle pre-fill
-  /// (MujocoSystemInterface::write()) so tests can verify which entries the plugin leaves
-  /// untouched versus which it overrides.
-  void fillQvelNaN()
+  /// Presents the command buffer's qvel the way the physics loop does: every entry unset
+  /// (NaN), which means "leave unchanged". Mirrors MujocoSimulation::run_plugin_updates().
+  void resetControlData()
   {
-    const int adr = dofAdr();
-    for (int i = 0; i < 6; ++i)
-    {
-      data_->qvel[adr + i] = std::numeric_limits<double>::quiet_NaN();
-    }
+    mju_fill(control_data_->qvel, std::numeric_limits<mjtNum>::quiet_NaN(), model_->nv);
+  }
+
+  /// Runs one plugin update cycle against a freshly unset command buffer.
+  void updatePlugin(mujoco_ros2_control_plugins::BaseVelocityPlugin& plugin)
+  {
+    resetControlData();
+    plugin.update(control_data_);
   }
 
   /// Declares "body" (defaulting to "base_link") and initializes a plugin instance with it.
@@ -170,7 +178,7 @@ protected:
       plugin_node_->declare_parameter(paramName("body"), body_name);
     }
     auto plugin = std::make_unique<mujoco_ros2_control_plugins::BaseVelocityPlugin>();
-    EXPECT_TRUE(plugin->init(plugin_node_, model_, data_));
+    EXPECT_TRUE(plugin->initialize(plugin_node_, model_, data_));
     return plugin;
   }
 
@@ -190,6 +198,7 @@ protected:
 
   mjModel* model_{ nullptr };
   mjData* data_{ nullptr };
+  mjData* control_data_{ nullptr };
   rclcpp::Node::SharedPtr node_;
   rclcpp::Node::SharedPtr plugin_node_;
 
@@ -203,7 +212,7 @@ TEST_F(BaseVelocityPluginTest, InitFailsForUnknownBody)
   plugin_node_->declare_parameter(paramName("body"), std::string("does_not_exist"));
 
   mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
-  EXPECT_FALSE(plugin.init(plugin_node_, model_, data_));
+  EXPECT_FALSE(plugin.initialize(plugin_node_, model_, data_));
   plugin.cleanup();
 }
 
@@ -225,7 +234,7 @@ TEST_F(BaseVelocityPluginTest, InitFailsForBodyWithoutFreeJoint)
   mujoco_ros2_control_plugins::BaseVelocityPlugin plugin;
   // A velocity override has nowhere to write without a free joint, so init() must fail
   // outright rather than merely warn as the old force-servo design did.
-  EXPECT_FALSE(plugin.init(plugin_node_, welded_model, welded_data));
+  EXPECT_FALSE(plugin.initialize(plugin_node_, welded_model, welded_data));
   plugin.cleanup();
 
   mj_deleteData(welded_data);
@@ -235,11 +244,10 @@ TEST_F(BaseVelocityPluginTest, InitFailsForBodyWithoutFreeJoint)
 TEST_F(BaseVelocityPluginTest, NoCommandRequestsZeroVelocity)
 {
   auto plugin = makeInitializedPlugin();
-  fillQvelNaN();
 
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   EXPECT_DOUBLE_EQ(qvel[0], 0.0);
   EXPECT_DOUBLE_EQ(qvel[1], 0.0);
   EXPECT_DOUBLE_EQ(qvel[5], 0.0);
@@ -256,12 +264,11 @@ TEST_F(BaseVelocityPluginTest, NoCommandRequestsZeroVelocity)
 TEST_F(BaseVelocityPluginTest, CommandIsReportedAsOverride)
 {
   auto plugin = makeInitializedPlugin();
-  fillQvelNaN();
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.3);
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   // Identity orientation => body-x == world-x. This is a direct assignment, not a servo,
   // so the commanded value is reached immediately -- no convergence tolerance needed.
   EXPECT_NEAR(qvel[0], 1.0, 1e-9);
@@ -282,13 +289,13 @@ TEST_F(BaseVelocityPluginTest, StaleCommandRequestsZeroVelocity)
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
 
-  plugin->update(model_, data_);
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  updatePlugin(*plugin);
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   ASSERT_GT(qvel[0], 0.0) << "sanity: velocity requested while command is fresh";
 
   // Wait past the timeout without publishing again.
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
   EXPECT_NEAR(qvel[0], 0.0, 1e-9) << "stale command should be treated as zero";
 
@@ -301,9 +308,9 @@ TEST_F(BaseVelocityPluginTest, LinearCommandIsClampedToMaxLinearVelocity)
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/5.0, /*vy=*/0.0, /*wz=*/0.0);
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[0], 0.2, 1e-9);
 
   plugin->cleanup();
@@ -315,9 +322,9 @@ TEST_F(BaseVelocityPluginTest, YawCommandIsClampedToMaxYawRate)
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/5.0);
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[5], 0.3, 1e-9);
 
   plugin->cleanup();
@@ -330,9 +337,9 @@ TEST_F(BaseVelocityPluginTest, UnsetLimitsDoNotClamp)
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/1000.0, /*vy=*/0.0, /*wz=*/1000.0);
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[0], 1000.0, 1e-6);
   EXPECT_NEAR(qvel[5], 1000.0, 1e-6);
 
@@ -355,9 +362,9 @@ TEST_F(BaseVelocityPluginTest, BodyFrameCommandIsRotatedIntoFreeJointFrame)
   mj_forward(model_, data_);
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
-  plugin->update(model_, data_);
+  updatePlugin(*plugin);
 
-  const mjtNum* qvel = data_->qvel + dofAdr();
+  const mjtNum* qvel = control_data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[0], 0.0, 1e-6) << "world-x should be ~0 after a 90 deg yaw";
   EXPECT_NEAR(qvel[1], 1.0, 1e-6) << "commanded body-x should land on world-y";
 

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -32,6 +32,10 @@
 
 using namespace std::chrono_literals;
 
+// These plugins are read-only: they publish simulation state and never command anything, so the
+// write-only control_data buffer handed to update() is unused.
+static mjData* const kNoCommands = nullptr;
+
 class CameraPluginTest : public ::testing::Test
 {
 protected:
@@ -184,8 +188,8 @@ TEST_F(CameraPluginTest, InitSucceedsWithNoCameras)
   ASSERT_EQ(model_->ncam, 0);
 
   mujoco_ros2_control_plugins::CameraPlugin plugin;
-  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
-  plugin.update(model_, data_);
+  EXPECT_TRUE(plugin.initialize(plugin_node_, model_, data_));
+  plugin.update(kNoCommands);
   plugin.cleanup();
 }
 

--- a/mujoco_ros2_control_plugins/test/test_external_wrench_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_external_wrench_plugin.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -98,6 +99,10 @@ protected:
     data_ = mj_makeData(model_);
     ASSERT_NE(data_, nullptr);
     mj_forward(model_, data_);
+
+    // Separate write-only command buffer, mirroring what the physics loop hands to plugins.
+    control_data_ = mj_makeData(model_);
+    ASSERT_NE(control_data_, nullptr);
   }
 
   void TearDown() override
@@ -110,10 +115,41 @@ protected:
     executor_.reset();
     plugin_node_.reset();
     node_.reset();
+    mj_deleteData(control_data_);
+    control_data_ = nullptr;
     mj_deleteData(data_);
     data_ = nullptr;
     mj_deleteModel(model_);
     model_ = nullptr;
+  }
+
+  /// Presents the command buffer the way the physics loop does: every entry unset (NaN), which
+  /// means "leave unchanged".
+  void resetControlData()
+  {
+    mju_fill(control_data_->xfrc_applied, std::numeric_limits<mjtNum>::quiet_NaN(), model_->nbody * 6);
+  }
+
+  /// Runs one plugin update cycle against a freshly unset command buffer.
+  void updatePlugin(mujoco_ros2_control_plugins::ExternalWrenchPlugin& plugin)
+  {
+    resetControlData();
+    plugin.update(control_data_);
+  }
+
+  /// Total magnitude the plugin actually commanded this cycle. Entries left unset (NaN) are
+  /// skipped, since they command nothing.
+  double commandedMagnitude() const
+  {
+    double total = 0.0;
+    for (int i = 0; i < model_->nbody * 6; ++i)
+    {
+      if (!std::isnan(control_data_->xfrc_applied[i]))
+      {
+        total += std::abs(control_data_->xfrc_applied[i]);
+      }
+    }
+    return total;
   }
 
   /// Sends a zero-duration wrench service request (no blocking sleep in the
@@ -141,6 +177,7 @@ protected:
 
   mjModel* model_{ nullptr };
   mjData* data_{ nullptr };
+  mjData* control_data_{ nullptr };
   rclcpp::Node::SharedPtr node_;
   rclcpp::Node::SharedPtr plugin_node_;
 
@@ -195,14 +232,14 @@ private:
 TEST_F(ExternalWrenchPluginTest, InitSucceeds)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
+  EXPECT_TRUE(plugin.initialize(plugin_node_, model_, data_));
   plugin.cleanup();
 }
 
 TEST_F(ExternalWrenchPluginTest, ServiceRejectsUnknownBodyName)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto resp = callServiceZeroDuration("nonexistent_body", /*fx=*/1.0);
   ASSERT_NE(resp, nullptr);
@@ -215,7 +252,7 @@ TEST_F(ExternalWrenchPluginTest, ServiceRejectsUnknownBodyName)
 TEST_F(ExternalWrenchPluginTest, ServiceAcceptsValidBodyName)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto resp = callServiceZeroDuration("test_body", /*fx=*/1.0);
   ASSERT_NE(resp, nullptr);
@@ -228,12 +265,13 @@ TEST_F(ExternalWrenchPluginTest, ServiceAcceptsValidBodyName)
 TEST_F(ExternalWrenchPluginTest, UpdateAppliesForceToXfrcApplied)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
-  // All xfrc_applied entries must start at zero.
+  // The command buffer starts fully unset: the plugin commands nothing until it writes.
+  resetControlData();
   for (int i = 0; i < model_->nbody * 6; ++i)
   {
-    EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0);
+    EXPECT_TRUE(std::isnan(control_data_->xfrc_applied[i])) << "xfrc_applied[" << i << "] did not start unset";
   }
 
   // Apply 10 N in body-frame X (≡ world-frame X at identity orientation).
@@ -241,15 +279,9 @@ TEST_F(ExternalWrenchPluginTest, UpdateAppliesForceToXfrcApplied)
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
-  // At least one xfrc_applied entry must carry a non-zero value.
-  double total = 0.0;
-  for (int i = 0; i < model_->nbody * 6; ++i)
-  {
-    total += std::abs(data_->xfrc_applied[i]);
-  }
-  EXPECT_GT(total, 0.0) << "xfrc_applied should be non-zero after applying a force";
+  EXPECT_GT(commandedMagnitude(), 0.0) << "xfrc_applied should be non-zero after applying a force";
 
   plugin.cleanup();
 }
@@ -257,22 +289,31 @@ TEST_F(ExternalWrenchPluginTest, UpdateAppliesForceToXfrcApplied)
 TEST_F(ExternalWrenchPluginTest, UpdateUndoesPreviousContributionOnNextCall)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto resp = callServiceZeroDuration("test_body", /*fx=*/10.0);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
   // First update: wrench applied, then immediately expired (zero duration).
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
-  // Second update: plugin subtracts its saved contribution; no active wrenches remain.
-  plugin.update(model_, data_);
+  // Second update: no active wrenches remain, so the plugin must release the force it applied.
+  updatePlugin(plugin);
 
-  for (int i = 0; i < model_->nbody * 6; ++i)
+  // The release has to be an *explicit* zero. Leaving the slot unset (NaN) would mean "leave
+  // unchanged", and the expired force would stay applied in the simulation indefinitely.
+  const int body_id = mj_name2id(model_, mjOBJ_BODY, "test_body");
+  ASSERT_GE(body_id, 0);
+  for (int j = 0; j < 6; ++j)
   {
-    EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0) << "xfrc_applied[" << i << "] not zeroed after wrench expiry";
+    const mjtNum released = control_data_->xfrc_applied[body_id * 6 + j];
+    EXPECT_FALSE(std::isnan(released)) << "xfrc_applied slot " << j
+                                       << " was left unset, so the expired wrench "
+                                          "would remain applied";
+    EXPECT_DOUBLE_EQ(released, 0.0) << "xfrc_applied slot " << j << " not zeroed after wrench expiry";
   }
+  EXPECT_DOUBLE_EQ(commandedMagnitude(), 0.0) << "No force should be commanded after the wrench expired";
 
   plugin.cleanup();
 }
@@ -280,7 +321,7 @@ TEST_F(ExternalWrenchPluginTest, UpdateUndoesPreviousContributionOnNextCall)
 TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   // Queue two equal wrenches simultaneously.
   {
@@ -295,16 +336,12 @@ TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
   }
 
   // First update: both wrenches active, both expire (zero duration).
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
-  double total_both = 0.0;
-  for (int i = 0; i < model_->nbody * 6; ++i)
-  {
-    total_both += std::abs(data_->xfrc_applied[i]);
-  }
+  const double total_both = commandedMagnitude();
 
   // Second update clears state.
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
   // Queue a single wrench of the same magnitude.
   {
@@ -313,13 +350,9 @@ TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
     ASSERT_TRUE(r->success);
   }
 
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
-  double total_one = 0.0;
-  for (int i = 0; i < model_->nbody * 6; ++i)
-  {
-    total_one += std::abs(data_->xfrc_applied[i]);
-  }
+  const double total_one = commandedMagnitude();
 
   ASSERT_GT(total_one, 0.0) << "Single wrench should produce non-zero xfrc_applied";
   // Two equal wrenches must contribute exactly twice as much as one.
@@ -331,7 +364,7 @@ TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
 TEST_F(ExternalWrenchPluginTest, TorqueOnlyWrenchAppliesRotationalForce)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   // Apply only a torque (no force) about body-frame Z.
   auto resp = callServiceZeroDuration("test_body", /*fx=*/0.0, /*fy=*/0.0, /*fz=*/0.0,
@@ -339,14 +372,9 @@ TEST_F(ExternalWrenchPluginTest, TorqueOnlyWrenchAppliesRotationalForce)
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
-  double total = 0.0;
-  for (int i = 0; i < model_->nbody * 6; ++i)
-  {
-    total += std::abs(data_->xfrc_applied[i]);
-  }
-  EXPECT_GT(total, 0.0) << "xfrc_applied should be non-zero after applying a torque";
+  EXPECT_GT(commandedMagnitude(), 0.0) << "xfrc_applied should be non-zero after applying a torque";
 
   plugin.cleanup();
 }
@@ -354,7 +382,7 @@ TEST_F(ExternalWrenchPluginTest, TorqueOnlyWrenchAppliesRotationalForce)
 TEST_F(ExternalWrenchPluginTest, SingleCallWithMultipleWrenchesAppliesAll)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   // Send two wrenches in a single service call: 5 N in X and 5 N in Y.
   auto client = plugin_node_->create_client<ApplyExternalWrench>("apply_wrench");
@@ -382,14 +410,9 @@ TEST_F(ExternalWrenchPluginTest, SingleCallWithMultipleWrenchesAppliesAll)
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
-  double total = 0.0;
-  for (int i = 0; i < model_->nbody * 6; ++i)
-  {
-    total += std::abs(data_->xfrc_applied[i]);
-  }
-  EXPECT_GT(total, 0.0) << "Both wrenches in the batch should produce non-zero xfrc_applied";
+  EXPECT_GT(commandedMagnitude(), 0.0) << "Both wrenches in the batch should produce non-zero xfrc_applied";
 
   plugin.cleanup();
 }
@@ -397,7 +420,7 @@ TEST_F(ExternalWrenchPluginTest, SingleCallWithMultipleWrenchesAppliesAll)
 TEST_F(ExternalWrenchPluginTest, SingleCallRejectsIfAnyBodyNameInvalid)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto client = plugin_node_->create_client<ApplyExternalWrench>("apply_wrench");
   ASSERT_TRUE(client->wait_for_service(std::chrono::seconds(2)));
@@ -426,11 +449,13 @@ TEST_F(ExternalWrenchPluginTest, SingleCallRejectsIfAnyBodyNameInvalid)
   EXPECT_FALSE(resp->success) << "Request with one invalid body name must be rejected entirely";
   EXPECT_FALSE(resp->message.empty());
 
-  // No wrench should have been applied — xfrc_applied must remain zero.
-  plugin.update(model_, data_);
+  // No wrench should have been applied — the plugin must command nothing at all, leaving every
+  // entry unset so the simulation is untouched.
+  updatePlugin(plugin);
   for (int i = 0; i < model_->nbody * 6; ++i)
   {
-    EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0) << "xfrc_applied[" << i << "] must be zero after rejected batch";
+    EXPECT_TRUE(std::isnan(control_data_->xfrc_applied[i]))
+        << "xfrc_applied[" << i << "] was commanded after a rejected batch";
   }
 
   plugin.cleanup();
@@ -439,7 +464,7 @@ TEST_F(ExternalWrenchPluginTest, SingleCallRejectsIfAnyBodyNameInvalid)
 TEST_F(ExternalWrenchPluginTest, PublishMarkersForActiveForceWrench)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   // Send a wrench with a 200 ms duration from a background thread so the
   // sleeping service callback does not block update() in the main thread.
@@ -449,7 +474,7 @@ TEST_F(ExternalWrenchPluginTest, PublishMarkersForActiveForceWrench)
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
   // Run update() while the wrench is still active.
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
   // Collect markers via the new aggregation API.
   MarkerArray markers;
@@ -481,10 +506,10 @@ TEST_F(ExternalWrenchPluginTest, PublishMarkersForActiveForceWrench)
 TEST_F(ExternalWrenchPluginTest, PublishMarkersContributesNothingWhenNoWrenchesActive)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   // No service calls — no active wrenches.
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
   // publish_markers() must not append anything when there are no active wrenches.
   // Marker lifetime-based expiry (managed by the system interface) handles cleanup
@@ -500,11 +525,11 @@ TEST_F(ExternalWrenchPluginTest, PublishMarkersContributesNothingWhenNoWrenchesA
 TEST_F(ExternalWrenchPluginTest, PublishMarkersAppendsToExistingArray)
 {
   mujoco_ros2_control_plugins::ExternalWrenchPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   std::thread svc_thread([this]() { callServiceWithDuration("test_body", 0.2, /*fx=*/5.0, /*fy=*/0.0, /*fz=*/0.0); });
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  plugin.update(model_, data_);
+  updatePlugin(plugin);
 
   // Pre-populate the array with a sentinel marker (simulates another plugin's contribution).
   MarkerArray markers;

--- a/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
@@ -51,6 +51,10 @@ constexpr const char* kMjcf = R"(
 )";
 }  // namespace
 
+// These plugins are read-only: they publish simulation state and never command anything, so the
+// write-only control_data buffer handed to update() is unused.
+static mjData* const kNoCommands = nullptr;
+
 class FreeJointStatePublisherPluginTest : public ::testing::Test
 {
 protected:
@@ -175,7 +179,7 @@ protected:
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     while (!received && std::chrono::steady_clock::now() < deadline)
     {
-      plugin.update(model_, data_);
+      plugin.update(kNoCommands);
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     return last_msg;
@@ -194,7 +198,7 @@ private:
 TEST_F(FreeJointStatePublisherPluginTest, InitSucceeds)
 {
   mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
-  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_));
+  EXPECT_TRUE(plugin.initialize(plugin_node_, model_, data_));
   plugin.cleanup();
 }
 
@@ -213,7 +217,7 @@ TEST_F(FreeJointStatePublisherPluginTest, WorldFrameDefaultsPublishAllFreeBodies
   mj_forward(model_, data_);
 
   mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto msg = waitForMessage("free_joint_states", plugin);
   ASSERT_NE(msg, nullptr) << "No FreeJointStateArray received";
@@ -253,7 +257,7 @@ TEST_F(FreeJointStatePublisherPluginTest, BodyNamesFilterRestrictsPublishedBodie
   setParam("body_names", std::vector<std::string>{ "free_b" });
 
   mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto msg = waitForMessage("free_joint_states", plugin);
   ASSERT_NE(msg, nullptr);
@@ -279,7 +283,7 @@ TEST_F(FreeJointStatePublisherPluginTest, NonWorldFrameTransformsPoseAndTwistRou
   setParam("body_names", std::vector<std::string>{ "free_a" });
 
   mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_));
 
   auto msg = waitForMessage("free_joint_states", plugin);
   ASSERT_NE(msg, nullptr);
@@ -333,7 +337,7 @@ TEST_F(FreeJointStatePublisherPluginTest, UnknownFrameIdFallsBackToWorld)
   setParam("body_names", std::vector<std::string>{ "free_a" });
 
   mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
-  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_)) << "init() must not fail on an unknown frame_id";
+  ASSERT_TRUE(plugin.initialize(plugin_node_, model_, data_)) << "init() must not fail on an unknown frame_id";
 
   auto msg = waitForMessage("free_joint_states", plugin);
   ASSERT_NE(msg, nullptr);
@@ -352,5 +356,5 @@ TEST_F(FreeJointStatePublisherPluginTest, InitRejectsUnknownBodyNameInFilter)
   setParam("body_names", std::vector<std::string>{ "nonexistent_body" });
 
   mujoco_ros2_control_plugins::FreeJointStatePublisherPlugin plugin;
-  EXPECT_FALSE(plugin.init(plugin_node_, model_, data_));
+  EXPECT_FALSE(plugin.initialize(plugin_node_, model_, data_));
 }

--- a/mujoco_ros2_control_tests/src/test_plugin.cpp
+++ b/mujoco_ros2_control_tests/src/test_plugin.cpp
@@ -11,7 +11,7 @@ public:
   {
     return true;
   }
-  void update(const mjModel*, mjData*) override
+  void update(mjData*) override
   {
   }
   void cleanup() override


### PR DESCRIPTION


## Description

Inspired from the discussions started in https://github.com/ros-controls/mujoco_ros2_control/pull/254#discussion_r3716344976


### Is this user-facing behavior change?

A bit yes, what mjData is parsed to update of the plugin

### Did you use Generative AI?

Idea is written down, but mostly brainstormed andd implemented with Claude

### Additional Information
I think this approach is interesting as it doesn't need a lot of handshakes of data and this should be pretty easy to expand for plugins, and I moved the plugins update cycle to the physics loop, so we don't need different datas

## TODOs

To send us a pull request, please:

- [ ] Fork the repository.
- [ ] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [ ] Commit to your fork using clear commit messages.
- [ ] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
