### PR TITLE
Add a pre-step callback to the simulation

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -84,17 +84,20 @@ namespace mujoco_ros2_control
  *
  * `apply_control_data(...)` will copy control inputs from the provided mjData into staging
  * buffers that the physics loop applies to `mj_data_` immediately before each step.
- * Specifically, it stages `ctrl`, `qfrc_applied`, and `xfrc_applied`. Cartesian forces from
- * `xfrc_applied` compete with inputs from Simulate's drag function, so they are resolved
- * separately. This only takes the control staging mutex and never blocks on physics stepping.
- * It also stages `qvel`: the system interface NaN-fills `qvel` before every plugin's
- * `update()` runs, so any DOF a plugin leaves untouched is NaN here and any DOF it writes a
- * finite value into is a requested hard velocity override (see
- * `MuJoCoROS2ControlPluginBase::update()`'s doc comment). Non-NaN entries are applied as a
- * direct `qvel` write, bypassing the normal dynamics for that DOF.
+ * Specifically, it stages `ctrl` and `qfrc_applied`. Both of these values should come from
+ * the interfaces consuming this class. This  This only takes the control staging mutex
+ * and never blocks on physics stepping.
  *
  * `overwrite_physics_data(...)` will completely replace the data for the sim. Should be used
  * with extreme caution.
+ *
+ * `set_pre_step_callback(...)` registers a callback which will be triggered in the Physics
+ * Loop. It will be called immediately before `mj_step()`, providing direct access to
+ * `mj_data_` immediately before progressing the simulation. This gives consumers direct
+ * access to access and modify the data immediately before integration. Users should be
+ * extremely careful with this callback, as it exposes "god like" powers to the simulation
+ * environment and can break, slow down, or otherwise damage the simulation. This should also
+ * be used with caution.
  *
  * Thread safety is still somewhat messy, as callers are provided with a simulation mutex that
  * locks the model and data while the actual mujoco engine moves the sim forward. Callers
@@ -116,6 +119,15 @@ public:
    *        initial state. When false, a keyframe has already been applied.
    */
   using ResetCallback = std::function<void(bool fill_initial_state)>;
+
+  /**
+   * @brief Callback function type the `set_pre_step_callback` hook.
+   *
+   * Called before `mjStep` in the physics loop, use with care.
+   *
+   * @param data The data from the physics simulation, under thread lock.
+   */
+  using PreStepCallback = std::function<void(mjData* data)>;
 
   /**
    * @brief Construct a new Mujoco Simulation object. This is a no-op until initialization.
@@ -153,6 +165,14 @@ public:
    * @brief Register a callback function to be called on `reset_world_state`.
    */
   void set_reset_callback(ResetCallback callback);
+
+  /**
+   * @brief Register the callback run before every `mj_step()`.
+   *
+   * See the class documentation for more information. Any function called here will hold
+   * the simulation mutex and block the physics loop. Use with care.
+   */
+  void set_pre_step_callback(PreStepCallback callback);
 
   /**
    * @brief Start the physics thread. Must be called after load_model().
@@ -279,13 +299,10 @@ public:
    * @brief Stages control fields from `control_data` for the physics loop in a thread safe way.
    *
    * Specifically, copies `control_data->ctrl` and `control_data->qfrc_applied` into staging
-   * buffers which the physics loop copies into `mj_data_` immediately before each step.
-   * `control_data->xfrc_applied` is copied into `xfrc_plugin_desired_` to avoid conflicts
-   * from the simulate app. `control_data->qvel` is copied into `qvel_override_staged_`;
-   * entries that are not NaN are plugin-requested velocity overrides (see
-   * `MuJoCoROS2ControlPluginBase::update()`'s doc comment for the NaN convention this
-   * relies on) and are applied as direct `qvel` writes before the next `mj_step`. This does
-   * not lock the sim mutex and never waits on stepping.
+   * buffers which the physics loop copies into `mj_data_` immediately before each step. These
+   * are the only two fields staged here because both are "held" quantities that persist
+   * correctly across a batch of steps. Anything else that requires direct access to simulation
+   * data can access it through the `set_pre_step_callback` functions.
    */
   void apply_control_data(mjData* control_data);
 
@@ -474,17 +491,6 @@ private:
   // reset ctrl values in mj_data_ are not clobbered by stale staging buffers.
   bool control_inputs_staged_{ false };
 
-  // Buffers to track actively applied Cartesian forces from both the plugins and the Simulate /
-  // viewer-only drag forces.
-  std::vector<mjtNum> xfrc_plugin_desired_;  // Tracks forces from plugins
-  std::vector<mjtNum> xfrc_viewer_capture_;  // Tracks forces from the viewer
-  std::vector<mjtNum> xfrc_last_written_;    // tracks the last value written to xfrc_applied
-
-  // qvel as staged by apply_control_data: sized nv, NaN by default. A plugin requests a
-  // velocity override on a DOF by writing a finite value into control_data->qvel during its
-  // update()
-  std::vector<mjtNum> qvel_override_staged_;
-
   // Guards only the snapshot pointer swap and snapshot_ready_ flag.
   // Lock order: sim_mutex_ (if needed) is always taken before this one.
   std::mutex data_exchange_mutex_;
@@ -494,10 +500,9 @@ private:
   // demand instead of the batch rate. Starts true so the first refresh happens.
   std::atomic<bool> snapshot_refresh_requested_{ true };
 
-  // Guards the staged control inputs (ctrl_staged_, qfrc_applied_staged_, xfrc_plugin_desired_,
-  // control_inputs_staged_, qvel_override_staged_). Separate from data_exchange_mutex_ so
-  // that staging commands in write() and applying them before each physics step never queue
-  // behind a full mjData copy.
+  // Guards the staged control inputs (ctrl_staged_, qfrc_applied_staged_,
+  // control_inputs_staged_). Separate from data_exchange_mutex_ so that staging commands in
+  // write() and applying them before each physics step never queue behind a full mjData copy.
   // Critical sections are all small buffer copies.
   // Lock order: sim_mutex_ (if needed) before this one; never held with data_exchange_mutex_.
   std::mutex control_staging_mutex_;
@@ -571,6 +576,9 @@ private:
 
   // Callback into the HW interface to perform component-side reset bookkeeping.
   ResetCallback reset_callback_;
+
+  // Callback run immediately before every mj_step(), defaults to nothing.
+  PreStepCallback pre_step_callback_{ [](mjData* /*data*/) {} };
 };
 
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -28,12 +28,10 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <future>
 #include <iostream>
-#include <limits>
 #include <memory>
 #include <new>
 #include <stdexcept>
@@ -714,10 +712,6 @@ bool MujocoSimulation::initialize(rclcpp::Node::SharedPtr node, const std::strin
     ctrl_staged_.assign(mj_model_->nu, 0.0);
     qfrc_applied_staged_.assign(mj_model_->nv, 0.0);
     control_inputs_staged_ = false;
-    xfrc_plugin_desired_.assign(6 * mj_model_->nbody, 0.0);
-    xfrc_viewer_capture_.assign(6 * mj_model_->nbody, 0.0);
-    xfrc_last_written_.assign(6 * mj_model_->nbody, 0.0);
-    qvel_override_staged_.assign(mj_model_->nv, std::numeric_limits<mjtNum>::quiet_NaN());
 
     if (mj_data_ && snapshot_write_ && snapshot_read_)
     {
@@ -766,6 +760,17 @@ void MujocoSimulation::capture_initial_state()
 void MujocoSimulation::set_reset_callback(ResetCallback callback)
 {
   reset_callback_ = std::move(callback);
+}
+
+void MujocoSimulation::set_pre_step_callback(PreStepCallback callback)
+{
+  // Don't drop in a nullptr if requested, just pass an empty function.
+  PreStepCallback next = callback ? std::move(callback) : PreStepCallback([](mjData* /*data*/) {});
+
+  // Plugins may be registered after the physics thread is already running, so the loop
+  // could otherwise be reading pre_step_callback_ while we assign to it.
+  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+  pre_step_callback_ = std::move(next);
 }
 
 void MujocoSimulation::start_physics_thread()
@@ -862,17 +867,13 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
   std::fill(mj_data_->xfrc_applied, mj_data_->xfrc_applied + 6 * mj_model_->nbody, 0.0);
 
   {
-    // Clear staged control inputs and plugin contributions so stale commands from before the
-    // reset are not re-applied on the next step.
+    // Clear staged control inputs so stale commands from before the reset are not re-applied
+    // on the next step.
     const std::lock_guard<std::mutex> staging_lock(control_staging_mutex_);
     control_inputs_staged_ = false;
     std::fill(ctrl_staged_.begin(), ctrl_staged_.end(), 0.0);
     std::fill(qfrc_applied_staged_.begin(), qfrc_applied_staged_.end(), 0.0);
-    std::fill(xfrc_plugin_desired_.begin(), xfrc_plugin_desired_.end(), 0.0);
-    std::fill(qvel_override_staged_.begin(), qvel_override_staged_.end(), std::numeric_limits<mjtNum>::quiet_NaN());
   }
-  std::fill(xfrc_viewer_capture_.begin(), xfrc_viewer_capture_.end(), 0.0);
-  std::fill(xfrc_last_written_.begin(), xfrc_last_written_.end(), 0.0);
 
   // Restore simulation time to preserve ROS clock continuity
   mj_data_->time = saved_time;
@@ -1339,8 +1340,6 @@ void MujocoSimulation::apply_control_data(mjData* control_data)
   const std::lock_guard<std::mutex> lock(control_staging_mutex_);
   mju_copy(ctrl_staged_.data(), control_data->ctrl, static_cast<int>(mj_model_->nu));
   mju_copy(qfrc_applied_staged_.data(), control_data->qfrc_applied, static_cast<int>(mj_model_->nv));
-  mju_copy(xfrc_plugin_desired_.data(), control_data->xfrc_applied, 6 * static_cast<int>(mj_model_->nbody));
-  mju_copy(qvel_override_staged_.data(), control_data->qvel, static_cast<int>(mj_model_->nv));
   control_inputs_staged_ = true;
 }
 
@@ -1389,20 +1388,6 @@ void MujocoSimulation::apply_staged_control_inputs()
   {
     mju_copy(mj_data_->ctrl, ctrl_staged_.data(), static_cast<int>(mj_model_->nu));
     mju_copy(mj_data_->qfrc_applied, qfrc_applied_staged_.data(), static_cast<int>(mj_model_->nv));
-  }
-
-  const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
-  mju_copy(mj_data_->xfrc_applied, xfrc_viewer_capture_.data(), nbody6);
-  mju_addTo(mj_data_->xfrc_applied, xfrc_plugin_desired_.data(), nbody6);
-  mju_copy(xfrc_last_written_.data(), mj_data_->xfrc_applied, nbody6);
-
-  // Apply plugin-requested velocity overrides as direct qvel writes
-  for (int i = 0; i < static_cast<int>(mj_model_->nv); ++i)
-  {
-    if (std::isfinite(qvel_override_staged_[i]))
-    {
-      mj_data_->qvel[i] = qvel_override_staged_[i];
-    }
   }
 }
 
@@ -1457,25 +1442,6 @@ void MujocoSimulation::physics_loop()
       // run only if model is present
       if (mj_model_)
       {
-        // Determine the viewer (drag) forces for this outer iteration.
-        //
-        // mjv_updateScene in simulate.cc reads mj_data_->xfrc_applied BEFORE zeroing it, so
-        // plugin forces written here are visible as arrows in the native viewer. To avoid
-        // accumulation across outer iterations we must preserve the viewer-drag portion.
-        // We do this in xfrc_viewer_capture_.
-        //
-        // After each outer iteration we restore mj_data_->xfrc_applied = viewer + plugin and
-        // record it in xfrc_last_written_. We can then combine the desired forces from the plugins
-        // as well as the viewers prior to stepping, without either of them stacking in
-        // undesirable ways.
-        const int nbody6 = 6 * static_cast<int>(mj_model_->nbody);
-        if (std::memcmp(mj_data_->xfrc_applied, xfrc_last_written_.data(), nbody6 * sizeof(mjtNum)) != 0)
-        {
-          // Render thread ran: xfrc_applied was zeroed then drag was applied.
-          mju_copy(xfrc_viewer_capture_.data(), mj_data_->xfrc_applied, nbody6);
-        }
-        // else: render thread did not run; keep the existing xfrc_viewer_capture_.
-
         // running (ie, not paused)
         if (sim_->run)
         {
@@ -1524,6 +1490,7 @@ void MujocoSimulation::physics_loop()
             sim_->speed_changed = false;
 
             apply_staged_control_inputs();
+            pre_step_callback_(mj_data_);
             // run single step, let next iteration deal with timing
             mj_step(mj_model_, mj_data_);
 
@@ -1575,6 +1542,7 @@ void MujocoSimulation::physics_loop()
               sim_->InjectNoise(-1);
 #endif
               apply_staged_control_inputs();
+              pre_step_callback_(mj_data_);
               // call mj_step
               mj_step(mj_model_, mj_data_);
 
@@ -1624,14 +1592,15 @@ void MujocoSimulation::physics_loop()
             pending_steps_.fetch_add(1);
           }
 
-          // Record so the next iteration can detect render thread changes, only necessary once
-          // when paused
+          // Merge staged actuator commands even while paused, so a queued step (and the
+          // viewer's display of ctrl) reflects the latest commands.
           apply_staged_control_inputs();
 
           // Execute one pending step per physics loop iteration so the clock publisher
           // (try_publish) has time to flush between steps, matching play mode behavior.
           if (pending_steps_.load() > 0)
           {
+            pre_step_callback_(mj_data_);
             mj_step(mj_model_, mj_data_);
             publish_control_state();
             publish_clock();

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -25,7 +25,6 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
-#include <limits>
 #include <memory>
 #include <mutex>
 #include <new>
@@ -251,6 +250,13 @@ MujocoSystemInterface::MujocoSystemInterface() = default;
 
 MujocoSystemInterface::~MujocoSystemInterface()
 {
+  // We don't know what plugins are doing with the mj_data pointer, so be
+  // sure to kill callback so that nothing can access it on destruction.
+  if (simulation_)
+  {
+    simulation_->set_pre_step_callback(nullptr);
+  }
+
   // Stop plugins
   for (auto& plugin : plugin_instances_)
   {
@@ -1084,13 +1090,8 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
     }
   }
 
-  // Update plugins.
-  // Clear plugin data, then let each plugin update as needed, in order. This enables plugins to read and
-  // rewrite control inputs immediately before they are sent to the simulation. Namely, we have to zero
-  // out xfrc_applied so plugins can update as needed. qvel is NaN-filled rather than zeroed: a plugin
-  // requests a hard velocity override on a DOF by writing a finite value into it.
-  mju_zero(control_data->xfrc_applied, 6 * static_cast<int>(simulation_->model()->nbody));
-  std::fill(control_data->qvel, control_data->qvel + simulation_->model()->nv, std::numeric_limits<mjtNum>::quiet_NaN());
+  // Update plugins, in order. This enables plugins to read and rewrite ctrl/qfrc_applied
+  // immediately before they are sent to the simulation.
   for (auto& plugin : plugin_instances_)
   {
     plugin->update(simulation_->model(), control_data);
@@ -2313,6 +2314,14 @@ void MujocoSystemInterface::load_mujoco_plugins()
   {
     RCLCPP_ERROR(get_logger(), "Failed to create plugin loader: %s", ex.what());
   }
+
+  // Connect plugin pre-step callbacks directly to the physics simulation.
+  simulation_->set_pre_step_callback([this](mjData* data) {
+    for (auto& plugin : plugin_instances_)
+    {
+      plugin->pre_step(data);
+    }
+  });
 }
 
 ///

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -229,32 +229,27 @@ TEST_F(MujocoSimulationTest, ControlUpdateTests)
   mj_deleteData(control);
 }
 
-TEST_F(MujocoSimulationTest, XfrcAppliedTests)
+TEST_F(MujocoSimulationTest, PreStepCallbackAppliesXfrcApplied)
 {
   ASSERT_TRUE(initialize_sim());
 
-  // Simulate the read/write cycle in the ros2_control loop, making sure data
-  // is updated where expected
-  mjData* control = nullptr;
-  sim_->copy_physics_data(control);
-  ASSERT_NE(control, nullptr);
-
-  // Zero xfrc_applied (like for plugins), and apply a force
+  // xfrc_applied is not staged through apply_control_data, instead we register a pre-step callback that
+  // writes directly into the live mjData immediately before every mj_step.
   const size_t body_id = 1;
-  mju_zero(control->xfrc_applied, 6 * sim_->model()->nbody);
-  control->xfrc_applied[body_id * 6 + 0] = 1.0;
-  control->xfrc_applied[body_id * 6 + 1] = 2.0;
-  control->xfrc_applied[body_id * 6 + 2] = 3.0;
+  sim_->set_pre_step_callback([body_id](mjData* data) {
+    data->xfrc_applied[body_id * 6 + 0] = 1.0;
+    data->xfrc_applied[body_id * 6 + 1] = 2.0;
+    data->xfrc_applied[body_id * 6 + 2] = 3.0;
+  });
 
-  sim_->apply_control_data(control);
-
-  // xfrc_applied should NOT be in mj_data_ directly, it goes through the triple
-  // plugin buffer and gets composed in the physics loop
+  // The callback has not run yet as it is only invoked from the physics loop.
   EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 0], 0.0);
-  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 1], 0.0);
-  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 2], 0.0);
 
-  mj_deleteData(control);
+  sim_->start_physics_thread();
+  EXPECT_TRUE(wait_until([this, body_id]() { return sim_->data()->xfrc_applied[body_id * 6 + 0] == 1.0; }))
+      << "pre_step callback's xfrc_applied write was not applied by the physics loop";
+  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 1], 2.0);
+  EXPECT_DOUBLE_EQ(sim_->data()->xfrc_applied[body_id * 6 + 2], 3.0);
 }
 
 TEST_F(MujocoSimulationTest, PauseStepUnpause)

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -326,11 +326,9 @@ Each cycle, the commanded body-frame ``vx``/``vy`` is clamped to ``max_linear_ve
 direction) and rotated into the world frame using the body's current orientation, since a free
 joint's linear ``qvel`` is expressed in the world frame. The commanded yaw-rate is clamped to
 ``max_yaw_rate`` and used as-is, since a free joint's rotational ``qvel`` is already expressed in
-the body-local frame. The result is written directly into ``data->qvel`` during ``update()``:
-the core NaN-fills ``qvel`` before every plugin's ``update()`` runs, so writing a finite value
-into an entry requests a hard velocity override there, applied by the core simulation as a direct
-``qvel`` write immediately before the next physics step (see "Creating Your Own Plugin" below for
-the full mechanism, which is not available through ``xfrc_applied`` alone).
+the body-local frame. The result is written directly into ``data->qvel`` during ``pre_step()``,
+which runs on the physics thread immediately before every ``mj_step``, which will happen per physics
+step!
 
 A command that hasn't been refreshed within ``cmd_timeout`` seconds is treated as zero (safety
 stop) rather than left to coast on the last commanded velocity.
@@ -602,7 +600,12 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
    {
    public:
      bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
+
+     // Override whichever of these you need -- both have a no-op default, see
+     // "Plugin Lifecycle" below for how they differ.
      void update(const mjModel* model, mjData* data) override;
+     void pre_step(mjData* data) override;
+
      void cleanup() override;
 
    private:
@@ -633,7 +636,12 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
 
    void MyCustomPlugin::update(const mjModel* model, mjData* data)
    {
-     // Called every control loop iteration
+     // Called once per ros2_control write() cycle, on the control thread.
+   }
+
+   void MyCustomPlugin::pre_step(mjData* data)
+   {
+     // Called on the physics thread, immediately before every mj_step.
    }
 
    void MyCustomPlugin::cleanup()
@@ -693,27 +701,24 @@ Plugin Lifecycle
 
 1. **Initialization** (``init``): Called once when the plugin is loaded. Use this to read
    parameters and set up publishers, subscribers, and services.
-2. **Update** (``update``): Called every simulation step at the **end of the** ``read`` **loop**,
-   before the controller update and ``write`` loops. Changes to ``mjData`` here are visible to
-   controllers and affect the next simulation step. This runs in a real-time thread — avoid
-   blocking operations.
-
-   ``data->qvel`` here has one special property: it is **NaN-filled before every plugin's**
-   ``update()`` **runs this cycle**. Most plugins never touch it and can ignore this entirely.
-   A plugin that needs to *dictate* a free joint's velocity exactly (``BaseVelocityPlugin`` is
-   the example in this package) can write a finite value into any ``qvel`` entry to request a
-   hard velocity override there — the core simulation applies every non-NaN entry as a direct
-   ``qvel`` write immediately before the next ``mj_step``, bypassing the normal mass/contact
-   dynamics for that DOF. This exists because plugins only ever see a throwaway copy of
-   ``mjData`` — only ``ctrl``, ``qfrc_applied``, and ``xfrc_applied`` are otherwise copied back
-   into the real simulation state, so this NaN convention is the only way a plugin can
-   influence ``qvel`` at all. Leaving an entry ``NaN`` keeps its normal physics-driven value;
-   because of this, ``data->qvel`` cannot be read here for the body's actual velocity either,
-   since it isn't restored to a real value until after every plugin's ``update()`` has run.
-   See ``MuJoCoROS2ControlPluginBase::update()``'s doc comment in
-   ``mujoco_ros2_control_plugins_base.hpp`` for the authoritative reference.
-3. **Cleanup** (``cleanup``): Called when shutting down. Release any resources acquired in
+2. **Update** (``update``, optional): Called once per ``ros2_control`` ``write()`` cycle, on the
+   control thread. ``data`` is a recent snapshot, not the live simulation data. Use this for
+   anything that doesn't need to run on exactly one physics step: publishing sensor data,
+   servicing a trigger, etc. Most plugins in this package (``CameraPlugin``, the lidar plugins,
+   ``HeartbeatPublisherPlugin``, ``FreeJointStatePublisherPlugin``) use only this hook.
+3. **Pre-step** (``pre_step``, optional): Called on the physics thread, immediately before every
+   ``mj_step`` -- including multiple times per outer iteration when the loop batches steps to
+   catch up. ``data`` is the live simulation data: read and write it directly, with no separate
+   command buffer, so an untouched entry keeps its last value. Use this for anything that must
+   hold for exactly one physics step, such as ``BaseVelocityPlugin``'s kinematic velocity
+   override. Runs with the simulation mutex held, so blocking here stalls the physics loop and
+   native viewer too.
+4. **Cleanup** (``cleanup``): Called when shutting down. Release any resources acquired in
    ``init``.
+
+Both hooks default to doing nothing, so implement whichever fits (or both, or neither). See
+``MuJoCoROS2ControlPluginBase``'s class doc comment in ``mujoco_ros2_control_plugins_base.hpp``
+for the authoritative reference.
 
 
 Building

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -24,9 +24,21 @@ namespace mujoco_ros2_control_plugins
 /**
  * @brief Base class for MuJoCo ROS 2 control plugins
  *
- * This is an example base class that plugins can inherit from.
- * Plugins can extend the functionality of mujoco_ros2_control
- * by implementing custom behaviors.
+ * Plugins extend mujoco_ros2_control with custom behavior, e.g. publishing extra topics or
+ * applying external forces.
+ *
+ * Two optional hooks are available. Override whichever fits your use case:
+ *
+ * - `update()` runs on the ros2_control control thread, once per `write()` cycle. `data` is a
+ *   recent snapshot, not the live `mj_data_`. Use this for anything that doesn't need to run on
+ *   exactly one physics step, e.g. publishing sensor data or servicing a trigger.
+ * - `pre_step()` runs on the physics thread, immediately before every `mj_step()`, with direct
+ *   access to the live `mj_data_`. Use this for anything that must hold for exactly one step,
+ *   e.g. a hard kinematic override. There's no command buffer: an untouched entry keeps its
+ *   last value, so releasing a command (e.g. an expired force) needs an explicit write. This
+ *   should be used with caution!
+ *
+ * @note Both hooks must avoid blocking or the control loop or simulation itself will be held up!
  */
 class MuJoCoROS2ControlPluginBase
 {
@@ -46,22 +58,24 @@ public:
   virtual bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) = 0;
 
   /**
-   * @brief Update the plugin (called every simulation step)
+   * @brief Called once per control cycle, on the control thread. Default does nothing.
    * @param model Pointer to the MuJoCo model
-   * @param data Pointer to the MuJoCo data
-   * @note This method will be called at the end of the mujoco_ros2_control read loop, before the update loop of
-   * controllers and the write loop. This means that changes to the data here will be visible to controllers and will
-   * affect the next simulation step.
-   * @note This method will be called in a real-time thread, so it should avoid blocking operations and should be
-   * efficient.
-   * @note data->qvel is NaN-filled before every plugin's update() runs this cycle. Write a finite value into any
-   * entry to request a hard velocity override on that DOF -- it bypasses the normal mass/contact dynamics for that
-   * DOF this step, overwriting mj_data_->qvel directly right before the next mj_step. Leave an entry NaN to keep its
-   * normal physics-driven value untouched. This is the only channel a plugin has to influence qvel: unlike
-   * ctrl/qfrc_applied/xfrc_applied, data->qvel here cannot be read for the body's actual velocity, since it is not
-   * restored to a real value until after every plugin's update() has run this cycle.
+   * @param data Pointer to a recent snapshot (not the live `mj_data_`)
    */
-  virtual void update(const mjModel* model, mjData* data) = 0;
+  virtual void update(const mjModel* /*model*/, mjData* /*data*/)
+  {
+  }
+
+  /**
+   * @brief Called immediately before every simulation step on the physics thread. Default does nothing.
+   *
+   * USE WITH CAUTION.
+   *
+   * @param data Pointer to the live MuJoCo data, can be modified as needed.
+   */
+  virtual void pre_step(mjData* /*data*/)
+  {
+  }
 
   /**
    * @brief Cleanup the plugin

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.cpp
@@ -128,7 +128,7 @@ void BaseVelocityPlugin::storeCommand(double vx, double vy, double wz)
   latest_cmd_ = { vx, vy, wz, node_->get_clock()->now() };
 }
 
-void BaseVelocityPlugin::update(const mjModel* /*model_arg*/, mjData* data)
+void BaseVelocityPlugin::pre_step(mjData* data)
 {
   // Step 1 - refresh the cached command from the subscription callback without
   // blocking the real-time thread; if the lock is contended, keep using the last

--- a/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/base_velocity_plugin.hpp
@@ -31,9 +31,7 @@ namespace mujoco_ros2_control_plugins
 /**
  * @brief Drives a mobile/floating-base robot from a commanded planar body velocity
  *        (vx, vy, yaw-rate) by writing a hard kinematic override of the base's free-joint
- *        velocity directly into data->qvel every cycle (see
- *        MuJoCoROS2ControlPluginBase::update()'s doc comment for the NaN convention this
- *        relies on).
+ *        velocity directly into data->qvel every cycle.
  *
  * Wheel-terrain friction/slip modelling is often unreliable enough to make it a poor
  * foundation for testing navigation stacks. This plugin instead subscribes to a
@@ -73,7 +71,7 @@ public:
   ~BaseVelocityPlugin() override = default;
 
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-  void update(const mjModel* model, mjData* data) override;
+  void pre_step(mjData* data) override;
   void cleanup() override;
 
 private:
@@ -106,12 +104,12 @@ private:
   };
 
   // Latest command, written by the subscription callback (ROS executor thread) under
-  // cmd_mutex_. update() (real-time thread) copies it into cached_cmd_ via try_lock, so
+  // cmd_mutex_. pre_step() (physics thread) copies it into cached_cmd_ via try_lock, so
   // it never blocks on the subscription callback.
   std::mutex cmd_mutex_;
   CommandState latest_cmd_;
 
-  // Local copy of the command, only ever touched from update() (single real-time thread).
+  // Local copy of the command, only ever touched from pre_step() (physics thread).
   CommandState cached_cmd_;
 };
 

--- a/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
@@ -55,12 +55,10 @@ bool ExternalWrenchPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* mod
   return true;
 }
 
-void ExternalWrenchPlugin::update(const mjModel* /*model_arg*/, mjData* data)
+void ExternalWrenchPlugin::pre_step(mjData* data)
 {
-  // Step 0 - undo the xfrc_applied contributions written in the previous cycle
-  // so stale forces are never left in the array when all wrenches have expired.
-  // When the system interface also zeroes xfrc_applied before calling update(),
-  // this loop is a harmless no-op on already-zero values.
+  // Step 0 - undo the xfrc_applied contributions written last cycle, so an expired wrench is
+  // actually released instead of left in place.
   for (const int body_id : prev_written_body_ids_)
   {
     mjtNum* base = data->xfrc_applied + body_id * 6;

--- a/mujoco_ros2_control_plugins/src/external_wrench_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/external_wrench_plugin.hpp
@@ -80,13 +80,10 @@ namespace mujoco_ros2_control_plugins
  * where R = data->xmat (body → world rotation) and
  *       p_world = data->xpos + R * application_point_body.
  *
- * At the start of every update() call the plugin zeroes the xfrc_applied slots
- * it wrote during the previous cycle before re-accumulating the current active
- * wrenches.  This self-cleanup ensures the plugin leaves no stale contributions
- * in xfrc_applied when all wrenches have expired.  When the surrounding system
- * interface also zeroes xfrc_applied before calling update() (as
- * MujocoSystemInterface::read() does), the plugin's undo step is a harmless
- * no-op on already-zero values.
+ * pre_step() writes directly into the live xfrc_applied, which holds its value across steps
+ * until written again. So at the start of every pre_step() call, the plugin zeroes the
+ * xfrc_applied slots it wrote last cycle before re-accumulating the active wrenches, that
+ * will release the expired wrenches.
  */
 class ExternalWrenchPlugin : public MuJoCoROS2ControlPluginBase
 {
@@ -95,7 +92,7 @@ public:
   ~ExternalWrenchPlugin() override = default;
 
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
-  void update(const mjModel* model, mjData* data) override;
+  void pre_step(mjData* data) override;
   void cleanup() override;
 
   /**
@@ -135,7 +132,7 @@ private:
   void handleApplyWrench(const ApplyExternalWrench::Request::SharedPtr request,
                          ApplyExternalWrench::Response::SharedPtr response);
 
-  /// Publish the result of publish_markers() via the realtime publisher. Called from update().
+  /// Publish the result of publish_markers() via the realtime publisher. Called from pre_step().
   void publish_markers();
 
   // ROS interfaces
@@ -149,15 +146,15 @@ private:
   // Model pointer (const, valid for simulation lifetime)
   const mjModel* model_{ nullptr };
 
-  // Pending queue written by service callback, drained in update()
+  // Pending queue written by service callback, drained in pre_step()
   std::mutex pending_mutex_;
   std::queue<ActiveWrench> pending_wrenches_;
 
-  // Active wrenches — only modified inside update()
+  // Active wrenches — only modified inside pre_step()
   std::vector<ActiveWrench> active_wrenches_;
 
-  // Body IDs whose xfrc_applied slots were written in the previous update() call.
-  // Zeroed at the start of the next update() before re-accumulating.
+  // Body IDs whose xfrc_applied slots were written in the previous pre_step() call.
+  // Zeroed at the start of the next pre_step() before re-accumulating.
   std::vector<int> prev_written_body_ids_;
 
   // Marker visualization scaling

--- a/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_base_velocity_plugin.cpp
@@ -237,7 +237,7 @@ TEST_F(BaseVelocityPluginTest, NoCommandRequestsZeroVelocity)
   auto plugin = makeInitializedPlugin();
   fillQvelNaN();
 
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   const mjtNum* qvel = data_->qvel + dofAdr();
   EXPECT_DOUBLE_EQ(qvel[0], 0.0);
@@ -259,7 +259,7 @@ TEST_F(BaseVelocityPluginTest, CommandIsReportedAsOverride)
   fillQvelNaN();
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.3);
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   const mjtNum* qvel = data_->qvel + dofAdr();
   // Identity orientation => body-x == world-x. This is a direct assignment, not a servo,
@@ -282,13 +282,13 @@ TEST_F(BaseVelocityPluginTest, StaleCommandRequestsZeroVelocity)
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
 
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
   const mjtNum* qvel = data_->qvel + dofAdr();
   ASSERT_GT(qvel[0], 0.0) << "sanity: velocity requested while command is fresh";
 
   // Wait past the timeout without publishing again.
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   EXPECT_NEAR(qvel[0], 0.0, 1e-9) << "stale command should be treated as zero";
 
@@ -301,7 +301,7 @@ TEST_F(BaseVelocityPluginTest, LinearCommandIsClampedToMaxLinearVelocity)
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/5.0, /*vy=*/0.0, /*wz=*/0.0);
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   const mjtNum* qvel = data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[0], 0.2, 1e-9);
@@ -315,7 +315,7 @@ TEST_F(BaseVelocityPluginTest, YawCommandIsClampedToMaxYawRate)
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/0.0, /*vy=*/0.0, /*wz=*/5.0);
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   const mjtNum* qvel = data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[5], 0.3, 1e-9);
@@ -330,7 +330,7 @@ TEST_F(BaseVelocityPluginTest, UnsetLimitsDoNotClamp)
   auto plugin = makeInitializedPlugin();
 
   publishTwist("cmd_vel", /*vx=*/1000.0, /*vy=*/0.0, /*wz=*/1000.0);
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   const mjtNum* qvel = data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[0], 1000.0, 1e-6);
@@ -355,7 +355,7 @@ TEST_F(BaseVelocityPluginTest, BodyFrameCommandIsRotatedIntoFreeJointFrame)
   mj_forward(model_, data_);
 
   publishTwist("cmd_vel", /*vx=*/1.0, /*vy=*/0.0, /*wz=*/0.0);
-  plugin->update(model_, data_);
+  plugin->pre_step(data_);
 
   const mjtNum* qvel = data_->qvel + dofAdr();
   EXPECT_NEAR(qvel[0], 0.0, 1e-6) << "world-x should be ~0 after a 90 deg yaw";

--- a/mujoco_ros2_control_plugins/test/test_external_wrench_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_external_wrench_plugin.cpp
@@ -241,7 +241,7 @@ TEST_F(ExternalWrenchPluginTest, UpdateAppliesForceToXfrcApplied)
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   // At least one xfrc_applied entry must carry a non-zero value.
   double total = 0.0;
@@ -264,10 +264,10 @@ TEST_F(ExternalWrenchPluginTest, UpdateUndoesPreviousContributionOnNextCall)
   ASSERT_TRUE(resp->success);
 
   // First update: wrench applied, then immediately expired (zero duration).
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   // Second update: plugin subtracts its saved contribution; no active wrenches remain.
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   for (int i = 0; i < model_->nbody * 6; ++i)
   {
@@ -295,7 +295,7 @@ TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
   }
 
   // First update: both wrenches active, both expire (zero duration).
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   double total_both = 0.0;
   for (int i = 0; i < model_->nbody * 6; ++i)
@@ -304,7 +304,7 @@ TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
   }
 
   // Second update clears state.
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   // Queue a single wrench of the same magnitude.
   {
@@ -313,7 +313,7 @@ TEST_F(ExternalWrenchPluginTest, MultipleWrenchesAccumulateLinearly)
     ASSERT_TRUE(r->success);
   }
 
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   double total_one = 0.0;
   for (int i = 0; i < model_->nbody * 6; ++i)
@@ -339,7 +339,7 @@ TEST_F(ExternalWrenchPluginTest, TorqueOnlyWrenchAppliesRotationalForce)
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   double total = 0.0;
   for (int i = 0; i < model_->nbody * 6; ++i)
@@ -382,7 +382,7 @@ TEST_F(ExternalWrenchPluginTest, SingleCallWithMultipleWrenchesAppliesAll)
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   double total = 0.0;
   for (int i = 0; i < model_->nbody * 6; ++i)
@@ -427,7 +427,7 @@ TEST_F(ExternalWrenchPluginTest, SingleCallRejectsIfAnyBodyNameInvalid)
   EXPECT_FALSE(resp->message.empty());
 
   // No wrench should have been applied — xfrc_applied must remain zero.
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
   for (int i = 0; i < model_->nbody * 6; ++i)
   {
     EXPECT_DOUBLE_EQ(data_->xfrc_applied[i], 0.0) << "xfrc_applied[" << i << "] must be zero after rejected batch";
@@ -442,14 +442,14 @@ TEST_F(ExternalWrenchPluginTest, PublishMarkersForActiveForceWrench)
   ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
 
   // Send a wrench with a 200 ms duration from a background thread so the
-  // sleeping service callback does not block update() in the main thread.
+  // sleeping service callback does not block pre_step() in the main thread.
   std::thread svc_thread([this]() { callServiceWithDuration("test_body", 0.2, /*fx=*/10.0); });
 
   // Wait briefly for the wrench to reach the pending queue.
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-  // Run update() while the wrench is still active.
-  plugin.update(model_, data_);
+  // Run pre_step() while the wrench is still active.
+  plugin.pre_step(data_);
 
   // Collect markers via the new aggregation API.
   MarkerArray markers;
@@ -484,7 +484,7 @@ TEST_F(ExternalWrenchPluginTest, PublishMarkersContributesNothingWhenNoWrenchesA
   ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
 
   // No service calls — no active wrenches.
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   // publish_markers() must not append anything when there are no active wrenches.
   // Marker lifetime-based expiry (managed by the system interface) handles cleanup
@@ -504,7 +504,7 @@ TEST_F(ExternalWrenchPluginTest, PublishMarkersAppendsToExistingArray)
 
   std::thread svc_thread([this]() { callServiceWithDuration("test_body", 0.2, /*fx=*/5.0, /*fy=*/0.0, /*fz=*/0.0); });
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  plugin.update(model_, data_);
+  plugin.pre_step(data_);
 
   // Pre-populate the array with a sentinel marker (simulates another plugin's contribution).
   MarkerArray markers;


### PR DESCRIPTION
This will provide god-like powers to plugins without breaking existing contracts. As it is a new interface.

Basically did what I mentioned in [this comment](https://github.com/ros-controls/mujoco_ros2_control/pull/262#pullrequestreview-4940734863). Added a hook into `MujocoSimulation` and extended the plugin interface with an opportunity to modify `mj_data` before the simulation steps. Plugins can modify data before stepping as needed, and we no longer need special cases for applied forces or velocities, so got to remove that.

Perhaps something to consider as an alternative solution to keep `MujocoSimulation` pure and avoid major changes to the API.

Closes #262