### PR TITLE
Feat/camera render pass timing

### DIFF
--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -105,6 +105,18 @@ Note that any number of cameras can be configured in the plugin configuration.
    giving each pass more wall-clock time. Polled triggers are never lost this way, only
    deferred to the next pass.
 
+   The cost of each pass is reported alongside it, split by stage, so it is clear which one
+   is over budget -- pixel readback typically dominates the draw call by an order of
+   magnitude::
+
+      Render pass: 6 camera(s) in 33.1 ms (render+readback 28.4, convert 4.1, publish 0.6)
+      -> ceiling 30.2 Hz
+
+   This is logged at DEBUG normally and raised to WARN only while frames are actually being
+   lost, because a pass may legitimately outlast ``1/camera_publish_rate`` when the
+   simulation is slowed: the interval is measured on the sim clock, so the wall-clock budget
+   is ``1/(rate * real-time factor)``.
+
 Headless Rendering
 ^^^^^^^^^^^^^^^^^^
 

--- a/mujoco_ros2_control_plugins/doc/plugins.rst
+++ b/mujoco_ros2_control_plugins/doc/plugins.rst
@@ -93,6 +93,18 @@ Note that any number of cameras can be configured in the plugin configuration.
    MuJoCo's camera coordinate conventions differ from ROS.
    Refer to the MuJoCo documentation for details.
 
+.. note::
+   Rendering happens on its own thread, so a render pass can outlast the publish interval.
+   When that happens the due slot is skipped rather than overwriting the frame being
+   rendered, and a throttled warning reports how many streaming frames have been lost::
+
+      Camera rendering cannot keep up: 12 streaming frame(s) dropped so far.
+
+   Lower ``camera_publish_rate``, the camera resolution, or the number of streaming
+   cameras; or lower ``sim_speed_factor``, which keeps the image rate in sim time while
+   giving each pass more wall-clock time. Polled triggers are never lost this way, only
+   deferred to the next pass.
+
 Headless Rendering
 ^^^^^^^^^^^^^^^^^^
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -611,14 +611,49 @@ void CameraPlugin::update_cameras()
   const rclcpp::Duration duration = rclcpp::Duration::from_seconds(mj_camera_data_->time);
   rclcpp::Time stamp(duration.nanoseconds(), RCL_ROS_TIME);
 
+  pass_gl_seconds_ = 0.0;
+  pass_convert_seconds_ = 0.0;
+  pass_publish_seconds_ = 0.0;
+
   for (const auto idx : render_indices_)
   {
     render_and_publish_camera(cameras_[idx], stamp);
+  }
+
+  // Report the cost split. The three stages differ by more than an order of magnitude, so
+  // saying which one dominates turns "cannot keep up" into an actionable message.
+  //
+  // Escalate to WARN only when frames were actually lost since the last report, rather than
+  // when the pass outlasts 1/camera_publish_rate. The publish interval is measured on the
+  // sim clock, so the wall-clock budget for a pass is 1/(rate * real-time factor): with the
+  // simulation deliberately slowed a pass may take far longer than 1/rate and still drop
+  // nothing. Keying off the drop counter is correct at any speed factor.
+  const double pass_seconds = pass_gl_seconds_ + pass_convert_seconds_ + pass_publish_seconds_;
+  const double ceiling_hz = pass_seconds > 0.0 ? 1.0 / pass_seconds : 0.0;
+  const char* const fmt = "Render pass: %zu camera(s) in %.1f ms "
+                          "(render+readback %.1f, convert %.1f, publish %.1f) -> ceiling %.1f Hz";
+  const uint64_t drops = dropped_frames_.load();
+  const bool losing_frames = drops > reported_drops_;
+  reported_drops_ = drops;
+  if (losing_frames)
+  {
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000, fmt, render_indices_.size(),
+                         1e3 * pass_seconds, 1e3 * pass_gl_seconds_, 1e3 * pass_convert_seconds_,
+                         1e3 * pass_publish_seconds_, ceiling_hz);
+  }
+  else
+  {
+    RCLCPP_DEBUG_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000, fmt, render_indices_.size(),
+                          1e3 * pass_seconds, 1e3 * pass_gl_seconds_, 1e3 * pass_convert_seconds_,
+                          1e3 * pass_publish_seconds_, ceiling_hz);
   }
 }
 
 void CameraPlugin::render_and_publish_camera(CameraData& camera, const rclcpp::Time& stamp)
 {
+  using clock = std::chrono::steady_clock;
+  const auto t_start = clock::now();
+
   // Step 1: Render the scene and copy images to relevant camera data containers.
   // Render scene
   mjv_updateScene(mj_model_, mj_camera_data_, &mjv_opt_, NULL, &camera.mjv_cam, mjCAT_ALL, &mjv_scn_);
@@ -626,6 +661,8 @@ void CameraPlugin::render_and_publish_camera(CameraData& camera, const rclcpp::T
 
   // Copy image into relevant buffers
   mjr_readPixels(camera.image_buffer.data(), camera.depth_buffer.data(), camera.viewport, &mjr_con_);
+
+  const auto t_read = clock::now();
 
   // Step 2: Adjust the images and copy depth data.
   // Fix non-linear depth buffer and flip it vertically (OpenGL's origin is the bottom left)
@@ -650,6 +687,8 @@ void CameraPlugin::render_and_publish_camera(CameraData& camera, const rclcpp::T
     std::memcpy(&camera.image.data[dest_idx], &camera.image_buffer[src_idx], row_size);
   }
 
+  const auto t_convert = clock::now();
+
   // Step 3: Publish the images and camera info.
   camera.image.header.stamp = stamp;
   camera.depth_image.header.stamp = stamp;
@@ -658,6 +697,11 @@ void CameraPlugin::render_and_publish_camera(CameraData& camera, const rclcpp::T
   camera.image_pub->publish(camera.image);
   camera.depth_image_pub->publish(camera.depth_image);
   camera.camera_info_pub->publish(camera.camera_info);
+
+  const auto t_publish = clock::now();
+  pass_gl_seconds_ += std::chrono::duration<double>(t_read - t_start).count();
+  pass_convert_seconds_ += std::chrono::duration<double>(t_convert - t_read).count();
+  pass_publish_seconds_ += std::chrono::duration<double>(t_publish - t_convert).count();
 }
 
 void CameraPlugin::handle_trigger(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,

--- a/mujoco_ros2_control_plugins/src/camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.cpp
@@ -88,7 +88,37 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
 
   bool any_selected = false;
   {
-    std::lock_guard<std::mutex> lock(data_mutex_);
+    std::unique_lock<std::mutex> lock(data_mutex_);
+
+    // The rendering thread is still working on the previous snapshot. Touching
+    // mj_camera_data_ or render_pending now would corrupt the frame it is rendering, so
+    // give up this slot instead. See CameraPlugin::render_in_flight_.
+    if (render_in_flight_)
+    {
+      // A poll trigger must survive the skip. poll_pending_ was already consumed by the
+      // exchange above, but the per-camera poll_requested flag is still set, so re-arm the
+      // wakeup hint and the request is merely deferred rather than lost.
+      if (poll_due)
+      {
+        poll_pending_.store(true);
+      }
+      if (stream_due)
+      {
+        // Consume the slot so the next attempt is a full interval away. Without this, every
+        // control cycle for the rest of the render would re-enter here and the counter
+        // would report attempts (thousands per second at a 2 kHz control rate) rather than
+        // lost frames.
+        last_publish_time_ = now;
+        ++dropped_frames_;
+        RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
+                             "Camera rendering cannot keep up: %llu streaming frame(s) dropped so far. "
+                             "Reduce mujoco_plugins.mujoco_camera_plugin.camera_publish_rate, the camera "
+                             "resolution, or the number of streaming cameras; or lower sim_speed_factor, which "
+                             "keeps the sim-time image rate and gives each pass more wall-clock time.",
+                             static_cast<unsigned long long>(dropped_frames_.load()));
+      }
+      return;
+    }
 
     // Flag streaming cameras when their interval is due and any polled cameras that have a
     // pending trigger (consuming the one-shot request so they render exactly once).
@@ -117,6 +147,10 @@ void CameraPlugin::update(const mjModel* model_arg, mjData* data)
     {
       mjv_copyData(mj_camera_data_, model_arg, data);
       new_data_ = true;
+      // Hand ownership of the snapshot to the rendering thread; it is released again once
+      // update_cameras() has published. Set under the lock so the flag can never be
+      // observed as false while new_data_ is already true.
+      render_in_flight_ = true;
     }
   }
 
@@ -523,6 +557,14 @@ void CameraPlugin::update_loop()
     lock.unlock();
 
     update_cameras();
+
+    // Release the snapshot so `update` may fill it again. This has to happen after
+    // update_cameras() returns, because that call is what reads mj_camera_data_ and the
+    // per-camera render_pending flags without holding the lock.
+    {
+      std::lock_guard<std::mutex> release_lock(data_mutex_);
+      render_in_flight_ = false;
+    }
   }
   publish_images_ = false;
 

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -184,6 +184,18 @@ public:
     return publish_images_.load();
   }
 
+  /**
+   * @brief Number of streaming slots skipped because the renderer was still busy.
+   *
+   * Counted per slot rather than per attempt, so it reads as "frames lost" rather than
+   * "times we looked": at a 2 kHz control rate the latter would report thousands per second
+   * for the duration of a single slow render.
+   */
+  [[nodiscard]] uint64_t dropped_frames() const
+  {
+    return dropped_frames_.load();
+  }
+
 private:
   // ROS interfaces
   rclcpp::Logger logger_{ rclcpp::get_logger("CameraPlugin") };
@@ -266,6 +278,22 @@ private:
   std::mutex data_mutex_;
   std::condition_variable data_cv_;
   bool new_data_{ false };
+
+  // True from the moment `update` hands a snapshot to the rendering thread until that
+  // thread has finished rendering and publishing it.
+  //
+  // `update_cameras` deliberately runs WITHOUT holding data_mutex_ (rendering is slow and
+  // must not block the control loop), so it reads mj_camera_data_ and CameraData::
+  // render_pending unlocked. Without this flag the control thread could mjv_copyData into
+  // that same snapshot mid-render, producing an image blended from two different sim
+  // times: corruption that still looks like a valid frame. Guarding on it makes `update`
+  // skip the slot instead, turning a silent race into a countable dropped frame.
+  bool render_in_flight_{ false };
+
+  // Number of streaming slots skipped because the renderer was still busy. Counted per
+  // slot rather than per attempt, so it reads as "frames lost", not "times we looked".
+  // Atomic so the counter can be read for diagnostics from a thread other than the sim one.
+  std::atomic<uint64_t> dropped_frames_{ 0 };
 
   // EGL context for headless rendering (used when GLFW is unavailable)
   EGLDisplay egl_display_{ EGL_NO_DISPLAY };

--- a/mujoco_ros2_control_plugins/src/camera_plugin.hpp
+++ b/mujoco_ros2_control_plugins/src/camera_plugin.hpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -196,6 +197,30 @@ public:
     return dropped_frames_.load();
   }
 
+  /// Wall-clock cost of the most recent render pass, in seconds, split by stage.
+  struct RenderPassTiming
+  {
+    double gl_seconds{ 0.0 };       ///< Draw call plus pixel readback.
+    double convert_seconds{ 0.0 };  ///< Depth linearisation and row flipping.
+    double publish_seconds{ 0.0 };  ///< Handing the messages to the middleware.
+
+    [[nodiscard]] double total_seconds() const
+    {
+      return gl_seconds + convert_seconds + publish_seconds;
+    }
+  };
+
+  /**
+   * @brief Cost of the most recent render pass.
+   *
+   * Reset at the start of every pass and summed over the cameras rendered in it, so this is
+   * the cost of one pass rather than a running total. All zero until a pass has completed.
+   */
+  [[nodiscard]] RenderPassTiming render_pass_timing() const
+  {
+    return { pass_gl_seconds_, pass_convert_seconds_, pass_publish_seconds_ };
+  }
+
 private:
   // ROS interfaces
   rclcpp::Logger logger_{ rclcpp::get_logger("CameraPlugin") };
@@ -294,6 +319,16 @@ private:
   // slot rather than per attempt, so it reads as "frames lost", not "times we looked".
   // Atomic so the counter can be read for diagnostics from a thread other than the sim one.
   std::atomic<uint64_t> dropped_frames_{ 0 };
+
+  // Value of dropped_frames_ at the last cost report, so a pass can tell whether anything
+  // was actually lost since then.
+  uint64_t reported_drops_{ 0 };
+
+  // Wall-clock cost of the last render pass, split by stage and summed over the cameras
+  // rendered in it. Only ever touched by the rendering thread, so no synchronisation.
+  double pass_gl_seconds_{ 0.0 };
+  double pass_convert_seconds_{ 0.0 };
+  double pass_publish_seconds_{ 0.0 };
 
   // EGL context for headless rendering (used when GLFW is unavailable)
   EGLDisplay egl_display_{ EGL_NO_DISPLAY };

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -361,6 +361,92 @@ TEST_F(CameraPluginTest, PolledCameraPublishesOncePerTrigger)
   plugin.cleanup();
 }
 
+// ---------------------------------------------------------------------------------------
+// Dropped-frame accounting
+//
+// update() runs on the sim thread and must not overwrite a snapshot the rendering thread is
+// still working on. When it has to skip, it consumes the slot and counts one lost frame.
+// A high publish rate against a camera large enough that a pass outlasts the interval puts
+// the guard on the hot path without needing to control the rendering thread directly.
+// ---------------------------------------------------------------------------------------
+
+namespace
+{
+// 1280x720 is comfortably slower to render and read back than a 1 ms publish interval.
+constexpr const char* SLOW_CAMERA_MODEL = R"(<?xml version="1.0"?>
+<mujoco model="slow_camera">
+  <visual>
+    <global offwidth="1280" offheight="720"/>
+  </visual>
+  <worldbody>
+    <light pos="0 0 3"/>
+    <body name="box" pos="0 0 0.1">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1.0" diaginertia="0.01 0.01 0.01"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <camera name="cam" pos="0 -1 0.2" mode="fixed" resolution="1280 720"/>
+  </worldbody>
+</mujoco>
+)";
+}  // namespace
+
+TEST_F(CameraPluginTest, NoFramesAreDroppedWhenTheRendererKeepsUp)
+{
+  load_model(SLOW_CAMERA_MODEL);
+  // One frame every 100 s, so no slot ever comes due after the first.
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.camera_publish_rate", 0.01);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  wait_for_rendering(plugin);
+
+  for (int i = 0; i < 2000; ++i)
+  {
+    plugin.update(model_, data_);
+  }
+  EXPECT_EQ(plugin.dropped_frames(), 0u);
+  plugin.cleanup();
+}
+
+// The regression this guards: without the in-flight check, update() would copy into the
+// snapshot the rendering thread is reading, producing a frame blended from two sim times --
+// corruption that still looks like a valid image. The counter is the observable proof that
+// the slot was skipped instead.
+TEST_F(CameraPluginTest, SkippedSlotsAreCountedOncePerLostFrameNotPerAttempt)
+{
+  load_model(SLOW_CAMERA_MODEL);
+  // 1 kHz: a slot comes due every millisecond, far faster than a 1280x720 pass completes.
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.camera_publish_rate", 1000.0);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  wait_for_rendering(plugin);
+
+  // Drive update() the way a 2 kHz control loop would, for long enough that several render
+  // passes are outrun.
+  std::size_t calls = 0;
+  const auto deadline = std::chrono::steady_clock::now() + 500ms;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    plugin.update(model_, data_);
+    ++calls;
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+
+  const uint64_t dropped = plugin.dropped_frames();
+  ASSERT_GT(calls, 500u) << "the loop did not run often enough to be meaningful";
+  EXPECT_GT(dropped, 0u) << "a 1280x720 pass cannot keep up with a 1 kHz slot rate";
+
+  // The point of consuming the slot: each lost frame is counted once, so the number of
+  // drops is bounded by the elapsed slots (~500 at 1 kHz over 500 ms) and not by the number
+  // of update() calls. Without that, every call during a render would increment.
+  EXPECT_LT(dropped, static_cast<uint64_t>(calls))
+      << "counted " << dropped << " drops over " << calls << " update() calls: the slot is not being consumed";
+  EXPECT_LT(dropped, 1500u) << "far more drops than slots elapsed in 500 ms";
+  plugin.cleanup();
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
+++ b/mujoco_ros2_control_plugins/test/test_camera_plugin.cpp
@@ -447,6 +447,55 @@ TEST_F(CameraPluginTest, SkippedSlotsAreCountedOncePerLostFrameNotPerAttempt)
   plugin.cleanup();
 }
 
+// ---------------------------------------------------------------------------------------
+// Render-pass cost accounting
+// ---------------------------------------------------------------------------------------
+
+TEST_F(CameraPluginTest, RenderPassTimingIsZeroBeforeAnyPass)
+{
+  load_model(SLOW_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.camera_publish_rate", 0.01);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+
+  const auto timing = plugin.render_pass_timing();
+  EXPECT_DOUBLE_EQ(timing.gl_seconds, 0.0);
+  EXPECT_DOUBLE_EQ(timing.convert_seconds, 0.0);
+  EXPECT_DOUBLE_EQ(timing.publish_seconds, 0.0);
+  EXPECT_DOUBLE_EQ(timing.total_seconds(), 0.0);
+  plugin.cleanup();
+}
+
+TEST_F(CameraPluginTest, RenderPassTimingIsPopulatedAfterAPass)
+{
+  load_model(SLOW_CAMERA_MODEL);
+  plugin_node_->declare_parameter("mujoco_plugins.camera_plugin.camera_publish_rate", 1000.0);
+
+  mujoco_ros2_control_plugins::CameraPlugin plugin;
+  ASSERT_TRUE(plugin.init(plugin_node_, model_, data_));
+  wait_for_rendering(plugin);
+
+  // Drive a handful of passes.
+  const auto deadline = std::chrono::steady_clock::now() + 500ms;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    plugin.update(model_, data_);
+    std::this_thread::sleep_for(POLL_INTERVAL);
+  }
+
+  const auto timing = plugin.render_pass_timing();
+  EXPECT_GT(timing.gl_seconds, 0.0) << "the draw and readback cannot be free";
+  EXPECT_GE(timing.convert_seconds, 0.0);
+  EXPECT_GE(timing.publish_seconds, 0.0);
+  EXPECT_DOUBLE_EQ(timing.total_seconds(), timing.gl_seconds + timing.convert_seconds + timing.publish_seconds);
+
+  // The cost of ONE pass, not a running total: a single 1280x720 pass is nowhere near the
+  // half-second this test spent driving several of them.
+  EXPECT_LT(timing.total_seconds(), 0.25) << "the timing looks cumulative rather than per-pass";
+  plugin.cleanup();
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
> **Depends on `fix/camera_render_data_race`** #299 , which adds the drop counter this keys its log
> level off. Please merge that one first.

## Description

"Camera rendering cannot keep up" says that a budget was missed but not which stage spent it,
and the three differ by more than an order of magnitude: pixel readback typically dwarfs the
draw call, and the depth conversion is a distant third. Timing them separately turns the
warning into something actionable -- lower the resolution, or the rate, or the camera count --
instead of a prompt to guess.

Each stage is timed per camera and summed over the pass, then reported with the resulting
frequency ceiling:

```text
Render pass: 6 camera(s) in 33.1 ms (render+readback 28.4, convert 4.1, publish 0.6)
-> ceiling 30.2 Hz
```

The report is logged at DEBUG and raised to WARN only while frames are actually being lost,
keyed off `dropped_frames()` rather than off the pass outlasting `1/camera_publish_rate`. The
publish interval is measured on the sim clock, so the wall-clock budget for a pass is
`1/(rate * real-time factor)`: with the simulation deliberately slowed a pass may take far
longer than `1/rate` and still drop nothing, and warning about that would be noise.

Fixes # (issue)

### Is this user-facing behavior change?

Only in logging. A new DEBUG line per render pass, throttled to once per 5 s, which is raised
to WARN while frames are being dropped. No new parameters and no change to published data.

### Did you use Generative AI?

Yes -- Claude Code (Claude Opus). The instrumentation, the log-level policy, the two tests
and the documentation were produced with it.

### Additional Information

`render_pass_timing()` exposes the split, which is what the tests check: zero before any pass
has run, populated afterwards, and per-pass rather than cumulative.

The measured split on a Kangaroo biped with six 848x480 cameras is roughly 28 ms readback,
4 ms convert and 0.6 ms publish, which is what makes the point that the readback is where the
budget goes.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
