### PR TITLE
Accept <capsule> geometry when parsing the URDF

### DIFF
--- a/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
+++ b/mujoco_ros2_control/mujoco_ros2_control/urdf_to_mujoco_utils.py
@@ -28,9 +28,61 @@ import math
 import numpy as np
 
 from urdf_parser_py.urdf import URDF
+import urdf_parser_py.urdf as _urdf
+import urdf_parser_py.xml_reflection as xmlr
 
 from ament_index_python.packages import get_package_share_directory
 from xml.dom import minidom
+
+
+class Capsule(xmlr.Object):
+    """A ``<capsule radius="" length="">`` collision/visual geometry.
+
+    Capsule is NOT part of the URDF specification, which defines only box, cylinder,
+    sphere and mesh. MuJoCo's own URDF importer nevertheless accepts it as an extension,
+    and MJCF has capsules natively, so robot descriptions written for MuJoCo legitimately
+    emit one: a capsule sole made of a few parallel capsules gives a far better
+    conditioned flat contact patch than the equivalent collision mesh.
+
+    ``urdf_parser_py`` is the odd one out. This module parses the description with it for
+    bookkeeping only (asset paths, link and joint structure); the actual URDF to MJCF
+    conversion is done by MuJoCo itself via ``MjModel.from_xml_path``. But its geometry
+    factory is a closed dict, so an unknown child of ``<geometry>`` raises
+    ``Exception: Invalid geometric tag: capsule`` and aborts the whole conversion before
+    MuJoCo is ever reached. Registering the type below removes that veto without touching
+    the conversion path; MuJoCo produces the capsule geom either way.
+    """
+
+    def __init__(self, radius=0.0, length=0.0):
+        self.radius = radius
+        self.length = length
+
+
+xmlr.reflect(Capsule, tag='capsule', params=[
+    xmlr.Attribute('radius', float),
+    xmlr.Attribute('length', float),
+])
+
+
+def _register_capsule_geometry():
+    """Teach ``urdf_parser_py``'s ``<geometry>`` factory about capsules.
+
+    The factory is built inside ``GeometricType.__init__`` and the instance is held in the
+    global value-type registry, so the maps have to be extended on the registered instance
+    rather than by subclassing. Idempotent, and a no-op on any future urdf_parser_py that
+    ships capsule support itself.
+    """
+    for value_type in xmlr.core.value_types.values():
+        if not isinstance(value_type, _urdf.GeometricType):
+            continue
+        factory = value_type.factory
+        if 'capsule' in factory.typeMap:
+            continue
+        factory.typeMap['capsule'] = Capsule
+        factory.nameMap[Capsule] = 'capsule'
+
+
+_register_capsule_geometry()
 
 # Hardcoded relative paths for MuJoCo asset outputs
 DECOMPOSED_PATH_NAME = "decomposed"


### PR DESCRIPTION
## Description

`urdf_to_mujoco_utils` aborts on any description that contains a capsule collision or visual
geometry:

```text
Exception: Invalid geometric tag: capsule
```

`urdf_parser_py`'s `<geometry>` factory is a closed dictionary of `box`, `cylinder`, `sphere`
and `mesh`, so an unknown child raises before MuJoCo is ever reached.

Capsule is not in the URDF specification, but MuJoCo's own URDF importer accepts it as an
extension and MJCF has capsules natively, so a description written for MuJoCo legitimately
emits one -- a sole built from a few parallel capsules gives a much better conditioned flat
contact patch than the equivalent collision mesh.

This module parses the description only for bookkeeping (asset paths, link and joint
structure); the conversion itself is done by MuJoCo via `MjModel.from_xml_path`. Registering
the type therefore removes the veto without touching the conversion path. Registration is
idempotent and a no-op on any future `urdf_parser_py` that gains capsule support of its own.

Fixes # (issue)

### Is this user-facing behavior change?

Yes: descriptions containing `<capsule>` can now be converted, where they previously aborted.
Nothing changes for descriptions that do not use it.

### Did you use Generative AI?

Yes -- Claude Code (Claude Opus) wrote the type registration and its documentation.

### Additional Information

Reproduced on a Kangaroo description built with `collision_type:=capsule` for MuJoCo, which
emits 11 `<capsule>` tags: plain `urdf_parser_py` aborts with the message above, and with the
registration the same URDF parses to 59 links.

No unit test is included: the change is a registration against a third-party parser's global
type registry, and a test would assert little more than that the registration call ran. Happy
to add one exercising a minimal capsule URDF through the parser if you would like it.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
