### PR TITLE
Do not overwrite a camera snapshot that is still being rendered

### DIFF
--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -93,6 +93,18 @@ Note that any number of cameras can be configured in the plugin configuration.
    MuJoCo's camera coordinate conventions differ from ROS.
    Refer to the MuJoCo documentation for details.
 
+.. note::
+   Rendering happens on its own thread, so a render pass can outlast the publish interval.
+   When that happens the due slot is skipped rather than overwriting the frame being
+   rendered, and a throttled warning reports how many streaming frames have been lost::
+
+      Camera rendering cannot keep up: 12 streaming frame(s) dropped so far.
+
+   Lower ``camera_publish_rate``, the camera resolution, or the number of streaming
+   cameras; or lower ``sim_speed_factor``, which keeps the image rate in sim time while
+   giving each pass more wall-clock time. Polled triggers are never lost this way, only
+   deferred to the next pass.
+
 Headless Rendering
 ^^^^^^^^^^^^^^^^^^
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -88,7 +88,37 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
 
   bool any_selected = false;
   {
-    std::lock_guard<std::mutex> lock(data_mutex_);
+    std::unique_lock<std::mutex> lock(data_mutex_);
+
+    // The rendering thread is still working on the previous snapshot. Touching
+    // mj_camera_data_ or render_pending now would corrupt the frame it is rendering, so
+    // give up this slot instead. See CameraPlugin::render_in_flight_.
+    if (render_in_flight_)
+    {
+      // A poll trigger must survive the skip. poll_pending_ was already consumed by the
+      // exchange above, but the per-camera poll_requested flag is still set, so re-arm the
+      // wakeup hint and the request is merely deferred rather than lost.
+      if (poll_due)
+      {
+        poll_pending_.store(true);
+      }
+      if (stream_due)
+      {
+        // Consume the slot so the next attempt is a full interval away. Without this, every
+        // control cycle for the rest of the render would re-enter here and the counter
+        // would report attempts (thousands per second at a 2 kHz control rate) rather than
+        // lost frames.
+        last_publish_time_ = now;
+        ++dropped_frames_;
+        RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
+                             "Camera rendering cannot keep up: %llu streaming frame(s) dropped so far. "
+                             "Reduce mujoco_plugins.mujoco_camera_plugin.camera_publish_rate, the camera "
+                             "resolution, or the number of streaming cameras; or lower sim_speed_factor, which "
+                             "keeps the sim-time image rate and gives each pass more wall-clock time.",
+                             static_cast<unsigned long long>(dropped_frames_.load()));
+      }
+      return;
+    }
 
     // Flag streaming cameras when their interval is due and any polled cameras that have a
     // pending trigger (consuming the one-shot request so they render exactly once).
@@ -117,6 +147,10 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
     {
       mjv_copyData(mj_camera_data_, model_arg, data);
       new_data_ = true;
+      // Hand ownership of the snapshot to the rendering thread; it is released again once
+      // update_cameras() has published. Set under the lock so the flag can never be
+      // observed as false while new_data_ is already true.
+      render_in_flight_ = true;
     }
   }
 
@@ -523,6 +557,14 @@ void CameraPlugin::update_loop()
     lock.unlock();
 
     update_cameras();
+
+    // Release the snapshot so `update` may fill it again. This has to happen after
+    // update_cameras() returns, because that call is what reads mj_camera_data_ and the
+    // per-camera render_pending flags without holding the lock.
+    {
+      std::lock_guard<std::mutex> release_lock(data_mutex_);
+      render_in_flight_ = false;
+    }
   }
   publish_images_ = false;
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -184,6 +184,18 @@ public:
     return publish_images_.load();
   }
 
+  /**
+   * @brief Number of streaming slots skipped because the renderer was still busy.
+   *
+   * Counted per slot rather than per attempt, so it reads as "frames lost" rather than
+   * "times we looked": at a 2 kHz control rate the latter would report thousands per second
+   * for the duration of a single slow render.
+   */
+  [[nodiscard]] uint64_t dropped_frames() const
+  {
+    return dropped_frames_.load();
+  }
+
 private:
   // ROS interfaces
   rclcpp::Logger logger_{ rclcpp::get_logger("CameraPlugin") };
@@ -266,6 +278,22 @@ private:
   std::mutex data_mutex_;
   std::condition_variable data_cv_;
   bool new_data_{ false };
+
+  // True from the moment `update` hands a snapshot to the rendering thread until that
+  // thread has finished rendering and publishing it.
+  //
+  // `update_cameras` deliberately runs WITHOUT holding data_mutex_ (rendering is slow and
+  // must not block the control loop), so it reads mj_camera_data_ and CameraData::
+  // render_pending unlocked. Without this flag the control thread could mjv_copyData into
+  // that same snapshot mid-render, producing an image blended from two different sim
+  // times: corruption that still looks like a valid frame. Guarding on it makes `update`
+  // skip the slot instead, turning a silent race into a countable dropped frame.
+  bool render_in_flight_{ false };
+
+  // Number of streaming slots skipped because the renderer was still busy. Counted per
+  // slot rather than per attempt, so it reads as "frames lost", not "times we looked".
+  // Atomic so the counter can be read for diagnostics from a thread other than the sim one.
+  std::atomic<uint64_t> dropped_frames_{ 0 };
 
   // EGL context for headless rendering (used when GLFW is unavailable)
   EGLDisplay egl_display_{ EGL_NO_DISPLAY };

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -361,6 +361,92 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   plugin.cleanup();
 }
 
+// ---------------------------------------------------------------------------------------
+// Dropped-frame accounting
+//
+// update() runs on the sim thread and must not overwrite a snapshot the rendering thread is
+// still working on. When it has to skip, it consumes the slot and counts one lost frame.
+// A high publish rate against a camera large enough that a pass outlasts the interval puts
+// the guard on the hot path without needing to control the rendering thread directly.
+// ---------------------------------------------------------------------------------------
+
+namespace
+{
+// 1280x720 is comfortably slower to render and read back than a 1 ms publish interval.
+constexpr const char* SLOW_CAMERA_MODEL = R"(<?xml version="1.0"?>
+<mujoco model="slow_camera">
+  <visual>
+    <global offwidth="1280" offheight="720"/>
+  </visual>
+  <worldbody>
+    <light pos="0 0 3"/>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <camera name="cam" pos="0 -1 0.2" mode="fixed" resolution="1280 720"/>
+  </worldbody>
+</mujoco>
+)";
+}  // namespace
+
+TEST_F(CameraPluginTest, NoFramesAreDroppedWhenTheRendererKeepsUp)
+{
+  load_model(SLOW_CAMERA_MODEL);
+  // One frame every 100 s, so no slot ever comes due after the first.
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.camera_publish_rate", 0.01);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  wait_for_rendering(plugin);
+
+  for (int i = 0; i < 2000; ++i)
+  {
+    plugin.update(model_, data_);
+  }
+  EXPECT_EQ(plugin.dropped_frames(), 0u);
+  plugin.cleanup();
+}
+
+// The regression this guards: without the in-flight check, update() would copy into the
+// snapshot the rendering thread is reading, producing a frame blended from two sim times --
+// corruption that still looks like a valid image. The counter is the observable proof that
+// the slot was skipped instead.
+TEST_F(CameraPluginTest, SkippedSlotsAreCountedOncePerLostFrameNotPerAttempt)
+{
+  load_model(SLOW_CAMERA_MODEL);
+  // 1 kHz: a slot comes due every millisecond, far faster than a 1280x720 pass completes.
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.camera_publish_rate", 1000.0);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  wait_for_rendering(plugin);
+
+  // Drive update() the way a 2 kHz control loop would, for long enough that several render
+  // passes are outrun.
+  std::size_t calls = 0;
+  const auto deadline = std::chrono::steady_clock::now() + 500ms;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    plugin.update(model_, data_);
+    ++calls;
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+
+  const uint64_t dropped = plugin.dropped_frames();
+  ASSERT_GT(calls, 500u) << "the loop did not run often enough to be meaningful";
+  EXPECT_GT(dropped, 0u) << "a 1280x720 pass cannot keep up with a 1 kHz slot rate";
+
+  // The point of consuming the slot: each lost frame is counted once, so the number of
+  // drops is bounded by the elapsed slots (~500 at 1 kHz over 500 ms) and not by the number
+  // of update() calls. Without that, every call during a render would increment.
+  EXPECT_LT(dropped, static_cast<uint64_t>(calls))
+      << "counted " << dropped << " drops over " << calls << " update() calls: the slot is not being consumed";
+  EXPECT_LT(dropped, 1500u) << "far more drops than slots elapsed in 500 ms";
+  plugin.cleanup();
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Description

`CameraPlugin::update_cameras()` deliberately runs *without* holding `data_mutex_`, because
rendering is slow and must not block the control loop, so it reads `mj_camera_data_` and the
per-camera `render_pending` flags unlocked. Nothing stopped `update()`, on the sim thread,
from calling `mjv_copyData` into that same snapshot mid-render. The result is an image
blended from two different simulation times: corruption that still looks like a perfectly
valid frame, and which becomes more likely the larger the cameras or the faster the publish
rate.

A `render_in_flight_` flag, set and cleared under the lock so it can never be observed as
`false` while `new_data_` is already `true`, makes `update()` skip the slot instead:

* A skipped **streaming** slot is counted and reported through a throttled warning naming
  the things that fix it.
* A **polled** trigger is re-armed rather than consumed, so a service request is deferred to
  the next pass rather than lost.
* The slot is consumed on a skip. Without that, every control cycle for the rest of the
  render would re-enter the guard and the counter would report *attempts* -- thousands per
  second at a 2 kHz control rate -- rather than frames actually lost.

`dropped_frames()` exposes the counter, which is also what makes the behaviour testable.

Fixes # (issue)

### Is this user-facing behavior change?

Yes, though only in what is reported. Frames that were previously published as silently
corrupted images are now skipped, and a throttled warning appears when that happens:

```text
Camera rendering cannot keep up: 12 streaming frame(s) dropped so far.
```

No new parameters. Polled camera behaviour is unchanged: triggers are deferred, never
dropped.

### Did you use Generative AI?

Yes -- Claude Code (Claude Opus). The synchronisation guard, the dropped-frame accounting,
the two tests and the documentation note were produced with it. The problem was identified
and the result reviewed by hand.

### Additional Information

Both tests use a 1280x720 camera whose render pass cannot keep up with a 1 kHz slot clock.
The second is the interesting one: it drives `update()` roughly 2500 times over 500 ms and
requires the drop count to stay bounded by the number of *slots* elapsed rather than
tracking the number of calls, which is exactly the distinction the slot-consuming logic
exists to make.

Verified on Humble against a Kangaroo biped with six 848x480 cameras at 30 Hz, where the
corruption was originally observed.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
