### PR TITLE
Model the depth camera instead of publishing exact geometry

### DIFF
--- a/mujoco_ros2_control_plugins/CMakeLists.txt
+++ b/mujoco_ros2_control_plugins/CMakeLists.txt
@@ -147,6 +147,13 @@ if(BUILD_TESTING)
     "LINKER:--pop-state"
   )
 
+  ament_add_gtest(test_depth_sensor_model
+    test/test_depth_sensor_model.cpp
+  )
+  target_include_directories(test_depth_sensor_model PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+
   ament_add_gtest(test_3d_lidar_plugin
     test/test_3d_lidar_plugin.cpp
   )

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -81,6 +81,13 @@ Note that any number of cameras can be configured in the plugin configuration.
       type: "mujoco_ros2_control_plugins/CameraPlugin"
       # Note all cameras are published at the same rate
       camera_publish_rate: 5.0
+      # Depth sensor model, see "Depth Sensor Model" below
+      depth_sensor_model: true
+      depth_min_range: 0.28
+      depth_max_range: 3.0
+      depth_stereo_baseline: 0.05
+      depth_subpixel_error: 0.15
+      depth_dropout_fraction: 0.02
       camera:
         frame_name: camera_color_optical_frame
         info_topic: /camera_topic/color/camera_info
@@ -92,6 +99,71 @@ Note that any number of cameras can be configured in the plugin configuration.
 
    MuJoCo's camera coordinate conventions differ from ROS.
    Refer to the MuJoCo documentation for details.
+
+Depth Sensor Model
+^^^^^^^^^^^^^^^^^^
+
+MuJoCo reports the exact geometric distance at every pixel: no noise, no invalid returns, and
+values below the Min-Z of any real device. Anything built on that stream -- an elevation map, a
+visual odometry front end, an obstacle check -- is tuned against a sensor that does not exist,
+and the discrepancy only appears on hardware.
+
+With ``depth_sensor_model`` enabled the published ``32FC1`` depth image is passed through a
+stereo depth model instead. Three effects, each with a parameter because the right value depends
+on the device:
+
+* **Usable range.** Outside ``[depth_min_range, depth_max_range]`` the pixel is ``NaN``, the ROS
+  convention for "no data" in a ``32FC1`` image. Returning a number instead is what lets a
+  consumer trust geometry the sensor could never have supplied.
+* **Triangulation error.** Stereo depth error grows with the *square* of range, because depth is
+  inversely proportional to disparity:
+
+  .. math::
+
+     \sigma(Z) = \frac{Z^2 \cdot \texttt{depth\_subpixel\_error}}
+                       {f_x \cdot \texttt{depth\_stereo\_baseline}}
+
+  It is derived from the geometry rather than fixed as a percentage, so it stays correct if the
+  resolution or field of view changes, and it uses the very :math:`f_x` published in
+  ``camera_info`` so the noise matches what the consumer reprojects with.
+* **Dropouts.** ``depth_dropout_fraction`` of pixels return ``NaN``. Real depth drops out on
+  low-texture, specular and occluded surfaces in *patches*; this reproduces their frequency but
+  not their spatial structure.
+
+The defaults describe an Intel RealSense D435i. At the 0.15 px default with a 50 mm baseline the
+error is about 1 % of range at 2 m, the figure usually reported for that device; raise
+``depth_subpixel_error`` to roughly 0.3 px to sit on the datasheet's "< 2 % at 2 m" bound instead.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Parameter
+     - Default
+     - Meaning
+   * - ``depth_sensor_model``
+     - ``true``
+     - Enable the model. ``false`` publishes MuJoCo's exact depth.
+   * - ``depth_min_range``
+     - ``0.28``
+     - [m] Min-Z; below this the pixel is ``NaN``.
+   * - ``depth_max_range``
+     - ``3.0``
+     - [m] beyond the ideal range; above this the pixel is ``NaN``.
+   * - ``depth_stereo_baseline``
+     - ``0.05``
+     - [m] separation of the IR pair, used by the error model.
+   * - ``depth_subpixel_error``
+     - ``0.15``
+     - [px] disparity matching error.
+   * - ``depth_dropout_fraction``
+     - ``0.02``
+     - Fraction of pixels returning ``NaN``.
+
+.. note::
+   The noise is seeded deterministically, so a recording made from the simulation is
+   reproducible. Set ``depth_sensor_model: false`` to recover the previous exact-depth
+   behaviour.
 
 Headless Rendering
 ^^^^^^^^^^^^^^^^^^

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -162,6 +162,45 @@ bool CameraPlugin::register_cameras()
   camera_publish_rate_ = node_->get_parameter(camera_publish_rate_param).as_double();
   RCLCPP_INFO(node_->get_logger(), "Publishing camera data at rate %f per second.", camera_publish_rate_);
 
+  // Depth sensor model. MuJoCo returns exact geometric depth at every pixel: no noise, no
+  // invalid returns, and values below the real Min-Z. A map or an estimator built against
+  // that looks far better in simulation than it can on hardware, so the sensor is modelled
+  // here rather than letting the consumer discover the difference on the robot.
+  const auto declare_double = [this](const std::string& name, double fallback) {
+    if (!node_->has_parameter(name))
+    {
+      node_->declare_parameter(name, fallback);
+    }
+    return node_->get_parameter(name).as_double();
+  };
+  if (!node_->has_parameter(param_prefix + "depth_sensor_model"))
+  {
+    node_->declare_parameter(param_prefix + "depth_sensor_model", true);
+  }
+  depth_sensor_model_ = node_->get_parameter(param_prefix + "depth_sensor_model").as_bool();
+  depth_model_.min_range = static_cast<float>(declare_double(param_prefix + "depth_min_range", 0.28));
+  depth_model_.max_range = static_cast<float>(declare_double(param_prefix + "depth_max_range", 3.0));
+  depth_model_.stereo_baseline =
+      static_cast<float>(declare_double(param_prefix + "depth_stereo_baseline", 0.05));
+  depth_model_.subpixel_error =
+      static_cast<float>(declare_double(param_prefix + "depth_subpixel_error", 0.15));
+  depth_model_.dropout_fraction = declare_double(param_prefix + "depth_dropout_fraction", 0.02);
+  if (depth_model_.min_range > depth_model_.max_range)
+  {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "depth_min_range (%.3f m) is above depth_max_range (%.3f m); every pixel would be NaN.",
+                 depth_model_.min_range, depth_model_.max_range);
+    return false;
+  }
+  if (depth_sensor_model_)
+  {
+    RCLCPP_INFO(node_->get_logger(),
+                "Depth sensor model ON: range [%.2f, %.2f] m, stereo baseline %.3f m, "
+                "subpixel error %.3f px, dropout %.1f%%. Invalid pixels are NaN.",
+                depth_model_.min_range, depth_model_.max_range, depth_model_.stereo_baseline,
+                depth_model_.subpixel_error, 100.0 * depth_model_.dropout_fraction);
+  }
+
   cameras_.resize(0);
   for (auto i = 0; i < mj_model_->ncam; ++i)
   {
@@ -595,7 +634,10 @@ void CameraPlugin::render_and_publish_camera(CameraData& camera, const rclcpp::T
     float* dst_row = depth_out + static_cast<size_t>(camera.height - 1 - h) * camera.width;
     for (uint32_t w = 0; w < camera.width; ++w)
     {
-      dst_row[w] = camera_near_distance_ / (1.0f - src_row[w] * camera_depth_scale_);
+      const float true_depth = camera_near_distance_ / (1.0f - src_row[w] * camera_depth_scale_);
+      dst_row[w] = depth_sensor_model_ ?
+                       depth_model_.apply(true_depth, static_cast<float>(camera.camera_info.k[0])) :
+                       true_depth;
     }
   }
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -34,6 +34,8 @@
 
 #include "mujoco_ros2_control_plugins/mujoco_ros2_control_plugins_base.hpp"
 
+#include "depth_sensor_model.hpp"
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLFW/glfw3.h>
@@ -234,6 +236,10 @@ private:
 
   // Image publishing rate (applies to streaming cameras only)
   double camera_publish_rate_{ 5.0 };
+
+  // Depth sensor model. Off restores MuJoCo's exact geometric depth.
+  bool depth_sensor_model_{ true };
+  DepthSensorModel depth_model_;
   rclcpp::Time last_publish_time_{ 0, 0, RCL_ROS_TIME };
 
   // Whether any streaming camera is registered. This lets the update loop skip the

--- a/mujoco_ros2_control_plugins/src/depth_sensor_model.hpp
+++ b/mujoco_ros2_control_plugins/src/depth_sensor_model.hpp
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2026 PAL Robotics S.L.
+ *
+ * All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <random>
+
+namespace mujoco_ros2_control_plugins
+{
+
+/**
+ * @brief Turns MuJoCo's exact geometric depth into a reading a stereo depth camera could return.
+ *
+ * MuJoCo reports the true distance at every pixel: no noise, no invalid returns, and values
+ * below the sensor's real Min-Z. Anything built on that stream is tuned against a sensor that
+ * does not exist, and the discrepancy only shows up on hardware. The defaults describe an
+ * Intel RealSense D435i; every one of them is a parameter because the right value depends on
+ * the device being simulated.
+ *
+ * Kept separate from the plugin so the arithmetic can be unit tested without an OpenGL context.
+ */
+class DepthSensorModel
+{
+public:
+  float min_range{ 0.28f };        ///< [m] Min-Z; below this the sensor returns nothing.
+  float max_range{ 3.0f };         ///< [m] beyond the ideal range.
+  float stereo_baseline{ 0.05f };  ///< [m] separation of the IR pair.
+  float subpixel_error{ 0.15f };   ///< [px] disparity matching error; about 1% at 2 m.
+  double dropout_fraction{ 0.02 }; ///< Fraction of pixels that return nothing.
+
+  /// Seeded deterministically so a recording can be reproduced; reseed for independent runs.
+  explicit DepthSensorModel(std::uint32_t seed = 42u) : generator_(seed)
+  {
+  }
+
+  /// Restarts the noise sequence. The distributions are reset too: normal_distribution
+  /// caches a second Box-Muller value, so reseeding the generator alone would not.
+  void reseed(std::uint32_t seed)
+  {
+    generator_.seed(seed);
+    noise_.reset();
+    dropout_.reset();
+  }
+
+  /**
+   * @brief Standard deviation of the triangulation error at @p depth.
+   *
+   * Stereo depth error grows with the SQUARE of range, because depth is inversely
+   * proportional to disparity:
+   *
+   *     sigma(Z) = Z^2 * subpixel / (focal_px * baseline)
+   *
+   * Derived from the geometry rather than fixed as a percentage, so it stays correct if the
+   * resolution or the field of view changes. Pass the very focal length published in
+   * camera_info, so the noise matches the geometry the consumer will reproject with.
+   *
+   * At the 0.15 px default with a 50 mm baseline:
+   *
+   *            fx 617 (colour/depth)      fx 433 (infra)
+   *   0.5 m       1.2 mm  (0.24%)          1.7 mm  (0.35%)
+   *   1.0 m       4.9 mm  (0.49%)          6.9 mm  (0.69%)
+   *   2.0 m      19.4 mm  (0.97%)         27.7 mm  (1.39%)
+   *   3.0 m      43.7 mm  (1.46%)         62.4 mm  (2.08%)
+   *
+   * That is about 1% at 2 m, the figure typically reported for a D435i rather than the
+   * datasheet's "<2% at 2 m" worst case. Raise subpixel_error to roughly 0.3 px to sit on
+   * that bound instead; the parameter is the honest place to say how pessimistic to be.
+   */
+  [[nodiscard]] float stddevAt(float depth, float focal_px) const
+  {
+    return depth * depth * subpixel_error / std::max(1e-6f, focal_px * stereo_baseline);
+  }
+
+  /**
+   * @brief Apply the model to one exact depth sample.
+   *
+   * @return NaN outside the usable range and for a dropped pixel -- the ROS convention for
+   *         "no data" in a 32FC1 image -- otherwise the sample perturbed by triangulation
+   *         error. Returning a number instead of NaN is what lets a consumer trust geometry
+   *         the sensor could never have supplied.
+   */
+  float apply(float true_depth, float focal_px)
+  {
+    // Written as !(x >= min) so that a NaN input stays NaN rather than passing the test.
+    if (!(true_depth >= min_range) || true_depth > max_range)
+    {
+      return std::numeric_limits<float>::quiet_NaN();
+    }
+
+    // Holes. Real depth drops out on low-texture, specular and occluded surfaces, none of
+    // which MuJoCo knows about, so this is a blunt stand-in for their FREQUENCY rather than
+    // their spatial structure: real dropouts come in patches, these do not.
+    if (dropout_fraction > 0.0 && dropout_(generator_) < dropout_fraction)
+    {
+      return std::numeric_limits<float>::quiet_NaN();
+    }
+
+    const float noisy = true_depth + stddevAt(true_depth, focal_px) * static_cast<float>(noise_(generator_));
+
+    // Noise can push a sample out of range; it is still a reading the sensor would not return.
+    if (!(noisy >= min_range) || noisy > max_range)
+    {
+      return std::numeric_limits<float>::quiet_NaN();
+    }
+    return noisy;
+  }
+
+private:
+  std::mt19937 generator_;
+  std::normal_distribution<double> noise_{ 0.0, 1.0 };
+  std::uniform_real_distribution<double> dropout_{ 0.0, 1.0 };
+};
+
+}  // namespace mujoco_ros2_control_plugins

--- a/mujoco_ros2_control_plugins/test/test_depth_sensor_model.cpp
+++ b/mujoco_ros2_control_plugins/test/test_depth_sensor_model.cpp
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2026 PAL Robotics S.L.
+ *
+ * All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "depth_sensor_model.hpp"
+
+using mujoco_ros2_control_plugins::DepthSensorModel;
+
+namespace
+{
+/// Focal length of the D435i colour/depth stream at 848x480, as published in camera_info.
+constexpr float FX = 617.0f;
+
+/// A model with the noise sources switched off, so range handling can be checked exactly.
+DepthSensorModel noiseless()
+{
+  DepthSensorModel model;
+  model.subpixel_error = 0.0f;
+  model.dropout_fraction = 0.0;
+  return model;
+}
+}  // namespace
+
+TEST(DepthSensorModel, DefaultsDescribeAD435i)
+{
+  const DepthSensorModel model;
+  EXPECT_FLOAT_EQ(model.min_range, 0.28f);
+  EXPECT_FLOAT_EQ(model.max_range, 3.0f);
+  EXPECT_FLOAT_EQ(model.stereo_baseline, 0.05f);
+  EXPECT_FLOAT_EQ(model.subpixel_error, 0.15f);
+  EXPECT_DOUBLE_EQ(model.dropout_fraction, 0.02);
+}
+
+TEST(DepthSensorModel, PassesSamplesInsideTheUsableRange)
+{
+  auto model = noiseless();
+  for (const float depth : { 0.28f, 0.5f, 1.5f, 3.0f })
+  {
+    EXPECT_FLOAT_EQ(model.apply(depth, FX), depth) << "at " << depth << " m";
+  }
+}
+
+TEST(DepthSensorModel, ReturnsNanBelowMinRange)
+{
+  auto model = noiseless();
+  // The regression this guards: MuJoCo happily reports 0.2477 m, inside the D435i's Min-Z.
+  EXPECT_TRUE(std::isnan(model.apply(0.2477f, FX)));
+  EXPECT_TRUE(std::isnan(model.apply(0.0f, FX)));
+  EXPECT_TRUE(std::isnan(model.apply(std::nextafterf(0.28f, 0.0f), FX)));
+}
+
+TEST(DepthSensorModel, ReturnsNanAboveMaxRange)
+{
+  auto model = noiseless();
+  EXPECT_TRUE(std::isnan(model.apply(3.01f, FX)));
+  EXPECT_TRUE(std::isnan(model.apply(100.0f, FX)));
+  EXPECT_TRUE(std::isnan(model.apply(std::numeric_limits<float>::infinity(), FX)));
+}
+
+TEST(DepthSensorModel, PropagatesNanInput)
+{
+  auto model = noiseless();
+  EXPECT_TRUE(std::isnan(model.apply(std::numeric_limits<float>::quiet_NaN(), FX)));
+}
+
+TEST(DepthSensorModel, RangeBoundsAreInclusive)
+{
+  auto model = noiseless();
+  EXPECT_FALSE(std::isnan(model.apply(model.min_range, FX)));
+  EXPECT_FALSE(std::isnan(model.apply(model.max_range, FX)));
+}
+
+TEST(DepthSensorModel, TriangulationErrorGrowsWithTheSquareOfRange)
+{
+  const DepthSensorModel model;
+  // sigma(Z) = Z^2 * subpixel / (fx * baseline): doubling the range quadruples the error.
+  const float s1 = model.stddevAt(1.0f, FX);
+  const float s2 = model.stddevAt(2.0f, FX);
+  EXPECT_NEAR(s2 / s1, 4.0f, 1e-4f);
+}
+
+TEST(DepthSensorModel, TriangulationErrorMatchesTheDocumentedTable)
+{
+  const DepthSensorModel model;
+  // The table in the header, in millimetres, for fx 617 and a 50 mm baseline.
+  // The table is quoted to 0.1 mm, so allow the rounding in either direction.
+  EXPECT_NEAR(1e3f * model.stddevAt(0.5f, FX), 1.2f, 0.1f);
+  EXPECT_NEAR(1e3f * model.stddevAt(1.0f, FX), 4.9f, 0.1f);
+  EXPECT_NEAR(1e3f * model.stddevAt(2.0f, FX), 19.4f, 0.1f);
+  EXPECT_NEAR(1e3f * model.stddevAt(3.0f, FX), 43.7f, 0.1f);
+  // About 1% of the range at 2 m, the figure usually quoted for a D435i.
+  EXPECT_NEAR(model.stddevAt(2.0f, FX) / 2.0f, 0.01f, 0.001f);
+}
+
+TEST(DepthSensorModel, ShorterFocalLengthMeansLargerError)
+{
+  const DepthSensorModel model;
+  // The infra streams have a shorter focal length, so they are noisier at the same range.
+  EXPECT_GT(model.stddevAt(2.0f, 433.0f), model.stddevAt(2.0f, FX));
+}
+
+TEST(DepthSensorModel, ZeroFocalLengthDoesNotDivideByZero)
+{
+  const DepthSensorModel model;
+  EXPECT_TRUE(std::isfinite(model.stddevAt(1.0f, 0.0f)));
+}
+
+TEST(DepthSensorModel, NoiseHasTheModelledMagnitude)
+{
+  DepthSensorModel model;
+  model.dropout_fraction = 0.0;  // isolate the noise from the holes
+  constexpr float depth = 2.0f;
+  constexpr int samples = 20000;
+
+  double sum = 0.0;
+  double sum_sq = 0.0;
+  int valid = 0;
+  for (int i = 0; i < samples; ++i)
+  {
+    const float value = model.apply(depth, FX);
+    if (!std::isnan(value))
+    {
+      const double error = value - depth;
+      sum += error;
+      sum_sq += error * error;
+      ++valid;
+    }
+  }
+  ASSERT_GT(valid, samples / 2);
+  const double mean = sum / valid;
+  const double stddev = std::sqrt(sum_sq / valid - mean * mean);
+
+  // Unbiased, and scattered by the sigma the formula predicts (19.4 mm at 2 m).
+  EXPECT_NEAR(mean, 0.0, 1e-3);
+  EXPECT_NEAR(stddev, model.stddevAt(depth, FX), 0.1 * model.stddevAt(depth, FX));
+}
+
+TEST(DepthSensorModel, DropoutFractionIsRespected)
+{
+  DepthSensorModel model;
+  model.subpixel_error = 0.0f;  // isolate the holes from the noise
+  model.dropout_fraction = 0.25;
+  constexpr int samples = 20000;
+
+  int dropped = 0;
+  for (int i = 0; i < samples; ++i)
+  {
+    if (std::isnan(model.apply(1.0f, FX)))
+    {
+      ++dropped;
+    }
+  }
+  EXPECT_NEAR(static_cast<double>(dropped) / samples, 0.25, 0.02);
+}
+
+TEST(DepthSensorModel, ZeroDropoutNeverDropsAnInRangeSample)
+{
+  DepthSensorModel model;
+  model.subpixel_error = 0.0f;
+  model.dropout_fraction = 0.0;
+  for (int i = 0; i < 1000; ++i)
+  {
+    ASSERT_FALSE(std::isnan(model.apply(1.0f, FX))) << "iteration " << i;
+  }
+}
+
+TEST(DepthSensorModel, IsDeterministicForAGivenSeed)
+{
+  DepthSensorModel a(7u);
+  DepthSensorModel b(7u);
+  for (int i = 0; i < 500; ++i)
+  {
+    const float lhs = a.apply(1.0f, FX);
+    const float rhs = b.apply(1.0f, FX);
+    ASSERT_EQ(std::isnan(lhs), std::isnan(rhs)) << "iteration " << i;
+    if (!std::isnan(lhs))
+    {
+      ASSERT_FLOAT_EQ(lhs, rhs) << "iteration " << i;
+    }
+  }
+}
+
+TEST(DepthSensorModel, DifferentSeedsGiveDifferentNoise)
+{
+  DepthSensorModel a(1u);
+  DepthSensorModel b(2u);
+  bool differs = false;
+  for (int i = 0; i < 100 && !differs; ++i)
+  {
+    const float lhs = a.apply(1.0f, FX);
+    const float rhs = b.apply(1.0f, FX);
+    differs = std::isnan(lhs) != std::isnan(rhs) || (!std::isnan(lhs) && std::fabs(lhs - rhs) > 0.0f);
+  }
+  EXPECT_TRUE(differs);
+}
+
+TEST(DepthSensorModel, ReseedRestartsTheSequence)
+{
+  DepthSensorModel model(3u);
+  std::vector<float> first;
+  for (int i = 0; i < 50; ++i)
+  {
+    first.push_back(model.apply(1.0f, FX));
+  }
+  model.reseed(3u);
+  for (std::size_t i = 0; i < first.size(); ++i)
+  {
+    const float again = model.apply(1.0f, FX);
+    ASSERT_EQ(std::isnan(first[i]), std::isnan(again)) << "sample " << i;
+    if (!std::isnan(again))
+    {
+      ASSERT_FLOAT_EQ(first[i], again) << "sample " << i;
+    }
+  }
+}
+
+TEST(DepthSensorModel, NoiseCannotProduceAnOutOfRangeReading)
+{
+  DepthSensorModel model;
+  // Right at the near edge, where the noise is as likely to push the sample below Min-Z as
+  // above it. Anything returned must still be a reading the sensor could produce.
+  for (int i = 0; i < 5000; ++i)
+  {
+    const float value = model.apply(model.min_range, FX);
+    if (!std::isnan(value))
+    {
+      ASSERT_GE(value, model.min_range);
+      ASSERT_LE(value, model.max_range);
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

MuJoCo returns exact geometric depth at every pixel: no noise, no invalid returns, and values
below the real Min-Z -- it happily reports 0.2477 m against a D435i's 0.28 m floor. Anything
built on that stream, an elevation map or a visual odometry front end, is tuned against a
sensor that does not exist, and the gap only shows up on hardware.

Three effects, each taken from the datasheet rather than invented, and each a parameter
because the right value depends on the device being simulated:

* **Usable range.** Outside `[depth_min_range, depth_max_range]` the pixel is `NaN`, the ROS
  convention for "no data" in a `32FC1` image. Returning a number instead is what lets a
  consumer trust geometry the sensor could never have supplied.
* **Triangulation error**, `sigma(Z) = Z^2 * subpixel / (fx * baseline)`. Stereo depth error
  grows with the *square* of range because depth is inversely proportional to disparity. It
  is derived from the geometry rather than fixed as a percentage, so it stays correct if the
  resolution or field of view changes, and it uses the very `fx` published in `camera_info`
  so the noise matches what the consumer reprojects with.
* **Dropouts.** A blunt uniform fraction, and the comment says so: real depth drops out on
  low-texture, specular and occluded surfaces in *patches*, and this reproduces their
  frequency but not their spatial structure.

The model lives in its own header, `depth_sensor_model.hpp`, rather than inside the plugin, so
the arithmetic can be unit tested without an OpenGL context.

Fixes # (issue)

### Is this user-facing behavior change?

**Yes, and one default changes existing behaviour.** Six new plugin parameters:

| Parameter | Default | Meaning |
|---|---|---|
| `depth_sensor_model` | `true` | Enable the model; `false` publishes MuJoCo's exact depth |
| `depth_min_range` | `0.28` | [m] Min-Z; below this the pixel is `NaN` |
| `depth_max_range` | `3.0` | [m] beyond the ideal range; above this the pixel is `NaN` |
| `depth_stereo_baseline` | `0.05` | [m] separation of the IR pair |
| `depth_subpixel_error` | `0.15` | [px] disparity matching error; about 1 % at 2 m |
| `depth_dropout_fraction` | `0.02` | Fraction of pixels returning `NaN` |

Because `depth_sensor_model` defaults to `true`, **existing users consuming a depth image
will see `NaN`s, added noise and a clamped range** where they previously got exact geometry.
That is the point of the change -- the old stream was not a sensor -- but it is a behaviour
change on upgrade rather than an opt-in. `depth_sensor_model: false` restores the previous
behaviour exactly.

**Maintainers: say the word and I will flip the default to `false`** so the modelling is
opt-in and the upgrade is silent.

### Did you use Generative AI?

Yes -- Claude Code (Claude Opus). The model, its extraction into a separate header, the 17
tests and the documentation were produced with it. The datasheet figures, the choice of which
effects to model, and the verification against a running simulation were directed and checked
by hand.

### Additional Information

Verified against a running simulation rather than by inspection. One frame of
`torso_front_down_rgbd_camera/depth` on a Kangaroo biped: 12.3 % `NaN` where there was none,
valid depths starting at exactly 0.2800 m where 0.2477 m used to appear, nothing beyond
3.0 m, and an adjacent-pixel median difference of 11.2 mm against the ~12 mm two independent
samples at that range should differ by. The noise is the modelled magnitude, not merely
present.

The 17 unit tests need no GPU and cover the range edges and their inclusivity, `NaN`
propagation, the sigma formula against the table documented in the header, the noise
magnitude and its lack of bias, the dropout rate, determinism for a given seed, and that
noise can never produce an out-of-range reading.

At the 0.15 px default the error is about 1 % of range at 2 m, the figure usually reported for
a D435i; `depth_subpixel_error` around 0.3 px sits on the datasheet's "< 2 % at 2 m" bound
instead.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
