### PR TITLE
Adding Tracking camera as a parameter

### DIFF
--- a/mujoco_ros2_control/docs/hardware_interface.rst
+++ b/mujoco_ros2_control/docs/hardware_interface.rst
@@ -41,6 +41,10 @@ Specify it in your URDF and point to a valid MJCF on launch:
        <!-- Optional: run the simulator without a GUI window. Defaults to false. -->
        <param name="headless">false</param>
 
+       <!-- Optional: name of a body for the viewer camera to track on startup. When set, the
+            camera starts in tracking mode instead of the default free camera. -->
+       <param name="camera_tracked_body">base_link</param>
+
        <!-- Optional: name of a MuJoCo free joint whose odometry is published as a
             nav_msgs/Odometry message. -->
        <param name="odom_free_joint_name">floating_base_joint</param>

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_simulation.hpp
@@ -131,7 +131,7 @@ public:
    * running headless). It also sets up required publishers and services using the provided node.
    */
   bool initialize(rclcpp::Node::SharedPtr node, const std::string& model_path, const std::string& mujoco_model_topic,
-                  double sim_speed_factor, bool headless);
+                  double sim_speed_factor, bool headless, const std::string& camera_tracked_body);
 
   /**
    * @brief Apply a keyframe to the simulation by name.
@@ -182,6 +182,16 @@ public:
   mjData* data()
   {
     return mj_data_;
+  }
+
+  /**
+   * @brief Accessor for the viewer camera.
+   *
+   * The Simulate app holds a reference to this camera, so it reflects the live view state.
+   */
+  const mjvCamera& camera() const
+  {
+    return cam_;
   }
 
   /**
@@ -337,6 +347,15 @@ private:
    * @brief Loops the physics simulation until asked to terminate.
    */
   void physics_loop();
+
+  /**
+   * @brief Point the viewer camera at `camera_tracked_body_`, if one was requested.
+   *
+   * Must run after the model has been handed to the Simulate app: `LoadOnRenderThread` calls
+   * `AlignAndScaleView`, which resets the camera to the default free camera on every new model.
+   * Leaves the free camera in place if the body name does not resolve.
+   */
+  void apply_tracking_camera();
 
   /**
    * @brief Publish the current sim time to /clock.
@@ -513,6 +532,9 @@ private:
   mjvCamera cam_;
   mjvOption opt_;
   mjvPerturb pert_;
+
+  // Name of the body the viewer camera tracks at startup. Empty leaves the default free camera.
+  std::string camera_tracked_body_;
 
   // Speed scaling parameter. if set to >0 then we ignore the value set in the simulate app and instead
   // attempt to loop at whatever this is set to. If this is <0, then we use the value from the app.

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -528,13 +528,15 @@ MujocoSimulation::~MujocoSimulation()
 }
 
 bool MujocoSimulation::initialize(rclcpp::Node::SharedPtr node, const std::string& model_path,
-                                  const std::string& mujoco_model_topic, double sim_speed_factor, bool headless)
+                                  const std::string& mujoco_model_topic, double sim_speed_factor, bool headless,
+                                  const std::string& camera_tracked_body)
 {
   node_ = node;
   model_path_ = model_path;
   mujoco_model_topic_ = mujoco_model_topic;
   sim_speed_factor_ = sim_speed_factor;
   headless_ = headless;
+  camera_tracked_body_ = camera_tracked_body;
 
   if (sim_speed_factor_ > 0)
   {
@@ -755,6 +757,31 @@ bool MujocoSimulation::apply_keyframe(const std::string& keyframe_name)
   return true;
 }
 
+void MujocoSimulation::apply_tracking_camera()
+{
+  if (camera_tracked_body_.empty())
+  {
+    return;
+  }
+
+  const int body_id = mj_name2id(mj_model_, mjOBJ_BODY, camera_tracked_body_.c_str());
+  if (body_id == -1)
+  {
+    RCLCPP_WARN(get_logger(),
+                "Body '%s' requested for camera tracking was not found in the MuJoCo model. "
+                "Falling back to the free camera.",
+                camera_tracked_body_.c_str());
+    return;
+  }
+
+  const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
+  cam_.type = mjCAMERA_TRACKING;
+  cam_.trackbodyid = body_id;
+  cam_.fixedcamid = -1;
+
+  RCLCPP_INFO(get_logger(), "Viewer camera is tracking body '%s' (id %d).", camera_tracked_body_.c_str(), body_id);
+}
+
 void MujocoSimulation::capture_initial_state()
 {
   const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);
@@ -795,6 +822,10 @@ void MujocoSimulation::start_physics_thread()
     {
       sim_->Load(mj_model_, mj_data_, model_path_.c_str());
     }
+
+    // Must follow the load: Simulate resets to the free camera whenever it loads a new model.
+    this->apply_tracking_camera();
+
     // lock the sim mutex
     {
       const std::unique_lock<std::recursive_mutex> lock(*sim_mutex_);

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -325,6 +325,9 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
   const bool headless =
       hardware_interface::parse_bool(get_hardware_parameter(get_hardware_info(), "headless").value_or("false"));
 
+  // Optional: body for the viewer camera to track on startup
+  const std::string camera_tracked_body = get_hardware_parameter_or(get_hardware_info(), "camera_tracked_body", "");
+
   // Construct and start the ROS node spinning
   /// The PIDs config file
   const auto pids_config_file = get_hardware_parameter(get_hardware_info(), "pids_config_file");
@@ -365,7 +368,8 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
 
   // Construct the simulation wrapper with the loaded parameters.
   simulation_ = std::make_unique<MujocoSimulation>();
-  if (!simulation_->initialize(get_node(), model_path, mujoco_model_topic, sim_speed_factor, headless))
+  if (!simulation_->initialize(get_node(), model_path, mujoco_model_topic, sim_speed_factor, headless,
+                               camera_tracked_body))
   {
     return hardware_interface::CallbackReturn::ERROR;
   }

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -141,9 +141,9 @@ protected:
   }
 
   // initialize the simulation in headless mode with default settings.
-  bool initialize_sim()
+  bool initialize_sim(const std::string& camera_tracked_body = "")
   {
-    return sim_->initialize(node_, kTestModelPath, "/mujoco_robot_description", -1.0, true);
+    return sim_->initialize(node_, kTestModelPath, "/mujoco_robot_description", -1.0, true, camera_tracked_body);
   }
 
   // Helper function to poll a condition until it returns true or the timeout expires.
@@ -199,6 +199,28 @@ TEST_F(MujocoSimulationTest, TestInitialization)
   EXPECT_EQ(sim_->model()->nv, 13);
   EXPECT_EQ(sim_->model()->nu, 1);
   EXPECT_EQ(sim_->model()->nbody, 4);
+}
+
+TEST_F(MujocoSimulationTest, TrackingCameraFollowsNamedBody)
+{
+  ASSERT_TRUE(initialize_sim("pendulum"));
+  sim_->start_physics_thread();
+  const int expected_id = mj_name2id(sim_->model(), mjOBJ_BODY, "pendulum");
+  ASSERT_NE(expected_id, -1);
+  EXPECT_TRUE(wait_until([this, expected_id]() {
+    return sim_->camera().type == mjCAMERA_TRACKING && sim_->camera().trackbodyid == expected_id;
+  })) << "Camera did not switch to tracking the requested body";
+}
+
+TEST_F(MujocoSimulationTest, TrackingCameraFallsBackOnUnknownBody)
+{
+  ASSERT_TRUE(initialize_sim("not_a_body"));
+
+  sim_->start_physics_thread();
+
+  // Let the physics loop run so that the camera would have been applied if it were going to be.
+  ASSERT_TRUE(wait_until([this]() { return sim_->step_count() > 0; }));
+  EXPECT_EQ(sim_->camera().type, mjCAMERA_FREE);
 }
 
 TEST_F(MujocoSimulationTest, ControlUpdateTests)


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
Adds an optional `camera_tracked_body` hardware parameter. When set, the viewer starts with
  `cam.type = mjCAMERA_TRACKING` and `trackbodyid` resolved from the body name instead of the
  default free camera. Nothing has to be added to the model.




<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #273 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
 Yes, but opt-in. If the param is unset (the default) the camera behaves exactly as before.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
Yes, Claude (Opus 5). I used it to explore how Simulate handles the camera and to work out
  where the camera had to be set, and to draft the implementation, which I then typed, built and
  debugged myself. It also flagged the formatting issues. The manual verification in the viewer
  was done using the demo package.


### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
 The tests cover name resolution and the fallback on an unknown body, but they run headless, and
  headless skips `sim_->Load()` entirely, so they don't exercise the ordering described above.
  They'd pass even with the camera set in the wrong place. I checked the real behaviour by hand
  with the mobile base demo. I couldn't see a clean way to cover it in CI; open to suggestions.

  ESC still drops back to the free camera. Happy to follow up with a runtime service to re-track a body as a separate PR, which would cover that.

  `camera_tracked_body` was my own naming choice rather than an existing convention here  happy
  to rename it.