### PR TITLE
Remove deprecated tinyxml2_vendor dependency

### DIFF
--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(mujoco_ros2_control_plugins REQUIRED)
 find_package(Threads REQUIRED)
 find_package(transmission_interface REQUIRED)
 find_package(backward_ros REQUIRED)
-find_package(tinyxml2_vendor QUIET)
 find_package(TinyXML2 REQUIRED)
 
 # Link MuJoCo via the vendor package

--- a/mujoco_ros2_control/package.xml
+++ b/mujoco_ros2_control/package.xml
@@ -38,7 +38,6 @@
   <depend>rosgraph_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tinyxml2_vendor</depend>
   <depend>mujoco_ros2_control_msgs</depend>
   <depend>mujoco_ros2_control_plugins</depend>
   <depend>transmission_interface</depend>


### PR DESCRIPTION
`mujoco_ros2_control` already requires `TinyXML2` directly and explicitly links `tinyxml2::tinyxml2`. The additional `tinyxml2_vendor` lookup and manifest dependency are therefore redundant and now emit a deprecation warning on ROS 2 Lyrical.

This removes only those two obsolete declarations. The Lyrical build resolves the distributed TinyXML2 CMake package and the resulting control library links `libtinyxml2.so.11` as before.

Validation:

- reproduced the `tinyxml2_vendor` deprecation on the exact parent commit using the repository's Lyrical Docker build
- rebuilt all 6 packages after the change with no `tinyxml2_vendor` reference or warning
- ran the full Lyrical test suite: 268 tests, 0 errors, 0 failures, 13 skipped
- ran the repository pre-commit hooks on both changed files

Closes #276.

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-18)
