### PR TITLE
Bind EGL surfaceless when the PBuffer surface is refused

### DIFF
--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -108,6 +108,14 @@ This allows camera topics to be published even when running in headless mode (e.
    EGL requires proper GPU drivers and EGL libraries to be installed (e.g., libegl1-mesa on Ubuntu).
    If both GLFW and EGL fail to initialize, camera publishing will be disabled with a warning.
 
+.. note::
+   EGL is bound surfaceless when the driver will not accept the PBuffer surface. Some drivers
+   (NVIDIA among them) refuse to bind a PBuffer in a process that already holds a GLX context,
+   which is the case whenever the MuJoCo viewer is open, and report success from
+   ``eglGetError`` while ``eglMakeCurrent`` fails. Rendering targets an offscreen framebuffer
+   in any case, so binding with no surface is equivalent; a warning names the retry when it
+   happens. If both binds fail, camera publishing is disabled and the error says so.
+
 
 ExternalWrenchPlugin
 ~~~~~~~~~~~~~~~~~~~~~

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -401,10 +401,37 @@ bool CameraPlugin::init_egl_context()
     return false;
   }
 
-  // Make the context current
-  if (!eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_))
+  // Make the context current.
+  //
+  // The PBuffer above is requested for drivers that need a real draw surface, but the
+  // surfaceless platform does not require one, and at least the NVIDIA driver refuses to bind
+  // a PBuffer here once the process already holds a GLX context (as it does whenever the
+  // MuJoCo viewer is open): eglMakeCurrent returns false while eglGetError reports success.
+  // MuJoCo only ever renders into its own offscreen framebuffer, so binding with no surface
+  // at all is equivalent, and it is what the surfaceless platform is for. Try the PBuffer
+  // first so drivers that do want one keep working, then fall back.
+  if (!egl_make_current_(egl_display_, egl_surface_, egl_surface_, egl_context_))
   {
-    RCLCPP_ERROR(node_->get_logger(), "EGL: Failed to make context current (error: 0x%x)", eglGetError());
+    RCLCPP_WARN(node_->get_logger(),
+                "EGL: Could not bind the PBuffer surface (error: 0x%x). Retrying surfaceless, which is "
+                "sufficient because rendering targets an offscreen framebuffer.",
+                eglGetError());
+    if (egl_surface_ != EGL_NO_SURFACE)
+    {
+      eglDestroySurface(egl_display_, egl_surface_);
+      egl_surface_ = EGL_NO_SURFACE;
+    }
+    if (egl_make_current_(egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context_))
+    {
+      RCLCPP_INFO(node_->get_logger(), "EGL: Successfully initialized headless OpenGL context (surfaceless)");
+      return true;
+    }
+    RCLCPP_ERROR(node_->get_logger(),
+                 "EGL: Failed to make context current (error: 0x%x). If the MuJoCo viewer is open, that is "
+                 "the likely cause: this driver refuses to bind an EGL context in a process that already "
+                 "holds a GLX one, and eglGetError misreports it as success. Use render_backend=egl only "
+                 "together with headless operation, or render through GLFW.",
+                 eglGetError());
     cleanup_egl_context();
     return false;
   }

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -143,6 +143,10 @@ public:
   /** Signature of the GLFW initializer; injectable for testing. */
   using GlfwInitFn = std::function<int()>;
 
+  /// Seam for eglMakeCurrent, so the surfaceless fallback below can be tested without a
+  /// driver that reproduces the failure. Defaults to the real entry point.
+  using EglMakeCurrentFn = std::function<EGLBoolean(EGLDisplay, EGLSurface, EGLSurface, EGLContext)>;
+
   CameraPlugin() = default;
   ~CameraPlugin() override = default;
 
@@ -159,6 +163,18 @@ public:
    * @param glfw_init_fn Function used to attempt GLFW initialization; same signature as `glfwInit`.
    */
   bool init(rclcpp::Node::SharedPtr node, const mjModel* model, mjData* data, GlfwInitFn glfw_init_fn);
+
+  /**
+   * @brief Overrides the eglMakeCurrent used when creating the EGL context.
+   *
+   * Exposed for the same reason as the GlfwInitFn overload above: the surfaceless fallback
+   * exists for a driver behaviour that cannot be provoked on demand. Must be called before
+   * init(), which starts the rendering thread.
+   */
+  void set_egl_make_current(EglMakeCurrentFn fn)
+  {
+    egl_make_current_ = std::move(fn);
+  }
   void update(const mjModel* model, mjData* data) override;
   void cleanup() override;
 
@@ -271,6 +287,9 @@ private:
   EGLDisplay egl_display_{ EGL_NO_DISPLAY };
   EGLContext egl_context_{ EGL_NO_CONTEXT };
   EGLSurface egl_surface_{ EGL_NO_SURFACE };
+  EglMakeCurrentFn egl_make_current_{ [](EGLDisplay d, EGLSurface draw, EGLSurface read, EGLContext ctx) {
+    return eglMakeCurrent(d, draw, read, ctx);
+  } };
   bool use_egl_{ false };
 
   /**

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -358,6 +359,87 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   }
   EXPECT_EQ(image_count.load(), 1);
 
+  plugin.cleanup();
+}
+
+// ---------------------------------------------------------------------------------------
+// EGL surfaceless fallback
+//
+// Some drivers (NVIDIA among them) refuse to bind a PBuffer surface in a process that
+// already holds a GLX context, and report success from eglGetError while doing so. The
+// eglMakeCurrent seam lets that be reproduced without such a driver.
+// ---------------------------------------------------------------------------------------
+
+namespace
+{
+constexpr const char* EGL_TEST_MODEL = R"(<?xml version="1.0"?>
+<mujoco model="egl_fallback">
+  <worldbody>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <camera name="cam" pos="0 -1 0.2" mode="fixed"/>
+  </worldbody>
+</mujoco>
+)";
+}  // namespace
+
+// The PBuffer bind fails, exactly as the driver behaves with a viewer open, and the
+// surfaceless retry is delegated to the real entry point so a genuine context is produced.
+TEST_F(CameraPluginTest, EglFallsBackToSurfacelessWhenPbufferBindFails)
+{
+  load_model(EGL_TEST_MODEL);
+
+  std::atomic<int> pbuffer_attempts{ 0 };
+  std::atomic<int> surfaceless_attempts{ 0 };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  plugin.set_egl_make_current(
+      [&](EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context) -> EGLBoolean {
+        if (draw != EGL_NO_SURFACE)
+        {
+          ++pbuffer_attempts;
+          return EGL_FALSE;  // what the driver does when a GLX context already exists
+        }
+        ++surfaceless_attempts;
+        return eglMakeCurrent(display, draw, read, context);
+      });
+
+  // GLFW reported unavailable, so the EGL path is taken.
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));
+  wait_for_rendering(plugin);
+
+  EXPECT_EQ(pbuffer_attempts.load(), 1);
+  EXPECT_EQ(surfaceless_attempts.load(), 1) << "the surfaceless retry should have been attempted once";
+  plugin.cleanup();
+}
+
+// When neither bind works there is nothing to fall back to: rendering stays unavailable
+// rather than the plugin pretending it has a context.
+TEST_F(CameraPluginTest, EglGivesUpWhenSurfacelessAlsoFails)
+{
+  load_model(EGL_TEST_MODEL);
+
+  std::atomic<int> attempts{ 0 };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  plugin.set_egl_make_current([&](EGLDisplay, EGLSurface, EGLSurface, EGLContext) -> EGLBoolean {
+    ++attempts;
+    return EGL_FALSE;
+  });
+
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_, []() { return 0; }));
+
+  // Give the rendering thread time to try and fail; it must not report itself available.
+  const auto deadline = std::chrono::steady_clock::now() + WAIT_TIMEOUT;
+  while (attempts.load() < 2 && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(POLL_INTERVAL);
+  }
+  EXPECT_EQ(attempts.load(), 2) << "both the PBuffer and the surfaceless bind should be tried";
+  EXPECT_FALSE(plugin.is_rendering_available());
   plugin.cleanup();
 }
 


### PR DESCRIPTION
Camera rendering could fail to start with:

```text
EGL: Failed to make context current (error: 0x3000)
```

where `0x3000` is `EGL_SUCCESS`. The cause is a driver behaviour rather than a bug in the
EGL setup: at least the NVIDIA driver refuses to bind a PBuffer surface in a process that
already holds a GLX context -- which is the case whenever the MuJoCo viewer is open -- and
`eglGetError` misreports the failure as success.

The PBuffer is only requested for drivers that need a real draw surface. The surfaceless
platform, which is what this code already asks for via `EGL_PLATFORM_SURFACELESS_MESA`, does
not require one, and MuJoCo renders into its own offscreen framebuffer regardless, so
binding with no surface at all is equivalent. The PBuffer is still tried first so drivers
that do want one keep working, then the bind is retried surfaceless. If both fail, the error
now names the viewer as the likely cause instead of printing a success code.

Fixes # (issue)

### Is this user-facing behavior change?

Yes: camera rendering now works in configurations where it previously failed to start, and a
warning names the retry when it happens. No new parameters, and no change on drivers that
accept the PBuffer.

### Did you use Generative AI?

Yes -- Claude Code (Claude Opus). The fallback, the test seam and the two tests were
produced with it. The driver behaviour was diagnosed by hand against a running simulation.

### Additional Information

`eglMakeCurrent` is reached through an `EglMakeCurrentFn` seam, in the style of the existing
`GlfwInitFn` overload of `init()`, because the driver behaviour cannot be provoked on demand:

* one test makes the PBuffer bind fail and delegates the surfaceless retry to the real entry
  point, so the fallback is checked to produce a genuine context;
* the other fails both binds and checks that rendering is reported unavailable rather than
  assumed.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
