### PR TITLE
Fix magnetometer unit conversion

### DIFF
--- a/mujoco_ros2_control/docs/hardware_interface.rst
+++ b/mujoco_ros2_control/docs/hardware_interface.rst
@@ -256,10 +256,18 @@ Map it to the corresponding ``ros2_control`` sensor:
      <param name="mujoco_type">magnetometer</param>
      <!-- mujoco_sensor_name does not need to match the ros2_control sensor name -->
      <param name="mujoco_sensor_name">magnetometer_sensor</param>
+     <!-- Convert MuJoCo model units to tesla; defaults to 1.0 -->
+     <param name="magnetic_field_scale">1.0</param>
      <state_interface name="magnetic_field.x"/>
      <state_interface name="magnetic_field.y"/>
      <state_interface name="magnetic_field.z"/>
    </sensor>
+
+MuJoCo does not define physical units for the model's global ``magnetic`` vector, while the ROS
+``magnetic_field`` interfaces use tesla. Set ``magnetic_field_scale`` to the number of tesla per
+MuJoCo unit. For example, use ``0.0001`` when the model values represent gauss. If the model values
+represent magnetic flux in webers through a known sensor area, use the reciprocal of that area in
+square metres because :math:`1\,\mathrm{T} = 1\,\mathrm{Wb}/\mathrm{m}^2`.
 
 .. warning::
 

--- a/mujoco_ros2_control/include/mujoco_ros2_control/data.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/data.hpp
@@ -227,6 +227,7 @@ struct MagnetometerSensorData
 {
   std::string name;
   SensorData<Eigen::Vector3d> magnetic_field;
+  double scale = 1.0;
 };
 
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -68,6 +68,8 @@ namespace mujoco_ros2_control
 constexpr char MUJOCO_TYPE_PARAM[] = "mujoco_type";
 /// Optional `<sensor>` parameter key overriding the MJCF sensor name; defaults to the sensor's own name.
 constexpr char MUJOCO_SENSOR_NAME_PARAM[] = "mujoco_sensor_name";
+/// Optional factor converting MuJoCo magnetometer values to tesla; defaults to 1.0.
+constexpr char MAGNETOMETER_SCALE_PARAM[] = "magnetic_field_scale";
 
 /// Force/torque sensor: reads a paired MJCF `force` + `torque` sensor.
 constexpr char MUJOCO_TYPE_FTS[] = "fts";

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -23,6 +23,7 @@
 #include <fmt/ranges.h>
 
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <limits>
@@ -969,9 +970,9 @@ hardware_interface::return_type MujocoSystemInterface::read(const rclcpp::Time& 
   // Magnetometer sensor data
   for (auto& data : magnetometer_sensor_data_)
   {
-    data.magnetic_field.data.x() = control_state_.sensordata[data.magnetic_field.mj_sensor_index];
-    data.magnetic_field.data.y() = control_state_.sensordata[data.magnetic_field.mj_sensor_index + 1];
-    data.magnetic_field.data.z() = control_state_.sensordata[data.magnetic_field.mj_sensor_index + 2];
+    data.magnetic_field.data.x() = data.scale * control_state_.sensordata[data.magnetic_field.mj_sensor_index];
+    data.magnetic_field.data.y() = data.scale * control_state_.sensordata[data.magnetic_field.mj_sensor_index + 1];
+    data.magnetic_field.data.z() = data.scale * control_state_.sensordata[data.magnetic_field.mj_sensor_index + 2];
   }
 
   // Publish Odometry
@@ -2023,6 +2024,26 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
       MagnetometerSensorData sensor_data;
       sensor_data.name = sensor_name;
       sensor_data.magnetic_field.name = mujoco_sensor_name;
+
+      if (const auto scale_it = sensor.parameters.find(MAGNETOMETER_SCALE_PARAM); scale_it != sensor.parameters.end())
+      {
+        try
+        {
+          size_t parsed_characters = 0;
+          sensor_data.scale = std::stod(scale_it->second, &parsed_characters);
+          if (parsed_characters != scale_it->second.size() || !std::isfinite(sensor_data.scale) ||
+              sensor_data.scale <= 0.0)
+          {
+            throw std::invalid_argument("scale must be a finite positive number");
+          }
+        }
+        catch (const std::exception& exception)
+        {
+          RCLCPP_ERROR(get_logger(), "Invalid '%s' for magnetometer sensor '%s': '%s' (%s)", MAGNETOMETER_SCALE_PARAM,
+                       sensor_name.c_str(), scale_it->second.c_str(), exception.what());
+          continue;
+        }
+      }
 
       const int magnetometer_id =
           mj_name2id(simulation_->model(), mjOBJ_SENSOR, sensor_data.magnetic_field.name.c_str());

--- a/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
@@ -221,6 +221,7 @@ TEST_F(MujocoSystemInterfaceTest, PoseSensorStateInterfacesRead)
 
 TEST_F(MujocoSystemInterfaceTest, MagnetometerSensorStateInterfacesRead)
 {
+  constexpr double kMagneticFieldScale = 0.25;
   auto hardware_info = create_hardware_info();
   hardware_interface::ComponentInfo sensor_info;
   sensor_info.name = "magnetometer_sensor";
@@ -232,6 +233,12 @@ TEST_F(MujocoSystemInterfaceTest, MagnetometerSensorStateInterfacesRead)
     sensor_info.state_interfaces.push_back(interface_info);
   }
   hardware_info.sensors.push_back(sensor_info);
+
+  auto scaled_sensor_info = sensor_info;
+  scaled_sensor_info.name = "scaled_magnetometer_sensor";
+  scaled_sensor_info.parameters[mujoco_ros2_control::MUJOCO_SENSOR_NAME_PARAM] = "magnetometer_sensor";
+  scaled_sensor_info.parameters[mujoco_ros2_control::MAGNETOMETER_SCALE_PARAM] = std::to_string(kMagneticFieldScale);
+  hardware_info.sensors.push_back(scaled_sensor_info);
 
   ASSERT_EQ(initialize_interface(hardware_info), hardware_interface::CallbackReturn::SUCCESS);
 
@@ -246,10 +253,13 @@ TEST_F(MujocoSystemInterfaceTest, MagnetometerSensorStateInterfacesRead)
   interface_->read(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002));
 
   const auto state_interfaces = interface_->export_state_interfaces();
-  ASSERT_EQ(state_interfaces.size(), 3u);
+  ASSERT_EQ(state_interfaces.size(), 6u);
   ASSERT_EQ(state_interfaces[0].get_name(), "magnetometer_sensor/magnetic_field.x");
   ASSERT_EQ(state_interfaces[1].get_name(), "magnetometer_sensor/magnetic_field.y");
   ASSERT_EQ(state_interfaces[2].get_name(), "magnetometer_sensor/magnetic_field.z");
+  ASSERT_EQ(state_interfaces[3].get_name(), "scaled_magnetometer_sensor/magnetic_field.x");
+  ASSERT_EQ(state_interfaces[4].get_name(), "scaled_magnetometer_sensor/magnetic_field.y");
+  ASSERT_EQ(state_interfaces[5].get_name(), "scaled_magnetometer_sensor/magnetic_field.z");
 
   const int magnetometer_id = mj_name2id(model, mjOBJ_SENSOR, "magnetometer_sensor");
   ASSERT_NE(magnetometer_id, -1);
@@ -259,16 +269,25 @@ TEST_F(MujocoSystemInterfaceTest, MagnetometerSensorStateInterfacesRead)
   const double magnetic_field_x = state_interfaces[0].get_value();
   const double magnetic_field_y = state_interfaces[1].get_value();
   const double magnetic_field_z = state_interfaces[2].get_value();
+  const double scaled_magnetic_field_x = state_interfaces[3].get_value();
+  const double scaled_magnetic_field_y = state_interfaces[4].get_value();
+  const double scaled_magnetic_field_z = state_interfaces[5].get_value();
 #else
   const double magnetic_field_x = state_interfaces[0].get_optional().value();
   const double magnetic_field_y = state_interfaces[1].get_optional().value();
   const double magnetic_field_z = state_interfaces[2].get_optional().value();
+  const double scaled_magnetic_field_x = state_interfaces[3].get_optional().value();
+  const double scaled_magnetic_field_y = state_interfaces[4].get_optional().value();
+  const double scaled_magnetic_field_z = state_interfaces[5].get_optional().value();
 #endif
 
   const double tol = 1e-9;
   EXPECT_NEAR(magnetic_field_x, data->sensordata[magnetometer_data_index], tol);
   EXPECT_NEAR(magnetic_field_y, data->sensordata[magnetometer_data_index + 1], tol);
   EXPECT_NEAR(magnetic_field_z, data->sensordata[magnetometer_data_index + 2], tol);
+  EXPECT_NEAR(scaled_magnetic_field_x, kMagneticFieldScale * magnetic_field_x, tol);
+  EXPECT_NEAR(scaled_magnetic_field_y, kMagneticFieldScale * magnetic_field_y, tol);
+  EXPECT_NEAR(scaled_magnetic_field_z, kMagneticFieldScale * magnetic_field_z, tol);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary

- add an optional per-sensor `magnetic_field_scale` parameter
- apply the scale when exposing MuJoCo magnetometer values through ROS `magnetic_field` state interfaces
- reject non-numeric, non-finite, and non-positive scale values
- document tesla-per-model-unit, gauss, and flux/area conversions
- test scaled and unscaled mappings to the same MuJoCo sensor together

## Rationale

MuJoCo does not define physical units for a model's global `magnetic` vector, while ROS magnetic-field interfaces use tesla. Passing the values through unchanged therefore only works when the model already uses tesla. A per-sensor factor lets users express the model's unit convention without changing the MJCF or silently mislabeling the exposed values.

The default remains `1.0`, preserving existing configurations.

## Validation

- `git diff --check`
- `codespell` on all changed files
- formatting checked with `clang-format`
- the Pixi build cannot run locally because the workspace supports Linux only and the current host is macOS ARM64; CI covers the supported Linux targets

Fixes #275
