### PR TITLE
Add world_reset plugin hook and restore eq_active on world reset

### DIFF
--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -876,9 +876,7 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
   std::fill(mj_data_->qfrc_applied, mj_data_->qfrc_applied + mj_model_->nv, 0.0);
   std::fill(mj_data_->xfrc_applied, mj_data_->xfrc_applied + 6 * mj_model_->nbody, 0.0);
 
-  // Restore equality-constraint activations to their MJCF defaults: plugins may activate
-  // constraints at runtime, and a reset must return them to the authored state (this field
-  // is not touched by the qpos/qvel/ctrl restore above).
+  // Restore equality-constraint activations to their MJCF defaults
   std::copy(mj_model_->eq_active0, mj_model_->eq_active0 + mj_model_->neq, mj_data_->eq_active);
 
   {

--- a/mujoco_ros2_control/src/mujoco_simulation.cpp
+++ b/mujoco_ros2_control/src/mujoco_simulation.cpp
@@ -876,6 +876,11 @@ void MujocoSimulation::reset_world_state(bool fill_initial_state,
   std::fill(mj_data_->qfrc_applied, mj_data_->qfrc_applied + mj_model_->nv, 0.0);
   std::fill(mj_data_->xfrc_applied, mj_data_->xfrc_applied + 6 * mj_model_->nbody, 0.0);
 
+  // Restore equality-constraint activations to their MJCF defaults: plugins may activate
+  // constraints at runtime, and a reset must return them to the authored state (this field
+  // is not touched by the qpos/qvel/ctrl restore above).
+  std::copy(mj_model_->eq_active0, mj_model_->eq_active0 + mj_model_->neq, mj_data_->eq_active);
+
   {
     // Clear staged control inputs so stale commands from before the reset are not re-applied
     // on the next step.

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -2213,7 +2213,7 @@ void MujocoSystemInterface::reset_simulation_state(bool /*fill_initial_state*/)
   // eq_active has already been restored to MJCF defaults.
   for (auto& plugin : plugin_instances_)
   {
-    plugin->world_reset(simulation_->data());
+    plugin->on_reset_world(simulation_->data());
   }
 }
 

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -2213,7 +2213,7 @@ void MujocoSystemInterface::reset_simulation_state(bool /*fill_initial_state*/)
   // eq_active has already been restored to MJCF defaults.
   for (auto& plugin : plugin_instances_)
   {
-    plugin->on_reset_world(simulation_->data());
+    plugin->on_reset(simulation_->data());
   }
 }
 

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -2208,6 +2208,13 @@ void MujocoSystemInterface::reset_simulation_state(bool /*fill_initial_state*/)
     joint.velocity_interface.command_ = 0.0;
     joint.effort_interface.command_ = 0.0;
   }
+
+  // Notify plugins: they own runtime state that the world reset has invalidated.
+  // eq_active has already been restored to MJCF defaults.
+  for (auto& plugin : plugin_instances_)
+  {
+    plugin->world_reset(simulation_->data());
+  }
 }
 
 void MujocoSystemInterface::get_model(mjModel*& dest)

--- a/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_simulation.cpp
@@ -40,7 +40,8 @@ namespace
 {
 
 // Basic model for executing unit tests: a hinge joint with an actuator, plus two free-floating
-// bodies ("free_object", "free_object_2") for exercising the free-joint state service.
+// bodies ("free_object", "free_object_2") for exercising the free-joint state service, plus an
+// inactive weld equality ("test_weld") for exercising the eq_active restore on world reset.
 //    nu=1, nq=15 (1 hinge + 7 + 7 free joint), nv=13 (1 hinge + 6 + 6 free joint), nbody=4
 //    (world + pendulum + free_object + free_object_2)
 constexpr const char* kTestModel = R"(<?xml version="1.0"?>
@@ -65,6 +66,10 @@ constexpr const char* kTestModel = R"(<?xml version="1.0"?>
   <actuator>
     <position name="hinge_pos" joint="hinge" kp="10"/>
   </actuator>
+
+  <equality>
+    <weld name="test_weld" body1="pendulum" body2="free_object" active="false"/>
+  </equality>
 
   <keyframe>
     <key name="home" qpos="0.5 1 0 1 1 0 0 0 2 0 1 1 0 0 0"/>
@@ -410,6 +415,26 @@ TEST_F(MujocoSimulationTest, ResetWorldTest)
   const double time_after_reset = sim_->data()->time;
   ASSERT_TRUE(wait_until([&]() { return sim_->data()->time > time_after_reset; }))
       << "Time should advance after unpausing post-reset";
+}
+
+TEST_F(MujocoSimulationTest, ResetWorldRestoresEqualityConstraintActivation)
+{
+  ASSERT_TRUE(initialize_sim());
+
+  const int eq_id = mj_name2id(sim_->model(), mjOBJ_EQUALITY, "test_weld");
+  ASSERT_NE(eq_id, -1);
+  ASSERT_EQ(sim_->model()->eq_active0[eq_id], 0) << "test_weld must be authored inactive";
+  ASSERT_EQ(sim_->data()->eq_active[eq_id], 0);
+
+  sim_->capture_initial_state();
+
+  // Simulate a plugin activating the constraint at runtime (e.g. a vacuum gripper engaging
+  // a weld); a world reset must restore the activation to the MJCF-authored default.
+  sim_->data()->eq_active[eq_id] = 1;
+  sim_->reset_world_state(true);
+
+  EXPECT_EQ(sim_->data()->eq_active[eq_id], 0)
+      << "eq_active should be restored to its MJCF default (eq_active0) on world reset";
 }
 
 TEST_F(MujocoSimulationTest, ResetWorldJointStateOverrides)

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -601,10 +601,11 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
    public:
      bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data) override;
 
-     // Override whichever of these you need -- both have a no-op default, see
+     // Override whichever of these you need -- all have a no-op default, see
      // "Plugin Lifecycle" below for how they differ.
      void update(const mjModel* model, mjData* data) override;
      void pre_step(mjData* data) override;
+     void on_reset(mjData* /*data*/)
 
      void cleanup() override;
 
@@ -644,12 +645,17 @@ Create a header that inherits from ``MuJoCoROS2ControlPluginBase``:
      // Called on the physics thread, immediately before every mj_step.
    }
 
+   void on_reset(mjData* /*data*/)
+   {
+     // Called after a world reset (ResetWorld service or UI reset).
+   }
+
    void MyCustomPlugin::cleanup()
    {
      // Clean up resources
    }
 
-   }  // namespace my_namespace
+   } // namespace my_namespace
 
    PLUGINLIB_EXPORT_CLASS(
      my_namespace::MyCustomPlugin,
@@ -713,7 +719,10 @@ Plugin Lifecycle
    hold for exactly one physics step, such as ``BaseVelocityPlugin``'s kinematic velocity
    override. Runs with the simulation mutex held, so blocking here stalls the physics loop and
    native viewer too.
-4. **Cleanup** (``cleanup``): Called when shutting down. Release any resources acquired in
+4. **On Reset** (``on_reset``, optional): Called when the simulation is "reset", either from
+   the ResetWorld service from the UI. This lets plugins know that the state of the world has
+   been reset and they can take appropriate action.
+5. **Cleanup** (``cleanup``): Called when shutting down. Release any resources acquired in
    ``init``.
 
 Both hooks default to doing nothing, so implement whichever fits (or both, or neither). See

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -37,11 +37,9 @@ namespace mujoco_ros2_control_plugins
  *   e.g. a hard kinematic override. There's no command buffer: an untouched entry keeps its
  *   last value, so releasing a command (e.g. an expired force) needs an explicit write. This
  *   should be used with caution!
- * - `world_reset()` runs on the control thread immediately after a world reset (ResetWorld
- *   service or a detected UI reset), with the live `mj_data_` in its post-reset state. Use
- *   this to clear plugin bookkeeping that refers to the pre-reset world (latched states,
- *   cached ids that are still valid, ...). Note that the reset preserves simulation time
- *   (ROS clock continuity), so detect resets via this hook, not by watching `data->time`.
+ * - `on_reset_world()` runs immediately after a world reset, with the live `mj_data_` in its
+ *   post-reset state. Use this to clear plugin state that refers to the pre-reset world,
+ *   e.g. a latched command.
  *
  * @note All hooks must avoid blocking or the control loop or simulation itself will be held up!
  */
@@ -83,10 +81,11 @@ public:
   }
 
   /**
-   * @brief Called after a world reset, on the control thread. Default does nothing.
+   * @brief Called after a world reset (ResetWorld service or UI reset). Default does nothing.
+   *
    * @param data Pointer to the live MuJoCo data in its post-reset state.
    */
-  virtual void world_reset(mjData* /*data*/)
+  virtual void on_reset_world(mjData* /*data*/)
   {
   }
 

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -37,7 +37,7 @@ namespace mujoco_ros2_control_plugins
  *   e.g. a hard kinematic override. There's no command buffer: an untouched entry keeps its
  *   last value, so releasing a command (e.g. an expired force) needs an explicit write. This
  *   should be used with caution!
- * - `on_reset_world()` runs immediately after a world reset, with the live `mj_data_` in its
+ * - `on_reset()` runs immediately after a world reset, with the live `mj_data_` in its
  *   post-reset state. Use this to clear plugin state that refers to the pre-reset world,
  *   e.g. a latched command.
  *
@@ -85,7 +85,7 @@ public:
    *
    * @param data Pointer to the live MuJoCo data in its post-reset state.
    */
-  virtual void on_reset_world(mjData* /*data*/)
+  virtual void on_reset(mjData* /*data*/)
   {
   }
 

--- a/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
+++ b/mujoco_ros2_control_plugins/include/mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp
@@ -27,7 +27,7 @@ namespace mujoco_ros2_control_plugins
  * Plugins extend mujoco_ros2_control with custom behavior, e.g. publishing extra topics or
  * applying external forces.
  *
- * Two optional hooks are available. Override whichever fits your use case:
+ * Three optional hooks are available. Override whichever fits your use case:
  *
  * - `update()` runs on the ros2_control control thread, once per `write()` cycle. `data` is a
  *   recent snapshot, not the live `mj_data_`. Use this for anything that doesn't need to run on
@@ -37,8 +37,13 @@ namespace mujoco_ros2_control_plugins
  *   e.g. a hard kinematic override. There's no command buffer: an untouched entry keeps its
  *   last value, so releasing a command (e.g. an expired force) needs an explicit write. This
  *   should be used with caution!
+ * - `world_reset()` runs on the control thread immediately after a world reset (ResetWorld
+ *   service or a detected UI reset), with the live `mj_data_` in its post-reset state. Use
+ *   this to clear plugin bookkeeping that refers to the pre-reset world (latched states,
+ *   cached ids that are still valid, ...). Note that the reset preserves simulation time
+ *   (ROS clock continuity), so detect resets via this hook, not by watching `data->time`.
  *
- * @note Both hooks must avoid blocking or the control loop or simulation itself will be held up!
+ * @note All hooks must avoid blocking or the control loop or simulation itself will be held up!
  */
 class MuJoCoROS2ControlPluginBase
 {
@@ -74,6 +79,14 @@ public:
    * @param data Pointer to the live MuJoCo data, can be modified as needed.
    */
   virtual void pre_step(mjData* /*data*/)
+  {
+  }
+
+  /**
+   * @brief Called after a world reset, on the control thread. Default does nothing.
+   * @param data Pointer to the live MuJoCo data in its post-reset state.
+   */
+  virtual void world_reset(mjData* /*data*/)
   {
   }
 

--- a/mujoco_ros2_control_tests/CMakeLists.txt
+++ b/mujoco_ros2_control_tests/CMakeLists.txt
@@ -30,7 +30,7 @@ if(BUILD_TESTING)
     mujoco_ros2_control_plugins src/test_plugin.xml
   )
 
-  # End-to-end check that reset_world dispatches world_reset() to loaded plugins.
+  # End-to-end check that reset_world dispatches on_reset_world() to loaded plugins.
   ament_add_gtest(test_world_reset_dispatch test/test_world_reset_dispatch.cpp)
   target_link_libraries(test_world_reset_dispatch
     ${mujoco_ros2_control_TARGETS}

--- a/mujoco_ros2_control_tests/CMakeLists.txt
+++ b/mujoco_ros2_control_tests/CMakeLists.txt
@@ -9,6 +9,9 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(pluginlib REQUIRED)
   find_package(rclcpp REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(mujoco_ros2_control REQUIRED)
+  find_package(mujoco_ros2_control_msgs REQUIRED)
   find_package(mujoco_ros2_control_plugins REQUIRED)
 
   # Compile a test plugin alongside base plugins to make sure it works.
@@ -16,6 +19,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_plugin
     ${mujoco_ros2_control_plugins_TARGETS}
     pluginlib::pluginlib
+    ${std_msgs_TARGETS}
   )
 
   install(TARGETS test_plugin
@@ -24,6 +28,16 @@ if(BUILD_TESTING)
 
   pluginlib_export_plugin_description_file(
     mujoco_ros2_control_plugins src/test_plugin.xml
+  )
+
+  # End-to-end check that reset_world dispatches world_reset() to loaded plugins.
+  ament_add_gtest(test_world_reset_dispatch test/test_world_reset_dispatch.cpp)
+  target_link_libraries(test_world_reset_dispatch
+    ${mujoco_ros2_control_TARGETS}
+    ${mujoco_ros2_control_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    rclcpp::rclcpp
+    hardware_interface::hardware_interface
   )
 
   install(

--- a/mujoco_ros2_control_tests/CMakeLists.txt
+++ b/mujoco_ros2_control_tests/CMakeLists.txt
@@ -30,7 +30,7 @@ if(BUILD_TESTING)
     mujoco_ros2_control_plugins src/test_plugin.xml
   )
 
-  # End-to-end check that reset_world dispatches on_reset_world() to loaded plugins.
+  # End-to-end check that reset_world dispatches on_reset() to loaded plugins.
   ament_add_gtest(test_world_reset_dispatch test/test_world_reset_dispatch.cpp)
   target_link_libraries(test_world_reset_dispatch
     ${mujoco_ros2_control_TARGETS}

--- a/mujoco_ros2_control_tests/src/test_plugin.cpp
+++ b/mujoco_ros2_control_tests/src/test_plugin.cpp
@@ -1,4 +1,5 @@
 #include <pluginlib/class_list_macros.hpp>
+#include <std_msgs/msg/u_int32.hpp>
 #include "mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp"
 
 namespace external_plugin_test
@@ -7,16 +8,30 @@ namespace external_plugin_test
 class TestPlugin : public mujoco_ros2_control_plugins::MuJoCoROS2ControlPluginBase
 {
 public:
-  bool init(rclcpp::Node::SharedPtr, const mjModel*, mjData*) override
+  bool init(rclcpp::Node::SharedPtr node, const mjModel*, mjData*) override
   {
+    // Latched so a test subscribing after a reset still observes the count.
+    world_reset_count_pub_ =
+        node->create_publisher<std_msgs::msg::UInt32>("world_reset_count", rclcpp::QoS(1).transient_local());
     return true;
   }
   void update(const mjModel*, mjData*) override
   {
   }
+  void world_reset(mjData*) override
+  {
+    std_msgs::msg::UInt32 msg;
+    msg.data = ++world_reset_count_;
+    world_reset_count_pub_->publish(msg);
+  }
   void cleanup() override
   {
+    world_reset_count_pub_.reset();
   }
+
+private:
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr world_reset_count_pub_;
+  uint32_t world_reset_count_{ 0 };
 };
 
 }  // namespace external_plugin_test

--- a/mujoco_ros2_control_tests/src/test_plugin.cpp
+++ b/mujoco_ros2_control_tests/src/test_plugin.cpp
@@ -18,7 +18,7 @@ public:
   void update(const mjModel*, mjData*) override
   {
   }
-  void world_reset(mjData*) override
+  void on_reset_world(mjData*) override
   {
     std_msgs::msg::UInt32 msg;
     msg.data = ++world_reset_count_;

--- a/mujoco_ros2_control_tests/src/test_plugin.cpp
+++ b/mujoco_ros2_control_tests/src/test_plugin.cpp
@@ -18,7 +18,7 @@ public:
   void update(const mjModel*, mjData*) override
   {
   }
-  void on_reset_world(mjData*) override
+  void on_reset(mjData*) override
   {
     std_msgs::msg::UInt32 msg;
     msg.data = ++world_reset_count_;

--- a/mujoco_ros2_control_tests/test/test_world_reset_dispatch.cpp
+++ b/mujoco_ros2_control_tests/test/test_world_reset_dispatch.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// End-to-end check of the on_reset_world plugin hook: the out-of-package TestPlugin is loaded
-// through the `mujoco_plugins` parameter namespace and must have its on_reset_world() called
+// End-to-end check of the on_reset plugin hook: the out-of-package TestPlugin is loaded
+// through the `mujoco_plugins` parameter namespace and must have its on_reset() called
 // when the reset_world service resets the simulation.
 
 #include <gtest/gtest.h>
@@ -167,7 +167,7 @@ TEST_F(WorldResetDispatchTest, ResetWorldServiceDispatchesWorldResetToPlugins)
 {
   ASSERT_EQ(initialize_interface(), hardware_interface::CallbackReturn::SUCCESS);
 
-  // TestPlugin publishes its on_reset_world call count (latched) from its plugin sub-namespace.
+  // TestPlugin publishes its on_reset call count (latched) from its plugin sub-namespace.
   std::atomic<uint32_t> world_reset_count{ 0 };
   auto count_sub = node_->create_subscription<std_msgs::msg::UInt32>(
       "/test_plugin/world_reset_count", rclcpp::QoS(1).transient_local(),
@@ -186,5 +186,5 @@ TEST_F(WorldResetDispatchTest, ResetWorldServiceDispatchesWorldResetToPlugins)
   ASSERT_TRUE(reset_future.get()->success);
 
   EXPECT_TRUE(wait_until([&]() { return world_reset_count.load() == 1u; }))
-      << "on_reset_world() was not dispatched to the loaded plugin on reset_world";
+      << "on_reset() was not dispatched to the loaded plugin on reset_world";
 }

--- a/mujoco_ros2_control_tests/test/test_world_reset_dispatch.cpp
+++ b/mujoco_ros2_control_tests/test/test_world_reset_dispatch.cpp
@@ -1,0 +1,190 @@
+// Copyright 2026 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end check of the world_reset plugin hook: the out-of-package TestPlugin is loaded
+// through the `mujoco_plugins` parameter namespace and must have its world_reset() called
+// when the reset_world service resets the simulation.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include <hardware_interface/version.h>
+#include <hardware_interface/hardware_info.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/u_int32.hpp>
+
+#include <mujoco_ros2_control/mujoco_system_interface.hpp>
+#include <mujoco_ros2_control_msgs/srv/reset_world.hpp>
+
+#define ROS_DISTRO_HUMBLE (HARDWARE_INTERFACE_VERSION_MAJOR < 3)
+
+namespace
+{
+
+constexpr const char* kTestModel = R"(<?xml version="1.0"?>
+<mujoco model="test_world_reset_dispatch">
+  <option timestep="0.002"/>
+  <worldbody>
+    <body name="pendulum" pos="0 0 1">
+      <joint name="hinge" type="hinge" axis="0 1 0"/>
+      <geom type="capsule" size="0.02" fromto="0 0 0 0.3 0 0" mass="1"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// Loads TestPlugin into the hardware node via the wildcard parameter file passed through the
+// `pids_config_file` hardware parameter (the node auto-declares parameters from overrides).
+constexpr const char* kPluginParams = R"(/**:
+  ros__parameters:
+    mujoco_plugins:
+      test_plugin:
+        type: "external_plugin_test/TestPlugin"
+)";
+
+const std::string kTestModelPath = "/tmp/test_world_reset_dispatch_model.xml";
+const std::string kPluginParamsPath = "/tmp/test_world_reset_dispatch_params.yaml";
+
+void write_file(const std::string& path, const char* content)
+{
+  std::ofstream file(path);
+  file << content;
+}
+
+}  // namespace
+
+class WorldResetDispatchTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  static void TearDownTestSuite()
+  {
+    if (rclcpp::ok())
+    {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override
+  {
+    write_file(kTestModelPath, kTestModel);
+    write_file(kPluginParamsPath, kPluginParams);
+    interface_ = std::make_shared<mujoco_ros2_control::MujocoSystemInterface>();
+
+    node_ = std::make_shared<rclcpp::Node>("world_reset_dispatch_test_node");
+    executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    if (executor_)
+    {
+      executor_->cancel();
+    }
+    if (spin_thread_.joinable())
+    {
+      spin_thread_.join();
+    }
+    if (interface_)
+    {
+      rclcpp_lifecycle::State inactive_state(0, "inactive");
+      interface_->on_deactivate(inactive_state);
+      interface_.reset();
+    }
+    node_.reset();
+    executor_.reset();
+
+    std::filesystem::remove(kTestModelPath);
+    std::filesystem::remove(kPluginParamsPath);
+  }
+
+  hardware_interface::CallbackReturn initialize_interface()
+  {
+    hardware_interface::HardwareInfo info;
+    info.name = "test_world_reset_dispatch";
+    info.type = "system";
+    info.hardware_parameters["mujoco_model"] = kTestModelPath;
+    info.hardware_parameters["meshdir"] = "";
+    info.hardware_parameters["headless"] = "true";
+    info.hardware_parameters["disable_rendering"] = "true";
+    info.hardware_parameters["pids_config_file"] = kPluginParamsPath;
+#if ROS_DISTRO_HUMBLE
+    return interface_->on_init(info);
+#else
+    hardware_interface::HardwareComponentInterfaceParams params;
+    params.hardware_info = info;
+    return interface_->on_init(params);
+#endif
+  }
+
+  bool wait_until(std::function<bool()> condition, std::chrono::milliseconds timeout = std::chrono::seconds(5),
+                  std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      if (condition())
+        return true;
+      std::this_thread::sleep_for(poll_interval);
+    }
+    return condition();
+  }
+
+  std::shared_ptr<mujoco_ros2_control::MujocoSystemInterface> interface_;
+  rclcpp::Node::SharedPtr node_;
+  std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+TEST_F(WorldResetDispatchTest, ResetWorldServiceDispatchesWorldResetToPlugins)
+{
+  ASSERT_EQ(initialize_interface(), hardware_interface::CallbackReturn::SUCCESS);
+
+  // TestPlugin publishes its world_reset call count (latched) from its plugin sub-namespace.
+  std::atomic<uint32_t> world_reset_count{ 0 };
+  auto count_sub = node_->create_subscription<std_msgs::msg::UInt32>(
+      "/test_plugin/world_reset_count", rclcpp::QoS(1).transient_local(),
+      [&world_reset_count](const std_msgs::msg::UInt32& msg) { world_reset_count = msg.data; });
+
+  auto reset_client =
+      node_->create_client<mujoco_ros2_control_msgs::srv::ResetWorld>("/mujoco_ros2_control_node/reset_world");
+  ASSERT_TRUE(reset_client->wait_for_service(std::chrono::seconds(5))) << "reset_world service not found";
+
+  // No reset yet: the plugin must not have been notified.
+  EXPECT_EQ(world_reset_count.load(), 0u);
+
+  auto reset_future =
+      reset_client->async_send_request(std::make_shared<mujoco_ros2_control_msgs::srv::ResetWorld::Request>());
+  ASSERT_EQ(reset_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  ASSERT_TRUE(reset_future.get()->success);
+
+  EXPECT_TRUE(wait_until([&]() { return world_reset_count.load() == 1u; }))
+      << "world_reset() was not dispatched to the loaded plugin on reset_world";
+}

--- a/mujoco_ros2_control_tests/test/test_world_reset_dispatch.cpp
+++ b/mujoco_ros2_control_tests/test/test_world_reset_dispatch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 PAL Robotics S.L.
+// Copyright 2026 Bilal Gill
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// End-to-end check of the world_reset plugin hook: the out-of-package TestPlugin is loaded
-// through the `mujoco_plugins` parameter namespace and must have its world_reset() called
+// End-to-end check of the on_reset_world plugin hook: the out-of-package TestPlugin is loaded
+// through the `mujoco_plugins` parameter namespace and must have its on_reset_world() called
 // when the reset_world service resets the simulation.
 
 #include <gtest/gtest.h>
@@ -167,7 +167,7 @@ TEST_F(WorldResetDispatchTest, ResetWorldServiceDispatchesWorldResetToPlugins)
 {
   ASSERT_EQ(initialize_interface(), hardware_interface::CallbackReturn::SUCCESS);
 
-  // TestPlugin publishes its world_reset call count (latched) from its plugin sub-namespace.
+  // TestPlugin publishes its on_reset_world call count (latched) from its plugin sub-namespace.
   std::atomic<uint32_t> world_reset_count{ 0 };
   auto count_sub = node_->create_subscription<std_msgs::msg::UInt32>(
       "/test_plugin/world_reset_count", rclcpp::QoS(1).transient_local(),
@@ -186,5 +186,5 @@ TEST_F(WorldResetDispatchTest, ResetWorldServiceDispatchesWorldResetToPlugins)
   ASSERT_TRUE(reset_future.get()->success);
 
   EXPECT_TRUE(wait_until([&]() { return world_reset_count.load() == 1u; }))
-      << "world_reset() was not dispatched to the loaded plugin on reset_world";
+      << "on_reset_world() was not dispatched to the loaded plugin on reset_world";
 }


### PR DESCRIPTION
I am working on a vacuum gripper plugin for mujoco_ros2_control that activates and deactivates weld equality constraints at runtime to simulate a vacuum gripper grabbing things.

Two changes are needed for such runtime-activated constraints to properly reset with the simulation:
- Restore eq_active from eq_active0 (the MJCF-authored defaults) in reset_world_state(), so a runtime-activated constraint returns to its authored state. The existing qpos/qvel/ctrl restore does not touch this field.
- Add a world_reset(mjData*) hook to MuJoCoROS2ControlPluginBase (default no-op, so existing plugins are unaffected) and dispatch it to all plugin instances after the state restore. Plugins cannot detect resets themselves: resets preserve simulation time for ROS clock continuity, so watching data->time go backwards does not work. An explicit notification is the only reliable signal for clearing plugin-owned state (e.g. a latched vacuum) that the reset invalidated.