### PR TITLE
Fix collision geometries usage and add command-line option to toggle it

### DIFF
--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -523,14 +523,6 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                     parent = geom_element.parentNode
                     parent.removeChild(geom_element)
                     for sub_geom in sub_geoms:
-                        # obj2mjcf's file classifies its own geoms: the render geoms (whole
-                        # mesh, with materials) are class "visual" and the collidable ones
-                        # (the whole mesh for composed, the convex pieces for decomposed) are
-                        # class "collision". Match them to the role of the URDF geom being
-                        # replaced - cloning everything into both would render the collision
-                        # pieces and, worse, collide the whole concave mesh as a convex hull.
-                        if (sub_geom.getAttribute("class") == "visual") != is_visual:
-                            continue
                         sub_geom_local = sub_geom.cloneNode(False)
                         if pos:
                             sub_geom_local.setAttribute("pos", pos)

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -582,19 +582,18 @@ def update_non_obj_assets(dom, output_filepath):
         if geom.hasAttribute("class"):
             continue
 
+        # Ensure a type: the saved model omits type="sphere" (MuJoCo's default).
+        if not geom.hasAttribute("type"):
+            geom.setAttribute("type", "sphere")
+
         if geom.hasAttribute("contype"):
             # visual geom: keep rgba, strip the raw import attributes.
-            # Ensure a type: the saved model omits type="sphere" (MuJoCo's default).
-            if not geom.hasAttribute("type"):
-                geom.setAttribute("type", "sphere")
             geom.setAttribute("class", "visual")
             for attribute in remove_attributes:
                 if geom.hasAttribute(attribute):
                     geom.removeAttribute(attribute)
         else:
-            # collision geom: ensure a type, drop rgba (not rendered)
-            if not geom.hasAttribute("type"):
-                geom.setAttribute("type", "sphere")
+            # collision geom: drop rgba (not rendered)
             geom.setAttribute("class", "collision")
             if geom.hasAttribute("rgba"):
                 geom.removeAttribute("rgba")

--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -450,7 +450,11 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
     for mesh in meshes:
         mesh_name = mesh.getAttribute("name")
 
-        # This should definitely be there, otherwise something is horribly wrong
+        # MuJoCo emits an auto-renamed sibling asset (e.g., "my_mesh1") when the same mesh
+        # file is referenced with a different scale. Leave these referencing the whole mesh.
+        if mesh_name not in mesh_info_dict:
+            continue
+
         scale = mesh_info_dict[mesh_name]["scale"]
 
         mesh_path = ""
@@ -519,9 +523,19 @@ def update_obj_assets(dom, output_filepath, mesh_info_dict):
                     parent = geom_element.parentNode
                     parent.removeChild(geom_element)
                     for sub_geom in sub_geoms:
+                        # obj2mjcf's file classifies its own geoms: the render geoms (whole
+                        # mesh, with materials) are class "visual" and the collidable ones
+                        # (the whole mesh for composed, the convex pieces for decomposed) are
+                        # class "collision". Match them to the role of the URDF geom being
+                        # replaced - cloning everything into both would render the collision
+                        # pieces and, worse, collide the whole concave mesh as a convex hull.
+                        if (sub_geom.getAttribute("class") == "visual") != is_visual:
+                            continue
                         sub_geom_local = sub_geom.cloneNode(False)
-                        sub_geom_local.setAttribute("pos", pos)
-                        sub_geom_local.setAttribute("quat", quat)
+                        if pos:
+                            sub_geom_local.setAttribute("pos", pos)
+                        if quat:
+                            sub_geom_local.setAttribute("quat", quat)
                         for attribute in remove_attributes:
                             if sub_geom_local.hasAttribute(attribute):
                                 sub_geom_local.removeAttribute(attribute)
@@ -577,7 +591,10 @@ def update_non_obj_assets(dom, output_filepath):
             continue
 
         if geom.hasAttribute("contype"):
-            # visual geom: keep rgba, strip the raw import attributes
+            # visual geom: keep rgba, strip the raw import attributes.
+            # Ensure a type: the saved model omits type="sphere" (MuJoCo's default).
+            if not geom.hasAttribute("type"):
+                geom.setAttribute("type", "sphere")
             geom.setAttribute("class", "visual")
             for attribute in remove_attributes:
                 if geom.hasAttribute(attribute):

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -401,6 +401,13 @@ def main(args=None):
         help="Allows MuJoCo to merge static bodies. Use --no-fuse to prevent merging.",
     )
     parser.add_argument(
+        "--use_collision_tags",
+        action="store_true",
+        help="Use the URDF's authored <collision> geometry for the MuJoCo collision geoms. "
+        "Without this flag, authored collisions are ignored and all collision geometry is "
+        "derived from the <visual> tags instead (the legacy behavior).",
+    )
+    parser.add_argument(
         "-a",
         "--asset_dir",
         required=False,
@@ -489,10 +496,17 @@ def main(args=None):
     # Add required MuJoCo tags to the starting URDF
     xml_data = mrc.add_mujoco_info(urdf, output_filepath, parsed_args.publish_topic, parsed_args.fuse)
 
-    # Keep authored collision geometry so it drives the MuJoCo collision geoms, and
-    # only synthesize a collision from the visual for links that don't define one.
-    # This way visual meshes render the robot while the (often simpler) collision
-    # geometry is used for physics, with the visual mesh as the fallback.
+    # Unless --use_collision_tags is given, drop the URDF's authored collision geometry
+    # first so every link falls back to a collision synthesized from its visuals (the
+    # legacy behavior, and the default).
+    if not parsed_args.use_collision_tags:
+        xml_data = mrc.remove_tag(xml_data, "collision")
+
+    # With --use_collision_tags, authored collision geometry is kept so it drives the
+    # MuJoCo collision geoms, and a collision is only synthesized from the visual for
+    # links that don't define one. This way visual meshes render the robot while the
+    # (often simpler) collision geometry is used for physics, with the visual mesh as
+    # the fallback.
     xml_data = mrc.add_missing_collisions(xml_data)
 
     xml_data = mrc.replace_package_names(xml_data)

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -266,22 +266,27 @@ def run_obj2mjcf(output_filepath, decompose_dict, mesh_info_dict):
     thresholds_file = os.path.join(f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}", "metadata.json")
     thresholds_data = {}
 
-    # run obj2mjcf to generate folders of processed objs with decompose option for decomposed components
-    for mesh_name, threshold in decompose_dict.items():
-        mesh_item = mesh_info_dict[mesh_name]
-        if not mesh_item["is_pre_generated"]:
-            cmd = [
-                "obj2mjcf",
-                "--obj-dir",
-                f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}",
-                "--save-mjcf",
-                "--decompose",
-                "--coacd-args.threshold",
-                threshold,
-            ]
-            subprocess.run(cmd)
+    # run obj2mjcf to generate folders of processed objs with decompose option for decomposed
+    # components. Make sure a collision mesh sharing its stem with a visual mesh is decomposed too.
+    for mesh_name, mesh_item in mesh_info_dict.items():
+        filename_no_ext = os.path.splitext(os.path.basename(mesh_item["filename"]))[0]
+        if mesh_name not in decompose_dict and filename_no_ext not in decompose_dict:
+            continue
+        if mesh_item["is_pre_generated"]:
+            continue
+        threshold = decompose_dict.get(mesh_name, decompose_dict.get(filename_no_ext))
+        cmd = [
+            "obj2mjcf",
+            "--obj-dir",
+            f"{output_filepath}assets/{mrc.DECOMPOSED_PATH_NAME}/{mesh_name}",
+            "--save-mjcf",
+            "--decompose",
+            "--coacd-args.threshold",
+            threshold,
+        ]
+        subprocess.run(cmd)
 
-            thresholds_data[mesh_name] = float(threshold)
+        thresholds_data[mesh_name] = float(threshold)
 
     with open(thresholds_file, "w") as f:
         json.dump(thresholds_data, f, indent=4)

--- a/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
+++ b/mujoco_ros2_control/scripts/make_mjcf_from_robot_description.py
@@ -502,11 +502,6 @@ def main(args=None):
     if not parsed_args.use_collision_tags:
         xml_data = mrc.remove_tag(xml_data, "collision")
 
-    # With --use_collision_tags, authored collision geometry is kept so it drives the
-    # MuJoCo collision geoms, and a collision is only synthesized from the visual for
-    # links that don't define one. This way visual meshes render the robot while the
-    # (often simpler) collision geometry is used for physics, with the visual mesh as
-    # the fallback.
     xml_data = mrc.add_missing_collisions(xml_data)
 
     xml_data = mrc.replace_package_names(xml_data)


### PR DESCRIPTION
## Description

Makes some fixes to add to https://github.com/ros-controls/mujoco_ros2_control/pull/264 based on testing on NASA's CLR setup. Specifically:

1. Fixed some bugs that caused the startup to fail for our model
2. Added an `argparse` argument `--use_collision_tags` so you can toggle the legacy and new behaviors (we can keep building on this).

So with that toggle I can get the old behavior, plus the new one!

[mjros2ctrl-collision-meshes.webm](https://github.com/user-attachments/assets/d6ba7562-5211-43a9-9eea-323cf85e003d)

There are still issues with the decomposed meshes sharing layers with other meshes, so they're not easy to isolate. But is a different grouping for these handled upstack?

### Is this user-facing behavior change?

Yes

### Did you use Generative AI?

Yes, Claude Fable 5