### PR TITLE
Support MuJoCo intvelocity actuators as velocity interfaces

### DIFF
--- a/mujoco_ros2_control/docs/hardware_interface.rst
+++ b/mujoco_ros2_control/docs/hardware_interface.rst
@@ -115,19 +115,27 @@ Maps to the following ``ros2_control`` hardware interface:
    * - Command Interface
      - MuJoCo ``position``
      - MuJoCo ``velocity``
+     - MuJoCo ``intvelocity``
      - MuJoCo ``motor``, ``general``, etc.
    * - **position**
      - Native support
      - Supported using PIDs
      - Supported using PIDs
+     - Supported using PIDs
    * - **velocity**
      - Not supported
+     - Native support
      - Native support
      - Supported using PIDs
    * - **effort**
      - Not supported
      - Not supported
+     - Not supported
      - Native support
+
+MuJoCo's ``intvelocity`` actuator integrates its ``ctrl`` input into an internal position setpoint. The input itself has
+velocity semantics, so it maps natively to a ros2_control ``velocity`` command interface without changing the actuator's
+integrated-velocity dynamics.
 
 .. note::
 

--- a/mujoco_ros2_control/include/mujoco_ros2_control/data.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/data.hpp
@@ -34,7 +34,7 @@ namespace mujoco_ros2_control
  * Maps to MuJoCo actuator types:
  *  - MOTOR for MuJoCo motor actuator
  *  - POSITION for MuJoCo position actuator
- *  - VELOCITY for MuJoCo velocity actuator
+ *  - VELOCITY for MuJoCo velocity and integrated-velocity actuators
  *  - CUSTOM  for MuJoCo general actuator or other types
  *
  * \note the MuJoCo types are as per the MuJoCo documentation:

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -107,13 +107,22 @@ void add_items(std::vector<T>& vector, const std::vector<T>& items)
 
 ActuatorType getActuatorType(const mjModel* mj_model, int mujoco_actuator_id)
 {
-  // Returns the MuJoCo actuator type based on the actuator's bias settings.
+  // Returns the MuJoCo actuator type based on the compiled actuator settings.
   ActuatorType actuator_type = ActuatorType::UNKNOWN;
-  int biastype = mj_model->actuator_biastype[mujoco_actuator_id];
-  const int NBias = 10;
-  const mjtNum* biasprm = mj_model->actuator_biasprm + mujoco_actuator_id * NBias;
+  const int dyntype = mj_model->actuator_dyntype[mujoco_actuator_id];
+  const int gaintype = mj_model->actuator_gaintype[mujoco_actuator_id];
+  const int biastype = mj_model->actuator_biastype[mujoco_actuator_id];
+  const mjtNum* gainprm = mj_model->actuator_gainprm + mujoco_actuator_id * mjNGAIN;
+  const mjtNum* biasprm = mj_model->actuator_biasprm + mujoco_actuator_id * mjNBIAS;
 
-  if (biastype == mjBIAS_NONE)
+  // MuJoCo compiles an intvelocity shortcut into a fixed-gain, affine-bias actuator whose control is integrated into
+  // a position setpoint. Although its feedback terms resemble a position actuator, ctrl has velocity semantics.
+  if (dyntype == mjDYN_INTEGRATOR && gaintype == mjGAIN_FIXED && biastype == mjBIAS_AFFINE && biasprm[0] == 0 &&
+      biasprm[1] == -gainprm[0])
+  {
+    actuator_type = ActuatorType::VELOCITY;
+  }
+  else if (biastype == mjBIAS_NONE)
   {
     actuator_type = ActuatorType::MOTOR;
   }

--- a/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
@@ -59,12 +59,38 @@ constexpr const char* kTestModel = R"(<?xml version="1.0"?>
 </mujoco>
 )";
 
+constexpr const char* kIntVelocityTestModel = R"(<?xml version="1.0"?>
+<mujoco model="intvelocity_system_interface">
+  <option timestep="0.002"/>
+
+  <worldbody>
+    <body name="wheel" pos="0 0 0">
+      <joint name="wheel_joint" type="hinge" axis="0 1 0"/>
+      <geom type="cylinder" size="0.1 0.02" mass="1"/>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <intvelocity name="wheel_joint" joint="wheel_joint" kp="10" kv="1" ctrlrange="-5 5"
+                 actrange="-100 100"/>
+  </actuator>
+</mujoco>
+)";
+
 // Write to disk for testing
 const std::string kTestModelPath = "/tmp/test_mujoco_system_interface_model.xml";
+const std::string kIntVelocityTestModelPath = "/tmp/test_mujoco_system_interface_intvelocity_model.xml";
 void write_test_model()
 {
   std::ofstream file(kTestModelPath);
   file << kTestModel;
+  file.close();
+}
+
+void write_intvelocity_test_model()
+{
+  std::ofstream file(kIntVelocityTestModelPath);
+  file << kIntVelocityTestModel;
   file.close();
 }
 
@@ -110,6 +136,10 @@ protected:
     {
       std::filesystem::remove(kTestModelPath);
     }
+    if (std::filesystem::exists(kIntVelocityTestModelPath))
+    {
+      std::filesystem::remove(kIntVelocityTestModelPath);
+    }
   }
 
   // Create the hardware info to initialize the interface with, in headless mode.
@@ -153,6 +183,56 @@ protected:
 
   std::shared_ptr<mujoco_ros2_control::MujocoSystemInterface> interface_;
 };
+
+TEST_F(MujocoSystemInterfaceTest, IntVelocityActuatorSupportsVelocityCommandInterface)
+{
+  write_intvelocity_test_model();
+  auto hardware_info = create_hardware_info();
+  hardware_info.hardware_parameters["mujoco_model"] = kIntVelocityTestModelPath;
+
+  hardware_interface::ComponentInfo joint_info;
+  joint_info.name = "wheel_joint";
+
+  hardware_interface::InterfaceInfo command_interface;
+  command_interface.name = hardware_interface::HW_IF_VELOCITY;
+  joint_info.command_interfaces.push_back(command_interface);
+
+  for (const auto* interface_name :
+       { hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY, hardware_interface::HW_IF_EFFORT })
+  {
+    hardware_interface::InterfaceInfo state_interface;
+    state_interface.name = interface_name;
+    joint_info.state_interfaces.push_back(state_interface);
+  }
+  hardware_info.joints.push_back(joint_info);
+
+  ASSERT_EQ(initialize_interface(hardware_info), hardware_interface::CallbackReturn::SUCCESS);
+
+  mjModel* model = nullptr;
+  interface_->get_model(model);
+  ASSERT_NE(model, nullptr);
+  const int actuator_id = mj_name2id(model, mjOBJ_ACTUATOR, "wheel_joint");
+  ASSERT_NE(actuator_id, -1);
+  EXPECT_EQ(model->actuator_dyntype[actuator_id], mjDYN_INTEGRATOR);
+
+  auto command_interfaces = interface_->export_command_interfaces();
+  ASSERT_EQ(command_interfaces.size(), 1u);
+  EXPECT_EQ(command_interfaces.front().get_name(), "wheel_joint/velocity");
+
+  constexpr double velocity_command = 2.0;
+  command_interfaces.front().set_value(velocity_command);
+  ASSERT_EQ(interface_->write(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002)),
+            hardware_interface::return_type::OK);
+
+  mjData* data = nullptr;
+  ASSERT_TRUE(wait_until([&]() {
+    interface_->get_data(data);
+    return data != nullptr && std::abs(data->ctrl[actuator_id] - velocity_command) < 1e-9;
+  })) << "Velocity command was not written to the intvelocity actuator ctrl input";
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
 
 TEST_F(MujocoSystemInterfaceTest, PoseSensorStateInterfacesRead)
 {


### PR DESCRIPTION
## Summary

- recognize MuJoCo `intvelocity` actuators as native velocity-command actuators
- document the `intvelocity` to ros2_control command-interface mapping
- add a regression test that exports a velocity interface and verifies that its command reaches `mjData.ctrl`

## Problem

MuJoCo compiles an `intvelocity` shortcut as an actuator with integrator dynamics, fixed gain, and affine position/velocity feedback. The existing actuator detection only inspects the affine bias parameters, so the nonzero position feedback term causes `intvelocity` to be classified as a position actuator.

That classification rejects a ros2_control velocity command interface even though the actuator's `ctrl` input has velocity semantics: MuJoCo integrates that input internally to produce the position setpoint.

## Change

Detect the compiled `intvelocity` signature before the generic position-actuator pattern and route it through the existing native velocity command path. This changes only the ros2_control interface classification; it does not alter the MJCF actuator or its integrated-velocity dynamics.

The regression test uses a real `<intvelocity>` MJCF actuator, confirms that a velocity command interface is exported, writes a `2.0` velocity command, and verifies that MuJoCo receives `2.0` in the actuator's `ctrl` input.

## Validation

- `pre-commit` passed on all changed files
- ROS 2 Humble build passed
- `colcon test --packages-select mujoco_ros2_control`: 136 tests, 0 errors, 0 failures, 0 skipped
