### PR TITLE
Use collision-tag meshes/info for collision geoms (primitives, STL/DAE/OBJ)

### DIFF
--- a/mujoco_ros2_control/docs/tools.rst
+++ b/mujoco_ros2_control/docs/tools.rst
@@ -128,11 +128,20 @@ Rough outline of the automated conversion process
      Duplicate mesh files will have an ``_N`` appended to them to avoid conflicts in the output ``assets`` folder.
      For instance, if running multiple types of UR robots in one sim, there will be multiple ``shoulder.dae`` files.
 
-- Reads absolute filepaths of all meshes and converts either ``.dae`` or ``.stl`` to ``.obj`` using trimesh.
+- Reads absolute filepaths of all meshes (from both ``<visual>`` and ``<collision>`` tags) and
+  converts either ``.dae`` or ``.stl`` to ``.obj`` using trimesh.
 
   - Puts all meshes into an ``assets/`` folder under ``mjcf_data/`` relative to current working dir.
   - Modifies filepaths again in URDF to point to the ``assets/`` folder.
   - Decomposes large meshes into multiple components to ensure convex hulls.
+
+- Handles visual and collision geometry independently:
+
+  - The ``<visual>`` geometry is used purely for rendering (the ``visual`` class).
+  - The ``<collision>`` geometry drives physics (the ``collision`` class). When a link defines no
+    ``<collision>``, a collision is synthesized from its ``<visual>`` so the visual mesh is reused
+    as the collision shape (the previous behaviour). This synthesis happens at the URDF level, so it
+    stays correct per link even when MuJoCo fuses fixed-jointed bodies together.
 
 - Publishes the new formatted robot description XML file that can be used for conversion.
 - Converts the new robot description URDF file.

--- a/mujoco_ros2_control/mujoco_ros2_control/__init__.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/__init__.py
@@ -15,6 +15,7 @@
 from .urdf_to_mujoco_utils import (
     add_mujoco_info,
     remove_tag,
+    add_missing_collisions,
     extract_mesh_info,
     replace_package_names,
     get_images_from_dae,
@@ -47,6 +48,7 @@ from .urdf_to_mujoco_utils import (
 __all__ = [
     "add_mujoco_info",
     "remove_tag",
+    "add_missing_collisions",
     "extract_mesh_info",
     "replace_package_names",
     "get_images_from_dae",

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -538,18 +538,27 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
 
 def update_non_obj_assets(dom, output_filepath):
     """
-    We want to take the group 1 objects that get created, and turn them into the equivalent
-    but both in group 2 and in group 3. That means taking something like this
+    Classifies the geoms that MuJoCo imported from the URDF into the "visual" and
+    "collision" default classes. Because the source URDF now always carries both a
+    <visual> and a <collision> per renderable link (the latter synthesized from the
+    visual when missing, see add_missing_collisions), MuJoCo emits a separate geom for
+    each, and we simply tag them rather than duplicating a single geom.
+
+    MuJoCo imports a URDF <visual> as a geom that still carries its raw import
+    attributes, e.g.
         <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="finger_v6"/>
-    and turning it into this
-        <geom mesh="finger_v6" class="visual" pos="0 0 0" quat="0.707107 0.707107 0 0"/>
-        <geom mesh="finger_v6" class="collision" pos="0 0 0" quat="0.707107 0.707107 0 0"/>
+    and a <collision> as a plain collidable geom with no contype. So:
 
-    To do this, we need to add in class visual, and class collision to them, keep the rgba on the visual one, and
-    get rid of the other components (type, contype, conaffinity, group, density)
+    - A geom WITH a contype attribute is a visual: it becomes
+        <geom mesh="finger_v6" class="visual" rgba="0.2 0.2 0.2 1" .../>
+      keeping its rgba but dropping the raw import attributes (contype, conaffinity,
+      group, density).
+    - A geom WITHOUT a contype attribute is a collision: it becomes
+        <geom mesh="finger_v6" class="collision" .../>
+      and its rgba (if any) is dropped since collisions are not rendered.
 
-    We can tell that we need to modify it because it will have a contype attribute attached to it (not the best way
-    but I guess it works for now)
+    Geoms that already carry a class attribute (e.g. those expanded by
+    update_obj_assets) are left untouched.
     """
 
     # Find the <worldbody> element
@@ -559,39 +568,27 @@ def update_non_obj_assets(dom, output_filepath):
     # get all of the geom elements in the worldbody element
     worldbody_geoms = worldbody_element.getElementsByTagName("geom")
 
-    # elements to remove
+    # raw import attributes that should not survive on a classified visual geom
     remove_attributes = ["contype", "conaffinity", "group", "density"]
 
     for geom in worldbody_geoms:
-        if not geom.hasAttribute("contype"):
-            pass
-        else:
-            collision_geom = geom.cloneNode(False)
+        # already classified upstream (e.g. obj-decomposed meshes); leave as is
+        if geom.hasAttribute("class"):
+            continue
 
-            # if there is no type associated, make the type sphere explicitly
-            if not collision_geom.hasAttribute("type"):
-                collision_geom.setAttribute("type", "sphere")
-
-            # set to collision class
-            collision_geom.setAttribute("class", "collision")
+        if geom.hasAttribute("contype"):
+            # visual geom: keep rgba, strip the raw import attributes
+            geom.setAttribute("class", "visual")
             for attribute in remove_attributes:
-                if collision_geom.hasAttribute(attribute):
-                    collision_geom.removeAttribute(attribute)
-
-            # most of the components are the same between collision and visual, so just copy it
-            visual_geom = collision_geom.cloneNode(False)
-            visual_geom.setAttribute("class", "visual")
-
-            # remove rgba from collision geom bc it isn't necessary
+                if geom.hasAttribute(attribute):
+                    geom.removeAttribute(attribute)
+        else:
+            # collision geom: ensure a type, drop rgba (not rendered)
+            if not geom.hasAttribute("type"):
+                geom.setAttribute("type", "sphere")
+            geom.setAttribute("class", "collision")
             if geom.hasAttribute("rgba"):
-                collision_geom.removeAttribute("rgba")
-
-            # get the parent of the geom node, and remove the old element
-            parent = geom.parentNode
-            parent.removeChild(geom)
-            # add the new collision and visual specific elements
-            parent.appendChild(collision_geom)
-            parent.appendChild(visual_geom)
+                geom.removeAttribute("rgba")
 
     return dom
 

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -125,9 +125,12 @@ def add_missing_collisions(xml_string):
 
 def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
     """
-    Builds a dictionary of all unique visual meshes in the URDF and rewrites the
-    raw_xml so every mesh filename points at a disambiguated path. There are some
-    gotchas:
+    Builds a dictionary of all unique meshes in the URDF (from both <visual> and
+    <collision> tags) and rewrites the raw_xml so every mesh filename points at a
+    disambiguated path. Visuals are processed first so their <material> color wins;
+    a collision that reuses a visual's mesh file shares that asset, while a distinct
+    collision mesh gets its own entry (defaulting to white, as collisions carry no
+    material). There are some gotchas:
 
     - Different URDF meshes can share a filename stem, so colliding stems get an
       "__N" suffix so each resolves to its own asset directory. For example, if
@@ -166,99 +169,123 @@ def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
                     return tuple(ref.color.rgba)
         return (1.0, 1.0, 1.0, 1.0)
 
-    for link in robot.links:
-        for vis in link.visuals:
-            geom = vis.geometry
-            if not (geom and hasattr(geom, "filename")):
-                continue
+    # Track which source mesh files have already been turned into an asset entry so a
+    # collision that reuses a visual's mesh (the fallback case) shares the same asset
+    # instead of producing a duplicate. Visuals are processed first so their material
+    # color wins; collisions then only add entries for genuinely distinct meshes.
+    processed_uris = set()
 
-            uri = geom.filename  # full URI
-            original_stem = pathlib.Path(uri).stem  # NEW: remember original for disambiguation
-            stem = original_stem
-            counter = 0
-            while stem in stem_to_original_uri and stem_to_original_uri[stem] != uri:
-                counter += 1
-                stem = f"{original_stem}__{counter}"
-            stem_to_original_uri[stem] = uri
+    def process_geometry(element, is_collision):
+        nonlocal raw_xml
+        geom = element.geometry
+        if not (geom and hasattr(geom, "filename")):
+            return
 
-            # Select the mesh file: use a pre-generated OBJ if available and valid; otherwise use the original
-            is_pre_generated = False
-            new_uri = uri  # default fallback
+        uri = geom.filename  # full URI
 
-            if asset_dir:
-                if original_stem in decompose_dict:
-                    # Decomposed mesh: check if a pre-generated OBJ exists and threshold matches
-                    mesh_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/{stem}/{stem}/{stem}.obj"
-                    settings_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/metadata.json"
+        # A collision reusing a visual's mesh file shares that already-built asset.
+        if is_collision and uri in processed_uris:
+            return
 
-                    if os.path.exists(mesh_file) and os.path.exists(settings_file):
-                        try:
-                            with open(settings_file) as f:
-                                data = json.load(f)
-                                used_threshold = float(data.get(f"{stem}"))
-                        except (FileNotFoundError, PermissionError, json.JSONDecodeError) as e:
-                            print(f"Warning: could not read thresholds for {stem}: {e}")
-                            used_threshold = None
-                        # Use existing decomposed object only if it has the same threshold, otherwise regenerate it.
-                        if used_threshold is not None and math.isclose(
-                            used_threshold, float(decompose_dict[original_stem]), rel_tol=1e-9
-                        ):
-                            new_uri = mesh_file
-                            is_pre_generated = True
-                            raw_xml = raw_xml.replace(geom.filename, new_uri)
-                        else:
-                            print(
-                                f"Existing decomposed obj for {stem} has different threshold {used_threshold} "
-                                f"than required {decompose_dict[original_stem]}. Regenerating..."
-                            )
-                else:
-                    # Composed mesh: check if a pre-generated OBJ exists
-                    mesh_file = f"{asset_dir}/{COMPOSED_PATH_NAME}/{stem}/{stem}.obj"
+        original_stem = pathlib.Path(uri).stem  # NEW: remember original for disambiguation
+        stem = original_stem
+        counter = 0
+        while stem in stem_to_original_uri and stem_to_original_uri[stem] != uri:
+            counter += 1
+            stem = f"{original_stem}__{counter}"
+        stem_to_original_uri[stem] = uri
 
-                    if os.path.exists(mesh_file):
+        # Select the mesh file: use a pre-generated OBJ if available and valid; otherwise use the original
+        is_pre_generated = False
+        new_uri = uri  # default fallback
+
+        if asset_dir:
+            if original_stem in decompose_dict:
+                # Decomposed mesh: check if a pre-generated OBJ exists and threshold matches
+                mesh_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/{stem}/{stem}/{stem}.obj"
+                settings_file = f"{asset_dir}/{DECOMPOSED_PATH_NAME}/metadata.json"
+
+                if os.path.exists(mesh_file) and os.path.exists(settings_file):
+                    try:
+                        with open(settings_file) as f:
+                            data = json.load(f)
+                            used_threshold = float(data.get(f"{stem}"))
+                    except (FileNotFoundError, PermissionError, json.JSONDecodeError) as e:
+                        print(f"Warning: could not read thresholds for {stem}: {e}")
+                        used_threshold = None
+                    # Use existing decomposed object only if it has the same threshold, otherwise regenerate it.
+                    if used_threshold is not None and math.isclose(
+                        used_threshold, float(decompose_dict[original_stem]), rel_tol=1e-9
+                    ):
                         new_uri = mesh_file
                         is_pre_generated = True
                         raw_xml = raw_xml.replace(geom.filename, new_uri)
+                    else:
+                        print(
+                            f"Existing decomposed obj for {stem} has different threshold {used_threshold} "
+                            f"than required {decompose_dict[original_stem]}. Regenerating..."
+                        )
+            else:
+                # Composed mesh: check if a pre-generated OBJ exists
+                mesh_file = f"{asset_dir}/{COMPOSED_PATH_NAME}/{stem}/{stem}.obj"
 
-            scale = " ".join(f"{v}" for v in geom.scale) if geom.scale else "1.0 1.0 1.0"
-            rgba = resolve_color(vis)
+                if os.path.exists(mesh_file):
+                    new_uri = mesh_file
+                    is_pre_generated = True
+                    raw_xml = raw_xml.replace(geom.filename, new_uri)
 
-            mesh_dict_value = {
+        scale = " ".join(f"{v}" for v in geom.scale) if geom.scale else "1.0 1.0 1.0"
+        # Collision elements carry no <material>, so they default to white.
+        rgba = (1.0, 1.0, 1.0, 1.0) if is_collision else resolve_color(element)
+
+        mesh_dict_value = {
+            "is_pre_generated": is_pre_generated,
+            "filename": new_uri,
+            "scale": scale,
+            "color": rgba,
+        }
+
+        # this source mesh file has now been accounted for
+        processed_uris.add(uri)
+
+        # check to see if the values we are trying to add already exist
+        existing_identifier = None
+        for key, value in mesh_info_dict.items():
+            if mesh_dict_value.items() <= value.items():
+                existing_identifier = key
+                break
+
+        # if the values we want to add are not in the dictionary yet, add them
+        if existing_identifier is None:
+            # get the name of the new file so that we can reference it later, but grab correct
+            # pre generated asset if it exists
+            path_obj = pathlib.Path(new_uri)
+            if is_pre_generated:
+                new_filepath = str(path_obj.parent.parent / stem / (stem + path_obj.suffix))
+            else:
+                new_filepath = str(path_obj.parent / (stem + path_obj.suffix))
+
+            # add the unique name to the dictionary
+            mesh_info_dict[stem] = {
                 "is_pre_generated": is_pre_generated,
                 "filename": new_uri,
                 "scale": scale,
                 "color": rgba,
+                "new_filepath": new_filepath,
             }
 
-            # check to see if the values we are trying to add already exist
-            existing_identifier = None
-            for key, value in mesh_info_dict.items():
-                if mesh_dict_value.items() <= value.items():
-                    existing_identifier = key
-                    break
+            # if we changed the identifier, make sure we update it in the underlying file
+            if stem != pathlib.Path(new_uri).stem:
+                raw_xml = raw_xml.replace(new_uri, new_filepath)
 
-            # if the values we want to add are not in the dictionary yet, add them
-            if existing_identifier is None:
-                # get the name of the new file so that we can reference it later, but grab correct
-                # pre generated asset if it exists
-                path_obj = pathlib.Path(new_uri)
-                if is_pre_generated:
-                    new_filepath = str(path_obj.parent.parent / stem / (stem + path_obj.suffix))
-                else:
-                    new_filepath = str(path_obj.parent / (stem + path_obj.suffix))
-
-                # add the unique name to the dictionary
-                mesh_info_dict[stem] = {
-                    "is_pre_generated": is_pre_generated,
-                    "filename": new_uri,
-                    "scale": scale,
-                    "color": rgba,
-                    "new_filepath": new_filepath,
-                }
-
-                # if we changed the identifier, make sure we update it in the underlying file
-                if stem != pathlib.Path(new_uri).stem:
-                    raw_xml = raw_xml.replace(new_uri, new_filepath)
+    # First pass: visual meshes (their material color wins). Second pass: collision
+    # meshes, which only add genuinely distinct meshes thanks to processed_uris.
+    for link in robot.links:
+        for vis in link.visuals:
+            process_geometry(vis, is_collision=False)
+    for link in robot.links:
+        for col in link.collisions:
+            process_geometry(col, is_collision=True)
 
     return mesh_info_dict, raw_xml
 
@@ -478,10 +505,16 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
             body = sub_dom.getElementsByTagName("body")
             body_element = body[0]
             sub_geoms = body_element.getElementsByTagName("geom")
+            # raw import attributes that should not survive on a classified geom
+            remove_attributes = ["contype", "conaffinity", "group", "density"]
             for geom_element in worldbody_geoms:
                 if geom_element.getAttribute("mesh") == mesh_name:
                     pos = geom_element.getAttribute("pos")
                     quat = geom_element.getAttribute("quat")
+                    # A visual geom from a URDF <visual> keeps its contype marker; a
+                    # collision geom does not. Tag the expanded sub-geoms accordingly so
+                    # obj-converted collision meshes land in the collision class.
+                    is_visual = geom_element.hasAttribute("contype")
 
                     parent = geom_element.parentNode
                     parent.removeChild(geom_element)
@@ -489,6 +522,15 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                         sub_geom_local = sub_geom.cloneNode(False)
                         sub_geom_local.setAttribute("pos", pos)
                         sub_geom_local.setAttribute("quat", quat)
+                        for attribute in remove_attributes:
+                            if sub_geom_local.hasAttribute(attribute):
+                                sub_geom_local.removeAttribute(attribute)
+                        if is_visual:
+                            sub_geom_local.setAttribute("class", "visual")
+                        else:
+                            sub_geom_local.setAttribute("class", "collision")
+                            if sub_geom_local.hasAttribute("rgba"):
+                                sub_geom_local.removeAttribute("rgba")
                         parent.appendChild(sub_geom_local)
 
     return dom

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -84,6 +84,45 @@ def remove_tag(xml_string, tag_to_remove):
     return xmldoc.toprettyxml()
 
 
+def add_missing_collisions(xml_string):
+    """
+    Ensures every link that can be rendered can also collide, while respecting any
+    collision geometry the URDF author already provided.
+
+    For each <link> that has at least one <visual> but no <collision>, a <collision>
+    is synthesized for every visual by copying that visual's <geometry> and <origin>.
+    Links that already declare a collision are left untouched (the authored collision
+    drives physics), and links without any visual are left untouched.
+
+    Establishing this fallback at the URDF level - before MuJoCo conversion and any
+    static-body fusion - keeps the visual->collision fallback correct per link: the
+    visual meshes are used purely for rendering while the collision geometry (authored
+    when present, copied from the visual otherwise) is used for physics.
+
+    :param xml_string: the URDF as a string
+    :returns: the URDF string with synthesized collisions added where they were missing
+    """
+    dom = minidom.parseString(xml_string)
+
+    for link in dom.getElementsByTagName("link"):
+        visuals = [c for c in link.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "visual"]
+        collisions = [c for c in link.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "collision"]
+
+        # Respect authored collisions and skip links with nothing to render.
+        if collisions or not visuals:
+            continue
+
+        for visual in visuals:
+            collision = dom.createElement("collision")
+            # Copy the geometry and origin (collisions carry no material in URDF).
+            for child in visual.childNodes:
+                if child.nodeType == child.ELEMENT_NODE and child.tagName in ("geometry", "origin"):
+                    collision.appendChild(child.cloneNode(deep=True))
+            link.appendChild(collision)
+
+    return dom.toprettyxml()
+
+
 def extract_mesh_info(raw_xml, asset_dir, decompose_dict):
     """
     Builds a dictionary of all unique visual meshes in the URDF and rewrites the

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -450,7 +450,11 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
     for mesh in meshes:
         mesh_name = mesh.getAttribute("name")
 
-        # This should definitely be there, otherwise something is horribly wrong
+        # MuJoCo emits an auto-renamed sibling asset (e.g., "my_mesh1") when the same mesh
+        # file is referenced with a different scale. Leave these referencing the whole mesh.
+        if mesh_name not in mesh_info_dict:
+            continue
+
         scale = mesh_info_dict[mesh_name]["scale"]
 
         mesh_path = ""
@@ -520,8 +524,10 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                     parent.removeChild(geom_element)
                     for sub_geom in sub_geoms:
                         sub_geom_local = sub_geom.cloneNode(False)
-                        sub_geom_local.setAttribute("pos", pos)
-                        sub_geom_local.setAttribute("quat", quat)
+                        if pos:
+                            sub_geom_local.setAttribute("pos", pos)
+                        if quat:
+                            sub_geom_local.setAttribute("quat", quat)
                         for attribute in remove_attributes:
                             if sub_geom_local.hasAttribute(attribute):
                                 sub_geom_local.removeAttribute(attribute)
@@ -576,16 +582,18 @@ def update_non_obj_assets(dom, output_filepath):
         if geom.hasAttribute("class"):
             continue
 
+        # Ensure a type: the saved model omits type="sphere" (MuJoCo's default).
+        if not geom.hasAttribute("type"):
+            geom.setAttribute("type", "sphere")
+
         if geom.hasAttribute("contype"):
-            # visual geom: keep rgba, strip the raw import attributes
+            # visual geom: keep rgba, strip the raw import attributes.
             geom.setAttribute("class", "visual")
             for attribute in remove_attributes:
                 if geom.hasAttribute(attribute):
                     geom.removeAttribute(attribute)
         else:
-            # collision geom: ensure a type, drop rgba (not rendered)
-            if not geom.hasAttribute("type"):
-                geom.setAttribute("type", "sphere")
+            # collision geom: drop rgba (not rendered)
             geom.setAttribute("class", "collision")
             if geom.hasAttribute("rgba"):
                 geom.removeAttribute("rgba")

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -484,9 +484,11 @@ def main(args=None):
     # Add required MuJoCo tags to the starting URDF
     xml_data = mrc.add_mujoco_info(urdf, output_filepath, parsed_args.publish_topic, parsed_args.fuse)
 
-    # get rid of collision data, assuming the visual data is much better resolution.
-    # not sure if this is the best move...
-    xml_data = mrc.remove_tag(xml_data, "collision")
+    # Keep authored collision geometry so it drives the MuJoCo collision geoms, and
+    # only synthesize a collision from the visual for links that don't define one.
+    # This way visual meshes render the robot while the (often simpler) collision
+    # geometry is used for physics, with the visual mesh as the fallback.
+    xml_data = mrc.add_missing_collisions(xml_data)
 
     xml_data = mrc.replace_package_names(xml_data)
     mesh_info_dict, xml_data = mrc.extract_mesh_info(xml_data, parsed_args.asset_dir, decompose_dict)

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -266,22 +266,27 @@ def run_obj2mjcf(output_filepath, decompose_dict, mesh_info_dict):
     thresholds_file = os.path.join(f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}", "metadata.json")
     thresholds_data = {}
 
-    # run obj2mjcf to generate folders of processed objs with decompose option for decomposed components
-    for mesh_name, threshold in decompose_dict.items():
-        mesh_item = mesh_info_dict[mesh_name]
-        if not mesh_item["is_pre_generated"]:
-            cmd = [
-                "obj2mjcf",
-                "--obj-dir",
-                f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}",
-                "--save-mjcf",
-                "--decompose",
-                "--coacd-args.threshold",
-                threshold,
-            ]
-            subprocess.run(cmd)
+    # run obj2mjcf to generate folders of processed objs with decompose option for decomposed
+    # components. Make sure a collision mesh sharing its stem with a visual mesh is decomposed too.
+    for mesh_name, mesh_item in mesh_info_dict.items():
+        filename_no_ext = os.path.splitext(os.path.basename(mesh_item["filename"]))[0]
+        if mesh_name not in decompose_dict and filename_no_ext not in decompose_dict:
+            continue
+        if mesh_item["is_pre_generated"]:
+            continue
+        threshold = decompose_dict.get(mesh_name, decompose_dict.get(filename_no_ext))
+        cmd = [
+            "obj2mjcf",
+            "--obj-dir",
+            f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}",
+            "--save-mjcf",
+            "--decompose",
+            "--coacd-args.threshold",
+            threshold,
+        ]
+        subprocess.run(cmd)
 
-            thresholds_data[mesh_name] = float(threshold)
+        thresholds_data[mesh_name] = float(threshold)
 
     with open(thresholds_file, "w") as f:
         json.dump(thresholds_data, f, indent=4)
@@ -396,6 +401,13 @@ def main(args=None):
         help="Allows MuJoCo to merge static bodies. Use --no-fuse to prevent merging.",
     )
     parser.add_argument(
+        "--use_collision_tags",
+        action="store_true",
+        help="Use the URDF's authored <collision> geometry for the MuJoCo collision geoms. "
+        "Without this flag, authored collisions are ignored and all collision geometry is "
+        "derived from the <visual> tags instead (the legacy behavior).",
+    )
+    parser.add_argument(
         "-a",
         "--asset_dir",
         required=False,
@@ -484,10 +496,12 @@ def main(args=None):
     # Add required MuJoCo tags to the starting URDF
     xml_data = mrc.add_mujoco_info(urdf, output_filepath, parsed_args.publish_topic, parsed_args.fuse)
 
-    # Keep authored collision geometry so it drives the MuJoCo collision geoms, and
-    # only synthesize a collision from the visual for links that don't define one.
-    # This way visual meshes render the robot while the (often simpler) collision
-    # geometry is used for physics, with the visual mesh as the fallback.
+    # Unless --use_collision_tags is given, drop the URDF's authored collision geometry
+    # first so every link falls back to a collision synthesized from its visuals (the
+    # legacy behavior, and the default).
+    if not parsed_args.use_collision_tags:
+        xml_data = mrc.remove_tag(xml_data, "collision")
+
     xml_data = mrc.add_missing_collisions(xml_data)
 
     xml_data = mrc.replace_package_names(xml_data)

--- a/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/tests/test_urdf_to_mujoco_utils.py
@@ -50,6 +50,7 @@ from mujoco_ros2_control import (
     parse_scene_xml,
     extract_mesh_info,
     copy_pre_generated_meshes,
+    add_missing_collisions,
 )
 
 
@@ -404,7 +405,55 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
             result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
             self.assertIsNotNone(result_dom)
 
-    def test_update_non_obj_assets_basic(self):
+    def test_update_obj_assets_tags_visual_and_collision(self):
+        # A visual-source geom (has contype) and a collision-source geom (no contype)
+        # that reference obj-converted meshes should have their expanded sub-geoms
+        # tagged class="visual" and class="collision" respectively.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            composed = os.path.join(tmpdir, "assets", COMPOSED_PATH_NAME)
+            os.makedirs(os.path.join(tmpdir, "assets", DECOMPOSED_PATH_NAME))
+            for name in ("vis_mesh", "col_mesh"):
+                mesh_dir = os.path.join(composed, name)
+                os.makedirs(mesh_dir)
+                with open(os.path.join(mesh_dir, f"{name}.xml"), "w") as f:
+                    f.write(
+                        '<mujoco><asset><mesh name="{n}_0" file="{n}.obj"/></asset>'
+                        '<worldbody><body><geom mesh="{n}_0"/></body></worldbody></mujoco>'.format(n=name)
+                    )
+            xml_string = (
+                '<?xml version="1.0"?><mujoco><asset>'
+                '<mesh name="vis_mesh" file="vis.obj"/><mesh name="col_mesh" file="col.obj"/>'
+                '</asset><worldbody><body name="test">'
+                '<geom type="mesh" contype="0" conaffinity="0" group="1" density="0" '
+                'rgba="1 0 0 1" mesh="vis_mesh" pos="0 0 0" quat="1 0 0 0"/>'
+                '<geom type="mesh" mesh="col_mesh" pos="0 0 0" quat="1 0 0 0"/>'
+                "</body></worldbody></mujoco>"
+            )
+            dom = minidom.parseString(xml_string)
+            mesh_info_dict = {
+                "vis_mesh": {
+                    "is_pre_generated": False,
+                    "filename": "/p/vis.obj",
+                    "scale": "1 1 1",
+                    "color": (1, 0, 0, 1),
+                },
+                "col_mesh": {
+                    "is_pre_generated": False,
+                    "filename": "/p/col.obj",
+                    "scale": "1 1 1",
+                    "color": (1, 1, 1, 1),
+                },
+            }
+            result_dom = update_obj_assets(dom, tmpdir + "/", mesh_info_dict)
+            result_xml = result_dom.toxml()
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="vis_mesh_0"[^>]*class="visual"[^>]*>')
+            self.assertRegex(result_xml, r'<geom[^>]*mesh="col_mesh_0"[^>]*class="collision"[^>]*>')
+            # raw import attrs stripped from the expanded visual geom
+            self.assertEqual(result_xml.count("contype"), 0)
+
+    def test_update_non_obj_assets_visual_geom(self):
+        # A geom with contype is a MuJoCo-imported <visual>; it is classified as
+        # visual only (no collision clone) and its raw import attributes are stripped.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
@@ -416,45 +465,70 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         dom = minidom.parseString(xml_string)
         result_dom = update_non_obj_assets(dom, "/tmp/output/")
         result_xml = result_dom.toxml()
-        assert 'class="collision"' in result_xml
         assert 'class="visual"' in result_xml
+        assert 'class="collision"' not in result_xml
         assert "contype" not in result_xml
+        assert "conaffinity" not in result_xml
+        assert 'group="1"' not in result_xml
+        assert 'density="0"' not in result_xml
+        # visual keeps its rgba for rendering
+        assert 'rgba="0.2 0.2 0.2 1"' in result_xml
 
-    def test_update_non_obj_assets_no_contype(self):
+    def test_update_non_obj_assets_collision_geom(self):
+        # A geom without contype is a MuJoCo-imported <collision>; it is classified
+        # as collision and its rgba (if any) is dropped.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
     <body name="test">
-      <geom type="box" size="1 1 1"/>
+      <geom type="box" size="1 1 1" rgba="0.2 0.2 0.2 1"/>
     </body>
   </worldbody>
 </mujoco>"""
         dom = minidom.parseString(xml_string)
         result_dom = update_non_obj_assets(dom, "/tmp/output/")
         result_xml = result_dom.toxml()
-        assert "<geom" in result_xml
+        assert 'class="collision"' in result_xml
+        assert 'class="visual"' not in result_xml
+        assert "rgba" not in result_xml
 
-    def test_update_non_obj_assets_multiple_geoms(self):
+    def test_update_non_obj_assets_visual_and_collision(self):
+        # Real case: a link with both a visual mesh and a collision mesh. The visual
+        # geom becomes class="visual" and the collision geom becomes class="collision";
+        # no duplication occurs.
         xml_string = """<?xml version="1.0"?>
 <mujoco>
   <worldbody>
     <body name="test">
-      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="mesh1"/>
-      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="mesh2"/>
+      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="visual_mesh"/>
+      <geom type="mesh" mesh="collision_mesh"/>
     </body>
   </worldbody>
 </mujoco>"""
         dom = minidom.parseString(xml_string)
         result_dom = update_non_obj_assets(dom, "/tmp/output/")
         result_xml = result_dom.toxml()
-        self.assertEqual(result_xml.count('class="collision"'), 2)
-        self.assertEqual(result_xml.count('class="visual"'), 2)
+        self.assertEqual(result_xml.count('class="visual"'), 1)
+        self.assertEqual(result_xml.count('class="collision"'), 1)
         self.assertEqual(result_xml.count("contype"), 0)
-        self.assertEqual(result_xml.count("conaffinity"), 0)
-        self.assertEqual(result_xml.count('group="1"'), 0)
-        self.assertEqual(result_xml.count('density="0"'), 0)
-        self.assertRegex(result_xml, r'<geom[^>]*mesh="mesh1"[^>]*class="visual"[^>]*>')
-        self.assertRegex(result_xml, r'<geom[^>]*mesh="mesh2"[^>]*class="collision"[^>]*>')
+        self.assertRegex(result_xml, r'<geom[^>]*mesh="visual_mesh"[^>]*class="visual"[^>]*>')
+        self.assertRegex(result_xml, r'<geom[^>]*mesh="collision_mesh"[^>]*class="collision"[^>]*>')
+
+    def test_update_non_obj_assets_skips_classified(self):
+        # Geoms already classified (e.g. by update_obj_assets) are left untouched.
+        xml_string = """<?xml version="1.0"?>
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <geom mesh="already" class="visual"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        dom = minidom.parseString(xml_string)
+        result_dom = update_non_obj_assets(dom, "/tmp/output/")
+        result_xml = result_dom.toxml()
+        self.assertEqual(result_xml.count('class="visual"'), 1)
+        self.assertEqual(result_xml.count('class="collision"'), 0)
 
     def test_add_mujoco_inputs_both_none(self):
         xml_string = '<?xml version="1.0"?><mujoco><worldbody/></mujoco>'
@@ -1783,6 +1857,86 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         finally:
             os.unlink(invalid_path)
 
+    def test_add_missing_collisions_adds_from_visual(self):
+        # A link with a visual but no collision should get a synthesized collision
+        # that copies the visual's geometry and origin.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <origin rpy="0 0 0" xyz="0.5 0 0"/>
+      <geometry>
+        <mesh filename="package://test_package/meshes/model.stl"/>
+      </geometry>
+      <material name="red"><color rgba="1 0 0 1"/></material>
+    </visual>
+  </link>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        collisions = link.getElementsByTagName("collision")
+        self.assertEqual(len(collisions), 1)
+        col = collisions[0]
+        # geometry mesh is copied
+        col_meshes = col.getElementsByTagName("mesh")
+        self.assertEqual(len(col_meshes), 1)
+        self.assertEqual(col_meshes[0].getAttribute("filename"), "package://test_package/meshes/model.stl")
+        # origin is copied
+        col_origins = col.getElementsByTagName("origin")
+        self.assertEqual(len(col_origins), 1)
+        self.assertEqual(col_origins[0].getAttribute("xyz"), "0.5 0 0")
+        # collisions must not carry a material
+        self.assertEqual(len(col.getElementsByTagName("material")), 0)
+
+    def test_add_missing_collisions_keeps_existing(self):
+        # A link that already defines a collision must be left untouched.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+    </visual>
+    <collision>
+      <geometry><sphere radius="0.5"/></geometry>
+    </collision>
+  </link>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        collisions = link.getElementsByTagName("collision")
+        self.assertEqual(len(collisions), 1)
+        # the original sphere collision is preserved (not replaced by the visual box)
+        self.assertEqual(len(collisions[0].getElementsByTagName("sphere")), 1)
+        self.assertEqual(len(collisions[0].getElementsByTagName("box")), 0)
+
+    def test_add_missing_collisions_no_visual(self):
+        # A link without any visual must not get a collision.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link"/>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        self.assertEqual(len(link.getElementsByTagName("collision")), 0)
+
+    def test_add_missing_collisions_multiple_visuals(self):
+        # Every visual on a collision-less link produces a matching collision.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual><geometry><box size="1 1 1"/></geometry></visual>
+    <visual><geometry><sphere radius="0.5"/></geometry></visual>
+  </link>
+</robot>"""
+        result = add_missing_collisions(urdf)
+        dom = minidom.parseString(result)
+        link = dom.getElementsByTagName("link")[0]
+        collisions = link.getElementsByTagName("collision")
+        self.assertEqual(len(collisions), 2)
+
     def test_extract_mesh_info_basic(self):
         urdf = """<?xml version="1.0"?>
 <robot name="test_robot">
@@ -1858,6 +2012,58 @@ class TestUrdfToMjcfUtils(unittest.TestCase):
         result, updated_xml = extract_mesh_info(urdf, None, {})
         self.assertEqual(len(result), 0)
         self.assertEqual(updated_xml, urdf)
+
+    def test_extract_mesh_info_distinct_collision_mesh(self):
+        # A link with a visual mesh and a different collision mesh yields two entries.
+        # The collision entry has no material, so its color defaults to white.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://test_package/meshes/visual_model.stl"/>
+      </geometry>
+      <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://test_package/meshes/collision_model.stl"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>"""
+        result, updated_xml = extract_mesh_info(urdf, None, {})
+        self.assertEqual(len(result), 2)
+        assert "visual_model" in result
+        assert "collision_model" in result
+        self.assertEqual(result["visual_model"]["color"], (1.0, 0.0, 0.0, 1.0))
+        self.assertEqual(result["collision_model"]["color"], (1.0, 1.0, 1.0, 1.0))
+        assert "package://test_package/meshes/collision_model.stl" in updated_xml
+
+    def test_extract_mesh_info_shared_collision_mesh(self):
+        # When the collision references the same mesh file as the visual (the
+        # fallback case), they share a single entry - no duplicate asset - and the
+        # visual's material color wins.
+        urdf = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://test_package/meshes/model.stl"/>
+      </geometry>
+      <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://test_package/meshes/model.stl"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>"""
+        result, _ = extract_mesh_info(urdf, None, {})
+        self.assertEqual(len(result), 1)
+        assert "model" in result
+        self.assertEqual(result["model"]["color"], (1.0, 0.0, 0.0, 1.0))
 
     def test_extract_mesh_info_with_decompose_dict(self):
         urdf = """<?xml version="1.0"?>


### PR DESCRIPTION

## Description

  First of a series of PRs splitting up #209 into smaller, reviewable pieces (see that PR for the original context, motivation, and before/after screenshots). Fixes some of the concerns listed in #120.

  This PR makes the URDF→MJCF converter treat `<visual>` and `<collision>` tags independently instead of always deriving collision geometry from whatever mesh was used for rendering:

  - Mesh filepaths are now read from **both** `<visual>` and `<collision>` tags (previously only one source was used), and converted to `.obj` as needed.
  - If a link defines a `<collision>` tag, its mesh/geometry is what drives physics — no longer just a byproduct of the visual mesh.
  - If a link has no `<collision>` tag, a collision is synthesized from its `<visual>` (matching the previous behaviour), so nothing regresses for URDFs that don't define collision geometry.
  - This synthesis happens at the URDF level (before MuJoCo fuses fixed-jointed bodies), so it stays correct per-link even after body fusion.

  ### Is this a user-facing behavior change?
  Yes — links that define separate collision geometry in their URDF will now get that geometry in the generated MJCF instead of their visual mesh.
