### PR TITLE
Fix plugin parameter namespaces

### DIFF
--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -152,14 +152,14 @@ void CameraPlugin::trigger_update()
 
 bool CameraPlugin::register_cameras()
 {
-  const std::string param_prefix = "mujoco_plugins.mujoco_camera_plugin.";
-
-  if (!node_->has_parameter(param_prefix + "camera_publish_rate"))
+  const std::string param_prefix = "mujoco_plugins." + node_->get_sub_namespace() + ".";
+  const std::string camera_publish_rate_param = param_prefix + "camera_publish_rate";
+  if (!node_->has_parameter(camera_publish_rate_param))
   {
-    node_->declare_parameter(param_prefix + "camera_publish_rate", 5.0);
+    node_->declare_parameter(camera_publish_rate_param, 5.0);
   }
 
-  camera_publish_rate_ = node_->get_parameter(param_prefix + "camera_publish_rate").as_double();
+  camera_publish_rate_ = node_->get_parameter(camera_publish_rate_param).as_double();
   RCLCPP_INFO(node_->get_logger(), "Publishing camera data at rate %f per second.", camera_publish_rate_);
 
   cameras_.resize(0);

--- a/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/external_wrench_plugin.cpp
@@ -31,16 +31,19 @@ bool ExternalWrenchPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* mod
   model_ = model;
 
   // Visualization parameters
-  if (!node_->has_parameter("force_arrow_scale"))
+  const std::string param_prefix = "mujoco_plugins." + node_->get_sub_namespace() + ".";
+  const std::string force_arrow_scale_param = param_prefix + "force_arrow_scale";
+  if (!node_->has_parameter(force_arrow_scale_param))
   {
-    node_->declare_parameter("force_arrow_scale", force_arrow_scale_);
+    node_->declare_parameter(force_arrow_scale_param, force_arrow_scale_);
   }
-  if (!node_->has_parameter("torque_arrow_scale"))
+  const std::string torque_arrow_scale_param = param_prefix + "torque_arrow_scale";
+  if (!node_->has_parameter(torque_arrow_scale_param))
   {
-    node_->declare_parameter("torque_arrow_scale", torque_arrow_scale_);
+    node_->declare_parameter(torque_arrow_scale_param, torque_arrow_scale_);
   }
-  force_arrow_scale_ = node_->get_parameter("force_arrow_scale").as_double();
-  torque_arrow_scale_ = node_->get_parameter("torque_arrow_scale").as_double();
+  force_arrow_scale_ = node_->get_parameter(force_arrow_scale_param).as_double();
+  torque_arrow_scale_ = node_->get_parameter(torque_arrow_scale_param).as_double();
 
   marker_pub_raw_ = node_->create_publisher<MarkerArray>("~/wrench_markers", rclcpp::SystemDefaultsQoS());
   marker_pub_ = std::make_unique<realtime_tools::RealtimePublisher<MarkerArray>>(marker_pub_raw_);

--- a/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/free_joint_state_publisher_plugin.cpp
@@ -84,27 +84,32 @@ bool FreeJointStatePublisherPlugin::init(rclcpp::Node::SharedPtr node, const mjM
   model_ = model;
   logger_ = node_->get_logger().get_child(node->get_sub_namespace());
 
-  if (!node_->has_parameter("frame_id"))
+  const std::string param_prefix = "mujoco_plugins." + node_->get_sub_namespace() + ".";
+  const std::string frame_id_param = param_prefix + "frame_id";
+  if (!node_->has_parameter(frame_id_param))
   {
-    node_->declare_parameter("frame_id", std::string(""));
+    node_->declare_parameter(frame_id_param, std::string(""));
   }
-  if (!node_->has_parameter("body_names"))
+  const std::string body_names_param = param_prefix + "body_names";
+  if (!node_->has_parameter(body_names_param))
   {
-    node_->declare_parameter("body_names", std::vector<std::string>{});
+    node_->declare_parameter(body_names_param, std::vector<std::string>{});
   }
-  if (!node_->has_parameter("topic"))
+  const std::string topic_param = param_prefix + "topic";
+  if (!node_->has_parameter(topic_param))
   {
-    node_->declare_parameter("topic", std::string("free_joint_states"));
+    node_->declare_parameter(topic_param, std::string("free_joint_states"));
   }
-  if (!node_->has_parameter("publish_rate"))
+  const std::string publish_rate_param = param_prefix + "publish_rate";
+  if (!node_->has_parameter(publish_rate_param))
   {
-    node_->declare_parameter("publish_rate", 50.0);
+    node_->declare_parameter(publish_rate_param, 50.0);
   }
 
-  const std::string frame_id = node_->get_parameter("frame_id").as_string();
-  const std::vector<std::string> body_names = node_->get_parameter("body_names").as_string_array();
-  const std::string topic = node_->get_parameter("topic").as_string();
-  const double publish_rate = node_->get_parameter("publish_rate").as_double();
+  const std::string frame_id = node_->get_parameter(frame_id_param).as_string();
+  const std::vector<std::string> body_names = node_->get_parameter(body_names_param).as_string_array();
+  const std::string topic = node_->get_parameter(topic_param).as_string();
+  const double publish_rate = node_->get_parameter(publish_rate_param).as_double();
 
   if (publish_rate <= 0.0)
   {

--- a/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/mujoco_3d_lidar_plugin.cpp
@@ -219,7 +219,7 @@ bool Mujoco3dLidarPlugin::register_sensor(const mjModel* model, int sensor_idx)
   // site name in the MJCF if not provided. Topics default to `/scan` and `/points` for 2-D and
   // 3-D scans, respectively.
   // Note that we must prefix our param declarations to ensure nesting works out properly.
-  const std::string param_prefix = "mujoco_plugins.mujoco_3d_lidar_plugin.";
+  const std::string param_prefix = "mujoco_plugins." + node_->get_sub_namespace() + ".";
   const auto site_name = mj_id2name(model, mjtObj::mjOBJ_SITE, model->sensor_objid[sensor_idx]);
   const std::string frame_name_param = param_prefix + lidar_config.name + ".frame_name";
   if (!node_->has_parameter(frame_name_param))

--- a/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/rangefinder_lidar_plugin.cpp
@@ -124,7 +124,7 @@ bool RangefinderLidarPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* m
 
 bool RangefinderLidarPlugin::register_sensor(const std::string& lidar_name, const mjModel* /* model */)
 {
-  const std::string ns = "mujoco_plugins.rangefinder_lidar_plugin." + lidar_name + ".";
+  const std::string ns = "mujoco_plugins." + node_->get_sub_namespace() + "." + lidar_name + ".";
 
   // Check required parameters
   if (!node_->has_parameter(ns + "frame_name"))

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -257,8 +257,9 @@ TEST_F(CameraPluginTest, InitAndPublish)
 // Only polled cameras should expose a trigger service; streaming cameras should not.
 TEST_F(CameraPluginTest, OnlyPolledCamerasCreateTriggerService)
 {
-  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.stream_cam.policy", std::string("streaming"));
-  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.policy", std::string("polled"));
+  const std::string param_prefix = "mujoco_plugins." + plugin_node_->get_sub_namespace() + ".";
+  plugin_node_->declare_parameter(param_prefix + "stream_cam.policy", std::string("streaming"));
+  plugin_node_->declare_parameter(param_prefix + "poll_cam.policy", std::string("polled"));
   load_model(R"(<?xml version="1.0"?>
 <mujoco model="two_cameras">
   <worldbody>
@@ -313,7 +314,8 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
 )");
   ASSERT_EQ(model_->ncam, 1);
 
-  plugin_node_->declare_parameter("mujoco_plugins.mujoco_camera_plugin.poll_cam.policy", std::string("polled"));
+  const std::string param_prefix = "mujoco_plugins." + plugin_node_->get_sub_namespace() + ".";
+  plugin_node_->declare_parameter(param_prefix + "poll_cam.policy", std::string("polled"));
 
   mujoco_ros2_control_plugins::CameraPlugin plugin;
   EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));

--- a/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_free_joint_state_publisher_plugin.cpp
@@ -152,11 +152,12 @@ protected:
   template <typename T>
   void setParam(const std::string& name, const T& value)
   {
-    if (!plugin_node_->has_parameter(name))
+    const std::string resolved_name = "mujoco_plugins." + plugin_node_->get_sub_namespace() + "." + name;
+    if (!plugin_node_->has_parameter(resolved_name))
     {
-      plugin_node_->declare_parameter(name, rclcpp::ParameterValue(value));
+      plugin_node_->declare_parameter(resolved_name, rclcpp::ParameterValue(value));
     }
-    plugin_node_->set_parameter(rclcpp::Parameter(name, value));
+    plugin_node_->set_parameter(rclcpp::Parameter(resolved_name, value));
   }
 
   /// Subscribes to `topic` on plugin_node_ (matching the publisher's node) and spins until a


### PR DESCRIPTION
## Description

This addresses 2 bugs in the plugin parameter namespaces:

1. Several of the plugins were assuming a hard-coded sub-node namespace that didn't necessarily match with the real plugin name, which is `node_->get_sub_namespace()`
2. Several of the plugins were not applying a parameter namespace. So I found this issue when I realized that for example the free joint state publisher was using fully un-prefixed parameters that clobbered my own plugin!

### Is this user-facing behavior change?

Yes, in that some incorrect / unexpected behavior got fixed and this may cause slight disruptions to users who had multiple plugins or non-default names.

### Did you use Generative AI?

No, this one was all by hand baby, I still got it!