### PR TITLE
Migrate to the modern Handle export API on hardware_interface >= 5.6

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system_interface.hpp
@@ -19,9 +19,11 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <hardware_interface/version.h>
@@ -99,8 +101,17 @@ public:
 #else
   on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
 #endif
+// hardware_interface 5.6+ deprecates the raw-pointer Handle constructor and the by-value
+// export_state_interfaces()/export_command_interfaces() overrides in favor of shared handles
+// returned from on_export_state_interfaces()/on_export_command_interfaces(). Older distros
+// (humble/jazzy/kilted) only have the by-value overrides.
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  std::vector<hardware_interface::StateInterface::ConstSharedPtr> on_export_state_interfaces() override;
+  std::vector<hardware_interface::CommandInterface::SharedPtr> on_export_command_interfaces() override;
+#else
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+#endif
 
   hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
   hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
@@ -243,6 +254,22 @@ private:
   void register_sensors(const hardware_interface::HardwareInfo& info);
 
   /**
+   * @brief Walks joints and sensors, calling `add` once per exported state interface with its
+   * name, interface name, and a pointer to the internal double backing it.
+   *
+   * Shared between the pre- and post-5.6 export_state_interfaces()/on_export_state_interfaces()
+   * implementations so the interface-enumeration logic isn't duplicated.
+   */
+  void enumerate_state_interfaces(
+      const std::function<void(const std::string&, const std::string&, double*)>& add);
+
+  /**
+   * @brief Same as enumerate_state_interfaces(), for command interfaces.
+   */
+  void enumerate_command_interfaces(
+      const std::function<void(const std::string&, const std::string&, double*)>& add);
+
+  /**
    * @brief Sets the initial simulation conditions (pos, vel, ctrl) values from provided filepath.
    *
    * @param override_start_position_file filepath that contains starting positions
@@ -327,6 +354,12 @@ private:
   // Data containers for the HW interface
   std::unordered_map<std::string, hardware_interface::ComponentInfo> joint_hw_info_;
   std::unordered_map<std::string, std::vector<hardware_interface::ComponentInfo>> sensors_hw_info_;
+
+  // hardware_interface >= 5.6 only: (handle, internal double it mirrors) pairs, populated by
+  // on_export_state_interfaces()/on_export_command_interfaces(), consumed each read()/write() to
+  // keep the exported handles in sync with the existing internal state_/command_ doubles.
+  std::vector<std::pair<hardware_interface::StateInterface::SharedPtr, double*>> state_interface_sync_;
+  std::vector<std::pair<hardware_interface::CommandInterface::SharedPtr, double*>> command_interface_sync_;
 
   // Container for interacting with the underlying physics sim's data.
   // Handed to plugins during `write` and used to stage control inputs.

--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
@@ -507,10 +507,9 @@ MujocoSystemInterface::on_init(const hardware_interface::HardwareComponentInterf
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_state_interfaces()
+void MujocoSystemInterface::enumerate_state_interfaces(
+    const std::function<void(const std::string&, const std::string&, double*)>& add)
 {
-  std::vector<hardware_interface::StateInterface> new_state_interfaces;
-
   // Joint state interfaces
   for (auto& joint : urdf_joint_data_)
   {
@@ -521,18 +520,16 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
       {
         if (state_if.name == hardware_interface::HW_IF_POSITION)
         {
-          new_state_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION,
-                                            &joint.position_interface.state_);
+          add(joint.name, hardware_interface::HW_IF_POSITION, &joint.position_interface.state_);
         }
         else if (state_if.name == hardware_interface::HW_IF_VELOCITY)
         {
-          new_state_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY,
-                                            &joint.velocity_interface.state_);
+          add(joint.name, hardware_interface::HW_IF_VELOCITY, &joint.velocity_interface.state_);
         }
         else if (state_if.name == hardware_interface::HW_IF_EFFORT ||
                  state_if.name == hardware_interface::HW_IF_TORQUE || state_if.name == hardware_interface::HW_IF_FORCE)
         {
-          new_state_interfaces.emplace_back(joint.name, state_if.name, &joint.effort_interface.state_);
+          add(joint.name, state_if.name, &joint.effort_interface.state_);
         }
       }
     }
@@ -551,27 +548,27 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
       {
         if (state_if.name == "force.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.force.data.x());
+          add(sensor.name, state_if.name, &sensor.force.data.x());
         }
         else if (state_if.name == "force.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.force.data.y());
+          add(sensor.name, state_if.name, &sensor.force.data.y());
         }
         else if (state_if.name == "force.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.force.data.z());
+          add(sensor.name, state_if.name, &sensor.force.data.z());
         }
         else if (state_if.name == "torque.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.torque.data.x());
+          add(sensor.name, state_if.name, &sensor.torque.data.x());
         }
         else if (state_if.name == "torque.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.torque.data.y());
+          add(sensor.name, state_if.name, &sensor.torque.data.y());
         }
         else if (state_if.name == "torque.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.torque.data.z());
+          add(sensor.name, state_if.name, &sensor.torque.data.z());
         }
       }
     }
@@ -590,43 +587,43 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
       {
         if (state_if.name == "orientation.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.x());
+          add(sensor.name, state_if.name, &sensor.orientation.data.x());
         }
         else if (state_if.name == "orientation.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.y());
+          add(sensor.name, state_if.name, &sensor.orientation.data.y());
         }
         else if (state_if.name == "orientation.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.z());
+          add(sensor.name, state_if.name, &sensor.orientation.data.z());
         }
         else if (state_if.name == "orientation.w")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.w());
+          add(sensor.name, state_if.name, &sensor.orientation.data.w());
         }
         else if (state_if.name == "angular_velocity.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.angular_velocity.data.x());
+          add(sensor.name, state_if.name, &sensor.angular_velocity.data.x());
         }
         else if (state_if.name == "angular_velocity.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.angular_velocity.data.y());
+          add(sensor.name, state_if.name, &sensor.angular_velocity.data.y());
         }
         else if (state_if.name == "angular_velocity.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.angular_velocity.data.z());
+          add(sensor.name, state_if.name, &sensor.angular_velocity.data.z());
         }
         else if (state_if.name == "linear_acceleration.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.linear_acceleration.data.x());
+          add(sensor.name, state_if.name, &sensor.linear_acceleration.data.x());
         }
         else if (state_if.name == "linear_acceleration.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.linear_acceleration.data.y());
+          add(sensor.name, state_if.name, &sensor.linear_acceleration.data.y());
         }
         else if (state_if.name == "linear_acceleration.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.linear_acceleration.data.z());
+          add(sensor.name, state_if.name, &sensor.linear_acceleration.data.z());
         }
         // Add covariance interfaces, these aren't currently used but some controllers require them.
         // TODO: Is there MuJoCo covariance data we could use?
@@ -636,7 +633,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
           size_t idx = std::stoul(state_if.name.substr(23));
           if (idx < sensor.orientation_covariance.size())
           {
-            new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation_covariance[idx]);
+            add(sensor.name, state_if.name, &sensor.orientation_covariance[idx]);
           }
         }
         else if (state_if.name.find("angular_velocity_covariance") == 0)
@@ -645,7 +642,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
           size_t idx = std::stoul(state_if.name.substr(28));
           if (idx < sensor.angular_velocity_covariance.size())
           {
-            new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.angular_velocity_covariance[idx]);
+            add(sensor.name, state_if.name, &sensor.angular_velocity_covariance[idx]);
           }
         }
         else if (state_if.name.find("linear_acceleration_covariance") == 0)
@@ -654,7 +651,7 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
           size_t idx = std::stoul(state_if.name.substr(31));
           if (idx < sensor.linear_acceleration_covariance.size())
           {
-            new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.linear_acceleration_covariance[idx]);
+            add(sensor.name, state_if.name, &sensor.linear_acceleration_covariance[idx]);
           }
         }
       }
@@ -674,31 +671,31 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
       {
         if (state_if.name == "position.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.position.data.x());
+          add(sensor.name, state_if.name, &sensor.position.data.x());
         }
         else if (state_if.name == "position.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.position.data.y());
+          add(sensor.name, state_if.name, &sensor.position.data.y());
         }
         else if (state_if.name == "position.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.position.data.z());
+          add(sensor.name, state_if.name, &sensor.position.data.z());
         }
         else if (state_if.name == "orientation.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.x());
+          add(sensor.name, state_if.name, &sensor.orientation.data.x());
         }
         else if (state_if.name == "orientation.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.y());
+          add(sensor.name, state_if.name, &sensor.orientation.data.y());
         }
         else if (state_if.name == "orientation.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.z());
+          add(sensor.name, state_if.name, &sensor.orientation.data.z());
         }
         else if (state_if.name == "orientation.w")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation.data.w());
+          add(sensor.name, state_if.name, &sensor.orientation.data.w());
         }
       }
     }
@@ -717,27 +714,24 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
       {
         if (state_if.name == "magnetic_field.x")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.magnetic_field.data.x());
+          add(sensor.name, state_if.name, &sensor.magnetic_field.data.x());
         }
         else if (state_if.name == "magnetic_field.y")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.magnetic_field.data.y());
+          add(sensor.name, state_if.name, &sensor.magnetic_field.data.y());
         }
         else if (state_if.name == "magnetic_field.z")
         {
-          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.magnetic_field.data.z());
+          add(sensor.name, state_if.name, &sensor.magnetic_field.data.z());
         }
       }
     }
   }
-
-  return new_state_interfaces;
 }
 
-std::vector<hardware_interface::CommandInterface> MujocoSystemInterface::export_command_interfaces()
+void MujocoSystemInterface::enumerate_command_interfaces(
+    const std::function<void(const std::string&, const std::string&, double*)>& add)
 {
-  std::vector<hardware_interface::CommandInterface> new_command_interfaces;
-
   // Joint command interfaces
   for (auto& joint : urdf_joint_data_)
   {
@@ -748,26 +742,70 @@ std::vector<hardware_interface::CommandInterface> MujocoSystemInterface::export_
       {
         if (command_if.name.find(hardware_interface::HW_IF_POSITION) != std::string::npos)
         {
-          new_command_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION,
-                                              &joint.position_interface.command_);
+          add(joint.name, hardware_interface::HW_IF_POSITION, &joint.position_interface.command_);
         }
         else if (command_if.name.find(hardware_interface::HW_IF_VELOCITY) != std::string::npos)
         {
-          new_command_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY,
-                                              &joint.velocity_interface.command_);
+          add(joint.name, hardware_interface::HW_IF_VELOCITY, &joint.velocity_interface.command_);
         }
         else if (command_if.name == hardware_interface::HW_IF_EFFORT ||
                  command_if.name == hardware_interface::HW_IF_TORQUE ||
                  command_if.name == hardware_interface::HW_IF_FORCE)
         {
-          new_command_interfaces.emplace_back(joint.name, command_if.name, &joint.effort_interface.command_);
+          add(joint.name, command_if.name, &joint.effort_interface.command_);
         }
       }
     }
   }
+}
 
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+std::vector<hardware_interface::StateInterface::ConstSharedPtr> MujocoSystemInterface::on_export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface::ConstSharedPtr> new_state_interfaces;
+  enumerate_state_interfaces(
+      [this, &new_state_interfaces](const std::string& name, const std::string& interface_name, double* value_ptr) {
+        auto handle = std::make_shared<hardware_interface::StateInterface>(name, interface_name);
+        (void)handle->set_value(*value_ptr, true);
+        state_interface_sync_.emplace_back(handle, value_ptr);
+        new_state_interfaces.push_back(handle);
+      });
+  return new_state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface::SharedPtr> MujocoSystemInterface::on_export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface::SharedPtr> new_command_interfaces;
+  enumerate_command_interfaces(
+      [this, &new_command_interfaces](const std::string& name, const std::string& interface_name, double* value_ptr) {
+        auto handle = std::make_shared<hardware_interface::CommandInterface>(name, interface_name);
+        (void)handle->set_value(*value_ptr, true);
+        command_interface_sync_.emplace_back(handle, value_ptr);
+        new_command_interfaces.push_back(handle);
+      });
   return new_command_interfaces;
 }
+#else
+std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> new_state_interfaces;
+  enumerate_state_interfaces(
+      [&new_state_interfaces](const std::string& name, const std::string& interface_name, double* value_ptr) {
+        new_state_interfaces.emplace_back(name, interface_name, value_ptr);
+      });
+  return new_state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> MujocoSystemInterface::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> new_command_interfaces;
+  enumerate_command_interfaces(
+      [&new_command_interfaces](const std::string& name, const std::string& interface_name, double* value_ptr) {
+        new_command_interfaces.emplace_back(name, interface_name, value_ptr);
+      });
+  return new_command_interfaces;
+}
+#endif
 
 hardware_interface::CallbackReturn MujocoSystemInterface::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
@@ -1022,12 +1060,29 @@ hardware_interface::return_type MujocoSystemInterface::read(const rclcpp::Time& 
 #endif
   }
 
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  // Push the freshly-computed internal state doubles into the handles the resource manager holds.
+  for (auto& [handle, value_ptr] : state_interface_sync_)
+  {
+    (void)handle->set_value(*value_ptr, true);
+  }
+#endif
+
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time& /*time*/,
                                                              const rclcpp::Duration& period)
 {
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  // Pull the controller-written command values out of the handles into the internal command_
+  // doubles, before any of the code below reads them.
+  for (auto& [handle, value_ptr] : command_interface_sync_)
+  {
+    (void)handle->get_value(*value_ptr, true);
+  }
+#endif
+
   // Update mimic joints
   for (auto& joint : urdf_joint_data_)
   {

--- a/mujoco_ros2_control/tests/test_headless_init.cpp
+++ b/mujoco_ros2_control/tests/test_headless_init.cpp
@@ -167,7 +167,11 @@ TEST_F(HeadlessInitTest, HeadlessInitialization)
   ASSERT_NE(test_data, nullptr) << "Model failed to initialize within timeout";
 
   // Test that we can export state interfaces without crashing
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  auto state_interfaces = interface_->on_export_state_interfaces();
+#else
   auto state_interfaces = interface_->export_state_interfaces();
+#endif
   EXPECT_GE(state_interfaces.size(), 0);
 }
 

--- a/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
+++ b/mujoco_ros2_control/tests/test_mujoco_system_interface.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <functional>
 #include <thread>
+#include <vector>
 
 #include <hardware_interface/version.h>
 #include <mujoco/mujoco.h>
@@ -215,12 +216,21 @@ TEST_F(MujocoSystemInterfaceTest, IntVelocityActuatorSupportsVelocityCommandInte
   ASSERT_NE(actuator_id, -1);
   EXPECT_EQ(model->actuator_dyntype[actuator_id], mjDYN_INTEGRATOR);
 
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  auto command_interfaces = interface_->on_export_command_interfaces();
+  ASSERT_EQ(command_interfaces.size(), 1u);
+  EXPECT_EQ(command_interfaces.front()->get_name(), "wheel_joint/velocity");
+
+  constexpr double velocity_command = 2.0;
+  command_interfaces.front()->set_value(velocity_command);
+#else
   auto command_interfaces = interface_->export_command_interfaces();
   ASSERT_EQ(command_interfaces.size(), 1u);
   EXPECT_EQ(command_interfaces.front().get_name(), "wheel_joint/velocity");
 
   constexpr double velocity_command = 2.0;
   command_interfaces.front().set_value(velocity_command);
+#endif
   ASSERT_EQ(interface_->write(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002)),
             hardware_interface::return_type::OK);
 
@@ -267,7 +277,17 @@ TEST_F(MujocoSystemInterfaceTest, PoseSensorStateInterfacesRead)
 
   // The pose sensor is the only component registered, so its interfaces are exported
   // in registration order: position.x/y/z, orientation.x/y/z/w.
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  auto exported_state_interfaces = interface_->on_export_state_interfaces();
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  state_interfaces.reserve(exported_state_interfaces.size());
+  for (const auto& handle : exported_state_interfaces)
+  {
+    state_interfaces.push_back(*handle);
+  }
+#else
   const auto state_interfaces = interface_->export_state_interfaces();
+#endif
   ASSERT_EQ(state_interfaces.size(), 7u);
   ASSERT_EQ(state_interfaces[0].get_name(), "pose_sensor/position.x");
   ASSERT_EQ(state_interfaces[1].get_name(), "pose_sensor/position.y");
@@ -325,7 +345,17 @@ TEST_F(MujocoSystemInterfaceTest, MagnetometerSensorStateInterfacesRead)
 
   interface_->read(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.002));
 
+#if HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)
+  auto exported_state_interfaces = interface_->on_export_state_interfaces();
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  state_interfaces.reserve(exported_state_interfaces.size());
+  for (const auto& handle : exported_state_interfaces)
+  {
+    state_interfaces.push_back(*handle);
+  }
+#else
   const auto state_interfaces = interface_->export_state_interfaces();
+#endif
   ASSERT_EQ(state_interfaces.size(), 3u);
   ASSERT_EQ(state_interfaces[0].get_name(), "magnetometer_sensor/magnetic_field.x");
   ASSERT_EQ(state_interfaces[1].get_name(), "magnetometer_sensor/magnetic_field.y");


### PR DESCRIPTION
## Summary

ros2_control is removing the deprecated raw-pointer `Handle` constructor and the by-value `export_state_interfaces()`/`export_command_interfaces()` overrides (see ros-controls/ros2_control#3610). `mujoco_ros2_control` still uses both throughout its joint/FT-sensor/IMU/pose/magnetometer registration, which breaks once that change lands.

- Interface enumeration logic (which joint/sensor interfaces exist) is unchanged in substance, factored into shared helpers (`enumerate_state_interfaces()`/`enumerate_command_interfaces()`) so it isn't duplicated between the old and new export paths.
- The existing internal `state_`/`command_` doubles stay the source of truth; `read()`/`write()` gained a small `set_value()`/`get_value()` sync step against the exported handles, replacing pointer aliasing.
- Guarded behind `HARDWARE_INTERFACE_VERSION_GTE(5, 6, 0)` — the version that introduced `on_export_state_interfaces()` — so humble/jazzy/kilted keep using the existing path unchanged.
- Also fixes two test files (`test_headless_init.cpp`, `test_mujoco_system_interface.cpp`) that called the deprecated export methods directly; on `hardware_interface` >= 5.6 the base class no longer routes those to the overridden `on_export_*()` methods, so exported interfaces came back empty without this fix.

## Test plan

Built and tested against both the current `ros2_control` `master` and the `remove/deprecated_methods` branch:

- `colcon build --packages-select mujoco_ros2_control` — clean on both.
- `colcon test --packages-select mujoco_ros2_control` — same result on both: all C++ gtests pass; the one remaining failure (`test_urdf_to_mujoco_utils`, a Python test) is a pre-existing, unrelated `ModuleNotFoundError: No module named 'urdf_parser_py'` dependency gap, reproducible on unmodified `main` too.