### PR TITLE
Allow the camera render backend to be selected

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -2395,6 +2395,12 @@ void MujocoSystemInterface::load_legacy_cameras(const std::vector<std::string>& 
     get_node()->declare_parameter(prefix + "camera_publish_rate", camera_publish_rate);
   }
 
+  const std::string render_backend = get_hardware_parameter_or(get_hardware_info(), "camera_render_backend", "auto");
+  if (!get_node()->has_parameter(prefix + "render_backend"))
+  {
+    get_node()->declare_parameter(prefix + "render_backend", render_backend);
+  }
+
   for (int i = 0; i < simulation_->model()->ncam; ++i)
   {
     const char* cam_name = simulation_->model()->names + simulation_->model()->name_camadr[i];

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -81,6 +81,8 @@ Note that any number of cameras can be configured in the plugin configuration.
       type: "mujoco_ros2_control_plugins/CameraPlugin"
       # Note all cameras are published at the same rate
       camera_publish_rate: 5.0
+      # "auto" (default), "glfw" or "egl"; see "Headless Rendering" below
+      render_backend: auto
       camera:
         frame_name: camera_color_optical_frame
         info_topic: /camera_topic/color/camera_info
@@ -103,6 +105,48 @@ The system automatically detects whether a display is available:
 * Without display: Falls back to EGL for GPU-accelerated headless rendering
 
 This allows camera topics to be published even when running in headless mode (e.g., on a server, in Docker containers, or in CI environments).
+
+Selecting the backend explicitly
+""""""""""""""""""""""""""""""""
+
+``render_backend`` overrides that detection:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Value
+     - Behaviour
+   * - ``auto``
+     - Default, and the behaviour described above: try GLFW, fall back to EGL.
+   * - ``glfw``
+     - Use GLFW. If it cannot be initialized, ``init`` **fails** rather than falling back --
+       an explicit request that silently produced the other backend would be worse than an
+       error.
+   * - ``egl``
+     - Use EGL, without initializing GLFW at all.
+
+Choosing ``egl`` is useful even on a machine that *has* a display. GLFW renders through the X
+display, which is also where the MuJoCo viewer draws, so the cameras and the viewer end up
+sharing a single GL queue and the cameras lose frames whenever the viewer is busy. An EGL
+surfaceless context does not go through X, so the viewer can stay open without the camera
+renders queueing behind it.
+
+.. warning::
+   Some drivers (NVIDIA among them) refuse to bind an EGL context in a process that already
+   holds a GLX context, which is the case whenever the viewer is open -- and ``eglGetError``
+   may report success while ``eglMakeCurrent`` fails. Use ``render_backend: egl`` together
+   with headless operation, or leave it at ``auto``.
+
+When the plugin is loaded through the hardware interface, the value can be set from the
+``ros2_control`` URDF instead of the plugin parameters:
+
+.. code-block:: xml
+
+   <hardware>
+     <plugin>mujoco_ros2_control/MujocoSystemInterface</plugin>
+     <param name="camera_render_backend">egl</param>
+   </hardware>
 
 .. note::
    EGL requires proper GPU drivers and EGL libraries to be installed (e.g., libegl1-mesa on Ubuntu).

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -50,15 +50,36 @@ bool CameraPlugin::init(rclcpp::Node::SharedPtr node, const mjModel* model, mjDa
   }
 
   // Start the rendering thread process
-  // Try GLFW first, fall back to EGL for headless environments
-  if (glfw_init_fn())
+  if (render_backend_ == "egl")
   {
+    // Asked for explicitly, so do not touch GLFW at all: the point of choosing EGL on a
+    // machine that has a display is to stay off the X queue the viewer draws on.
+    RCLCPP_INFO(node_->get_logger(), "Using EGL for camera rendering (render_backend=egl).");
+    use_egl_ = true;
+  }
+  else if (render_backend_ == "glfw")
+  {
+    // Also explicit, so failing is more useful than quietly rendering through something the
+    // caller did not ask for.
+    if (!glfw_init_fn())
+    {
+      RCLCPP_ERROR(node_->get_logger(), "render_backend=glfw was requested but GLFW failed to initialize.");
+      return false;
+    }
     use_egl_ = false;
   }
   else
   {
-    RCLCPP_WARN(node_->get_logger(), "Failed to initialize GLFW. Attempting EGL for headless rendering.");
-    use_egl_ = true;
+    // Try GLFW first, fall back to EGL for headless environments
+    if (glfw_init_fn())
+    {
+      use_egl_ = false;
+    }
+    else
+    {
+      RCLCPP_WARN(node_->get_logger(), "Failed to initialize GLFW. Attempting EGL for headless rendering.");
+      use_egl_ = true;
+    }
   }
   rendering_thread_ = std::thread(&CameraPlugin::update_loop, this);
   return true;
@@ -161,6 +182,18 @@ bool CameraPlugin::register_cameras()
 
   camera_publish_rate_ = node_->get_parameter(camera_publish_rate_param).as_double();
   RCLCPP_INFO(node_->get_logger(), "Publishing camera data at rate %f per second.", camera_publish_rate_);
+
+  if (!node_->has_parameter(param_prefix + "render_backend"))
+  {
+    node_->declare_parameter(param_prefix + "render_backend", "auto");
+  }
+  render_backend_ = node_->get_parameter(param_prefix + "render_backend").as_string();
+  if (render_backend_ != "auto" && render_backend_ != "glfw" && render_backend_ != "egl")
+  {
+    RCLCPP_ERROR(node_->get_logger(), "Unknown render_backend '%s'; expected \"auto\", \"glfw\" or \"egl\".",
+                 render_backend_.c_str());
+    return false;
+  }
 
   cameras_.resize(0);
   for (auto i = 0; i < mj_model_->ncam; ++i)

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -234,6 +234,15 @@ private:
 
   // Image publishing rate (applies to streaming cameras only)
   double camera_publish_rate_{ 5.0 };
+
+  // Which OpenGL backend the rendering thread should use: "auto", "glfw" or "egl".
+  //
+  // This is not only a headless/desktop switch. GLFW renders through the X display, which is
+  // also where the MuJoCo viewer draws, so on a desktop the cameras and the viewer share one
+  // GL queue and the cameras lose frames whenever the viewer is busy. An EGL surfaceless
+  // context does not go through X at all, so selecting it explicitly keeps the viewer open
+  // without putting the camera renders behind it.
+  std::string render_backend_{ "auto" };
   rclcpp::Time last_publish_time_{ 0, 0, RCL_ROS_TIME };
 
   // Whether any streaming camera is registered. This lets the update loop skip the

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -361,6 +361,139 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   plugin.cleanup();
 }
 
+// ---------------------------------------------------------------------------------------
+// render_backend
+//
+// The dispatch is only reached when the model actually has a camera (init returns early
+// otherwise), so these load a one-camera model. GLFW availability is injected through the
+// init() overload rather than depending on whether this machine has a display.
+// ---------------------------------------------------------------------------------------
+
+namespace
+{
+constexpr const char* ONE_CAMERA_MODEL = R"(<?xml version="1.0"?>
+<mujoco model="one_camera">
+  <worldbody>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <camera name="cam" pos="0 -1 0.2" mode="fixed"/>
+  </worldbody>
+</mujoco>
+)";
+
+constexpr const char* NO_CAMERA_MODEL = R"(<?xml version="1.0"?>
+<mujoco model="no_cameras_backend">
+  <worldbody>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+}  // namespace
+
+// An unrecognised value is rejected outright rather than silently treated as "auto":
+// a typo in a description would otherwise be invisible.
+TEST_F(CameraPluginTest, UnknownRenderBackendIsRejected)
+{
+  load_model(NO_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.render_backend", "vulkan");
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_FALSE(plugin.init(plugin_node_, model_, data_));
+  plugin.cleanup();
+}
+
+TEST_F(CameraPluginTest, RenderBackendDefaultsToAuto)
+{
+  load_model(NO_CAMERA_MODEL);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  EXPECT_EQ(plugin_node_->get_parameter("mujoco_plugins.camera_plugin.render_backend").as_string(), "auto");
+  plugin.cleanup();
+}
+
+// auto is the pre-existing behaviour: prefer GLFW, fall back to EGL when it is unavailable.
+TEST_F(CameraPluginTest, AutoPrefersGlfwWhenAvailable)
+{
+  load_model(ONE_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.render_backend", "auto");
+
+  bool glfw_consulted = false;
+  auto fake_glfw = [&glfw_consulted]() {
+    glfw_consulted = true;
+    return 1;
+  };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, fake_glfw));
+  EXPECT_TRUE(glfw_consulted);
+  plugin.cleanup();
+}
+
+TEST_F(CameraPluginTest, AutoFallsBackToEglWhenGlfwIsUnavailable)
+{
+  load_model(ONE_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.render_backend", "auto");
+
+  auto fake_glfw = []() { return 0; };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, fake_glfw));
+  plugin.cleanup();
+}
+
+// The reason the parameter exists: on a desktop, GLFW shares the X queue with the viewer.
+// Choosing EGL must therefore not touch GLFW at all, even when GLFW would have worked.
+TEST_F(CameraPluginTest, ExplicitEglDoesNotConsultGlfw)
+{
+  load_model(ONE_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.render_backend", "egl");
+
+  bool glfw_consulted = false;
+  auto fake_glfw = [&glfw_consulted]() {
+    glfw_consulted = true;
+    return 1;
+  };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, fake_glfw));
+  EXPECT_FALSE(glfw_consulted) << "render_backend=egl must not initialize GLFW";
+  plugin.cleanup();
+}
+
+// An explicit request that cannot be honoured fails loudly. Falling back to EGL here would
+// hand the caller the backend they specifically avoided.
+TEST_F(CameraPluginTest, ExplicitGlfwFailureIsNotDowngradedToEgl)
+{
+  load_model(ONE_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.render_backend", "glfw");
+
+  auto fake_glfw = []() { return 0; };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_FALSE(plugin.init(plugin_node_, model_, data_, fake_glfw));
+  plugin.cleanup();
+}
+
+TEST_F(CameraPluginTest, ExplicitGlfwSucceedsWhenGlfwIsAvailable)
+{
+  load_model(ONE_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.render_backend", "glfw");
+
+  auto fake_glfw = []() { return 1; };
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  EXPECT_TRUE(plugin.init(plugin_node_, model_, data_, fake_glfw));
+  plugin.cleanup();
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Description

Backend selection was implicit: try GLFW, fall back to EGL if it fails. That is the right
default, but it cannot express the case that matters on a desktop. GLFW renders through the X
display, which is also where the MuJoCo viewer draws, so the cameras and the viewer end up
sharing one GL queue and the cameras lose frames whenever the viewer is busy. An EGL
surfaceless context does not go through X at all, so being able to ask for EGL keeps the
viewer open without putting the camera renders behind it.

`render_backend` takes `auto` (the previous behaviour, and the default), `glfw` or `egl`. An
explicit request is honoured strictly:

* `glfw` fails `init` rather than falling back, because silently handing back the other
  backend defeats the point of asking;
* `egl` does not initialize GLFW at all;
* an unrecognised value is rejected rather than treated as `auto`, so a typo in a
  description is not invisible.

The hardware interface forwards a `camera_render_backend` hardware parameter into the plugin
the same way `camera_publish_rate` already is, so the backend can be set from the
`ros2_control` URDF. Without that the plugin declared its own `auto` default first and the
URDF value was silently ignored.

Fixes # (issue)

### Is this user-facing behavior change?

Yes, additive. One new plugin parameter:

| Parameter | Default | Meaning |
|---|---|---|
| `render_backend` | `auto` | `auto`, `glfw` or `egl` |

`auto` reproduces the previous behaviour exactly, so nothing changes for existing users. The
matching hardware parameter is `camera_render_backend`:

```xml
<hardware>
  <plugin>mujoco_ros2_control/MujocoSystemInterface</plugin>
  <param name="camera_render_backend">egl</param>
</hardware>
```

### Did you use Generative AI?

Yes -- Claude Code (Claude Opus). The dispatch, the parameter plumbing, the seven tests and
the documentation were produced with it. The GL-queue contention that motivates the parameter
was measured by hand.

### Additional Information

The tests go through the existing `GlfwInitFn` injection point, so none of the seven depend
on whether the machine running them has a display. They cover the default, rejection of an
unknown value, `auto` preferring GLFW and falling back without it, `egl` not touching GLFW
even when GLFW would have worked, and `glfw` failing rather than being downgraded.

Please note the interaction with EGL documented in the same section: some drivers refuse to
bind an EGL context in a process that already holds a GLX one, so `render_backend: egl` is
useful together with headless operation. `fix/egl_surfaceless_fallback` addresses that
separately and the two do not conflict.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
